### PR TITLE
prover: compute starting power arg properly

### DIFF
--- a/nil/services/synccommittee/core/block_tasks_integration_test.go
+++ b/nil/services/synccommittee/core/block_tasks_integration_test.go
@@ -179,7 +179,7 @@ func newTestSuccessProviderResult(taskToExecute *types.Task, executorId types.Ta
 	return types.NewSuccessProviderTaskResult(
 		taskToExecute.Id,
 		executorId,
-		types.TaskResultAddresses{},
+		types.TaskOutputArtifacts{},
 		types.TaskResultData{},
 	)
 }

--- a/nil/services/synccommittee/internal/rpc/task_request_handler_rpc_test.go
+++ b/nil/services/synccommittee/internal/rpc/task_request_handler_rpc_test.go
@@ -57,7 +57,7 @@ func (s *TaskRequestHandlerTestSuite) Test_TaskRequestHandler_UpdateTaskStatus()
 			types.NewSuccessProverTaskResult(
 				types.NewTaskId(),
 				testaide.RandomExecutorId(),
-				types.TaskResultAddresses{types.FinalProof: "final-proof.1.0xAABC"},
+				types.TaskOutputArtifacts{types.FinalProof: "final-proof.1.0xAABC"},
 				types.TaskResultData{10, 20, 30, 40},
 			),
 		},

--- a/nil/services/synccommittee/internal/storage/task_result_storage_test.go
+++ b/nil/services/synccommittee/internal/storage/task_result_storage_test.go
@@ -51,7 +51,7 @@ func (s *TaskResultStorageSuite) Test_Put_Same_Task_Result_N_Times() {
 	result := types.NewSuccessProviderTaskResult(
 		types.NewTaskId(),
 		testaide.RandomExecutorId(),
-		types.TaskResultAddresses{types.AggregatedProof: "agg-proof.1.1.0xAABC"},
+		types.TaskOutputArtifacts{types.AggregatedProof: "agg-proof.1.1.0xAABC"},
 		testaide.RandomTaskResultData(),
 	)
 
@@ -119,7 +119,7 @@ func newTaskResults() []*types.TaskResult {
 		types.NewSuccessProviderTaskResult(
 			types.NewTaskId(),
 			testaide.RandomExecutorId(),
-			types.TaskResultAddresses{types.AggregatedProof: "agg-proof.1.1.0xAABC"},
+			types.TaskOutputArtifacts{types.AggregatedProof: "agg-proof.1.1.0xAABC"},
 			testaide.RandomTaskResultData(),
 		),
 		types.NewFailureProviderTaskResult(
@@ -130,7 +130,7 @@ func newTaskResults() []*types.TaskResult {
 		types.NewSuccessProverTaskResult(
 			types.NewTaskId(),
 			testaide.RandomExecutorId(),
-			types.TaskResultAddresses{
+			types.TaskOutputArtifacts{
 				types.PartialProofChallenges:     "challenge.1.1.0xAABC",
 				types.AssignmentTableDescription: "assignment_table_description.1.1.0xAABC",
 				types.PartialProof:               "proof.1.1.0xAABC",

--- a/nil/services/synccommittee/internal/storage/task_storage_test.go
+++ b/nil/services/synccommittee/internal/storage/task_storage_test.go
@@ -87,7 +87,7 @@ func (s *TaskStorageSuite) TestRequestAndProcessResult() {
 	// Make lower priority task ready for execution
 	err = s.ts.ProcessTaskResult(
 		s.ctx,
-		types.NewSuccessProverTaskResult(dependency1.Task.Id, dependency1.Owner, types.TaskResultAddresses{}, types.TaskResultData{}),
+		types.NewSuccessProverTaskResult(dependency1.Task.Id, dependency1.Owner, types.TaskOutputArtifacts{}, types.TaskResultData{}),
 	)
 	s.Require().NoError(err)
 	task, err = s.ts.RequestTaskToExecute(s.ctx, 88)
@@ -97,7 +97,7 @@ func (s *TaskStorageSuite) TestRequestAndProcessResult() {
 	// Make higher priority task ready
 	err = s.ts.ProcessTaskResult(
 		s.ctx,
-		types.NewSuccessProverTaskResult(dependency2.Task.Id, dependency2.Owner, types.TaskResultAddresses{}, types.TaskResultData{}),
+		types.NewSuccessProverTaskResult(dependency2.Task.Id, dependency2.Owner, types.TaskOutputArtifacts{}, types.TaskResultData{}),
 	)
 	s.Require().NoError(err)
 
@@ -292,7 +292,7 @@ func (s *TaskStorageSuite) Test_ProcessTaskResult_Concurrently() {
 			defer waitGroup.Done()
 			err := s.ts.ProcessTaskResult(
 				s.ctx,
-				types.NewSuccessProverTaskResult(runningEntry.Task.Id, executorId, types.TaskResultAddresses{}, types.TaskResultData{}),
+				types.NewSuccessProverTaskResult(runningEntry.Task.Id, executorId, types.TaskOutputArtifacts{}, types.TaskResultData{}),
 			)
 			s.NoError(err)
 		}()
@@ -355,7 +355,7 @@ func (s *TaskStorageSuite) tryToChangeStatus(
 
 	var taskResult *types.TaskResult
 	if trySetSuccess {
-		taskResult = types.NewSuccessProverTaskResult(taskEntry.Task.Id, executorId, types.TaskResultAddresses{}, types.TaskResultData{})
+		taskResult = types.NewSuccessProverTaskResult(taskEntry.Task.Id, executorId, types.TaskOutputArtifacts{}, types.TaskResultData{})
 	} else {
 		taskResult = types.NewFailureProverTaskResult(taskEntry.Task.Id, executorId, errors.New("some error"))
 	}

--- a/nil/services/synccommittee/internal/testaide/prover_tasks.go
+++ b/nil/services/synccommittee/internal/testaide/prover_tasks.go
@@ -79,7 +79,7 @@ func NewSuccessTaskResult(taskId types.TaskId, executor types.TaskExecutorId) *t
 	return types.NewSuccessProverTaskResult(
 		taskId,
 		executor,
-		types.TaskResultAddresses{},
+		types.TaskOutputArtifacts{},
 		types.TaskResultData{},
 	)
 }

--- a/nil/services/synccommittee/proofprovider/task_handler.go
+++ b/nil/services/synccommittee/proofprovider/task_handler.go
@@ -57,8 +57,6 @@ func (h *taskHandler) Handle(ctx context.Context, _ types.TaskExecutorId, task *
 	return err
 }
 
-var circuitTypes = [...]types.CircuitType{types.CircuitBytecode, types.CircuitMPT, types.CircuitReadWrite, types.CircuitZKEVM, types.CircuitCopy}
-
 func (h *taskHandler) prepareTasksForBlock(providerTask *types.Task) []*types.TaskEntry {
 	currentTime := h.timer.NowTime()
 	taskEntries := make([]*types.TaskEntry, 0)
@@ -71,7 +69,7 @@ func (h *taskHandler) prepareTasksForBlock(providerTask *types.Task) []*types.Ta
 
 	// Third level of circuit-dependent tasks
 	consistencyCheckTasks := make(map[types.CircuitType]*types.TaskEntry)
-	for _, ct := range circuitTypes {
+	for ct := range types.Circuits() {
 		checkTaskEntry := types.NewFRIConsistencyCheckTaskEntry(
 			providerTask.BatchId, providerTask.ShardId, providerTask.BlockNum, providerTask.BlockHash, ct, currentTime,
 		)
@@ -97,7 +95,7 @@ func (h *taskHandler) prepareTasksForBlock(providerTask *types.Task) []*types.Ta
 
 	// Second level of circuit-dependent tasks
 	combinedQTasks := make(map[types.CircuitType]*types.TaskEntry)
-	for _, ct := range circuitTypes {
+	for ct := range types.Circuits() {
 		combinedQTaskEntry := types.NewCombinedQTaskEntry(
 			providerTask.BatchId, providerTask.ShardId, providerTask.BlockNum, providerTask.BlockHash, ct, currentTime,
 		)
@@ -126,7 +124,7 @@ func (h *taskHandler) prepareTasksForBlock(providerTask *types.Task) []*types.Ta
 	aggFRITaskEntry.AddDependency(aggChallengeTaskEntry)
 
 	// Create partial proof tasks (bottom level, no dependencies)
-	for _, ct := range circuitTypes {
+	for ct := range types.Circuits() {
 		partialProveTaskEntry := types.NewPartialProveTaskEntry(
 			providerTask.BatchId, providerTask.ShardId, providerTask.BlockNum, providerTask.BlockHash, ct, currentTime,
 		)

--- a/nil/services/synccommittee/proofprovider/task_state_change_handler.go
+++ b/nil/services/synccommittee/proofprovider/task_state_change_handler.go
@@ -49,7 +49,7 @@ func (h taskStateChangeHandler) OnTaskTerminated(ctx context.Context, task *type
 
 	var parentTaskResult *types.TaskResult
 	if result.IsSuccess {
-		parentTaskResult = types.NewSuccessProviderTaskResult(*task.ParentTaskId, h.currentExecutorId, result.DataAddresses, result.Data)
+		parentTaskResult = types.NewSuccessProviderTaskResult(*task.ParentTaskId, h.currentExecutorId, result.OutputArtifacts, result.Data)
 	} else {
 		parentTaskResult = types.NewFailureProviderTaskResult(
 			*task.ParentTaskId,

--- a/nil/services/synccommittee/prover/commands/aggregate_challenges.go
+++ b/nil/services/synccommittee/prover/commands/aggregate_challenges.go
@@ -1,0 +1,81 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
+)
+
+type aggregateChallengesCmd struct {
+	cmdCommon
+}
+
+func NewAggregateChallengesCmd(config CommandConfig) Command {
+	return &aggregateChallengesCmd{
+		cmdCommon: makeCmdCommon(config),
+	}
+}
+
+var _ BeforeCommandExecuted = new(aggregateChallengesCmd)
+
+func (cmd *aggregateChallengesCmd) BeforeCommandExecuted(ctx context.Context, task *types.Task, results types.TaskOutputArtifacts) error {
+	// Collect values from theta files
+	thetaPowerFiles, err := aggregateCircuitDependencies(task, types.PartialProve, types.ThetaPower)
+	if err != nil {
+		return err
+	}
+	thetas := make([]int, types.CircuitAmount)
+	for i, filename := range thetaPowerFiles {
+		bytes, err := os.ReadFile(filename)
+		if err != nil {
+			return fmt.Errorf("Cannot read theta power file: %w", err)
+		}
+		num, err := strconv.Atoi(strings.TrimSpace(string(bytes)))
+		if err != nil {
+			return fmt.Errorf("Couldn't conver theta file content to integer: %w", err)
+		}
+		thetas[i] = num
+	}
+
+	// Compute partial sums that would be actual arguments for combined Q stage handling
+	thetaPartialSums := make([]int, types.CircuitAmount)
+	for i := range types.CircuitAmount - 1 {
+		thetaPartialSums[i+1] = thetas[i] + thetaPartialSums[i]
+	}
+
+	// Write partial sums into file
+	bytes, err := json.Marshal(thetaPartialSums)
+	if err != nil {
+		return err
+	}
+	aggregateFileName := filepath.Join(cmd.outDir, fmt.Sprintf("aggregated_thetas.%v.%v", task.ShardId, task.BlockHash.String()))
+	results[types.AggregatedThetaPowers] = aggregateFileName
+	return os.WriteFile(aggregateFileName, bytes, 0o644) //nolint:gosec
+}
+
+func (cmd *aggregateChallengesCmd) MakeCommandDefinition(task *types.Task) (*CommandDefinition, error) {
+	binary := cmd.binary
+	stage := []string{"--stage", "generate-aggregated-challenge"}
+	inputFiles, err := aggregateCircuitDependencies(task, types.PartialProve, types.PartialProofChallenges)
+	if err != nil {
+		return nil, err
+	}
+	inputs := append([]string{"--input-challenge-files"}, inputFiles...)
+	outFile := filepath.Join(cmd.outDir,
+		fmt.Sprintf("aggregated_challenges.%v.%v", task.ShardId, task.BlockHash.String()))
+	outArg := []string{"--aggregated-challenge-file", outFile}
+	allArgs := slices.Concat(stage, inputs, outArg)
+	execCmd := exec.Command(binary, allArgs...)
+	return &CommandDefinition{
+		ExecCommands:   []*exec.Cmd{execCmd},
+		ExpectedResult: types.TaskOutputArtifacts{types.AggregatedChallenges: outFile},
+	}, execCmd.Err
+}

--- a/nil/services/synccommittee/prover/commands/aggregate_fri.go
+++ b/nil/services/synccommittee/prover/commands/aggregate_fri.go
@@ -1,0 +1,55 @@
+package commands
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"slices"
+
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
+)
+
+type aggregateFRICmd struct {
+	cmdCommon
+}
+
+func NewAggregateFRICmd(config CommandConfig) Command {
+	return &aggregateFRICmd{
+		cmdCommon: makeCmdCommon(config),
+	}
+}
+
+func (cmd *aggregateFRICmd) MakeCommandDefinition(task *types.Task) (*CommandDefinition, error) {
+	binary := cmd.binary
+	stage := []string{"--stage", "aggregated-FRI"}
+	assignmentTableFile, err := aggregateCircuitDependencies(task, types.PartialProve, types.AssignmentTableDescription)
+	if err != nil {
+		return nil, err
+	}
+	assignmentTable := []string{"--assignment-description-file", assignmentTableFile[0]}
+
+	aggChallengeFile, err := findDependencyResult(task, types.AggregatedChallenge, types.AggregatedChallenges)
+	if err != nil {
+		return nil, err
+	}
+	aggregatedChallenge := []string{"--aggregated-challenge-file", aggChallengeFile}
+
+	combinedQFiles, err := aggregateCircuitDependencies(task, types.CombinedQ, types.CombinedQPolynomial)
+	if err != nil {
+		return nil, err
+	}
+	combinedQ := append([]string{"--input-combined-Q-polynomial-files"}, combinedQFiles...)
+
+	resFiles := make(types.TaskOutputArtifacts)
+	filePostfix := fmt.Sprintf(".%v.%v", task.ShardId, task.BlockHash.String())
+	resFiles[types.AggregatedFRIProof] = filepath.Join(cmd.outDir, "aggregated_FRI_proof"+filePostfix)
+	resFiles[types.ProofOfWork] = filepath.Join(cmd.outDir, "POW"+filePostfix)
+	resFiles[types.ConsistencyCheckChallenges] = filepath.Join(cmd.outDir, "challenges"+filePostfix)
+
+	aggFRI := []string{"--proof", resFiles[types.AggregatedFRIProof]}
+	POW := []string{"--proof-of-work-file", resFiles[types.ProofOfWork]}
+	consistencyChallenges := []string{"--consistency-checks-challenges-file", resFiles[types.ConsistencyCheckChallenges]}
+	allArgs := slices.Concat(stage, assignmentTable, aggregatedChallenge, combinedQ, aggFRI, POW, consistencyChallenges)
+	execCmd := exec.Command(binary, allArgs...)
+	return &CommandDefinition{ExecCommands: []*exec.Cmd{execCmd}, ExpectedResult: resFiles}, execCmd.Err
+}

--- a/nil/services/synccommittee/prover/commands/aggregate_proof.go
+++ b/nil/services/synccommittee/prover/commands/aggregate_proof.go
@@ -1,0 +1,53 @@
+package commands
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"slices"
+
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
+)
+
+type aggregateProofCmd struct {
+	cmdCommon
+}
+
+func NewAggregateProofCmd(config CommandConfig) Command {
+	return &aggregateProofCmd{
+		cmdCommon: makeCmdCommon(config),
+	}
+}
+
+var _ AfterCommandExecuted = new(aggregateProofCmd)
+
+func collectFinalProofsToAggregate(_ *types.Task) ([]string, error) {
+	// TODO: clarify source of proof files
+	return nil, nil
+}
+
+func (cmd *aggregateProofCmd) MakeCommandDefinition(task *types.Task) (*CommandDefinition, error) {
+	binary := "echo" // TODO: enable aggregate proof command once it will be implemented
+	stage := []string{"--stage", "aggregate-proofs"}
+	blockProofFiles, err := collectFinalProofsToAggregate(task)
+	if err != nil {
+		return nil, err
+	}
+	blockProofs := append([]string{"--block-proof"}, blockProofFiles...)
+
+	outFile := filepath.Join(cmd.outDir,
+		fmt.Sprintf("aggregated-proof.%v.%v", task.ShardId, task.BlockHash.String()))
+	outArg := []string{"--proof", outFile}
+
+	allArgs := slices.Concat(stage, blockProofs, outArg)
+	execCmd := exec.Command(binary, allArgs...)
+	return &CommandDefinition{
+		ExecCommands:   []*exec.Cmd{execCmd},
+		ExpectedResult: types.TaskOutputArtifacts{types.AggregatedProof: outFile},
+	}, execCmd.Err
+}
+
+func (cmd *aggregateProofCmd) AfterCommandExecuted(task *types.Task, results types.TaskOutputArtifacts) (types.TaskResultData, error) {
+	// TODO: pass aggregated proof here
+	return types.TaskResultData{}, nil
+}

--- a/nil/services/synccommittee/prover/commands/combined_q.go
+++ b/nil/services/synccommittee/prover/commands/combined_q.go
@@ -1,0 +1,72 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strconv"
+
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
+)
+
+type combinedQCmd struct {
+	cmdCommon
+}
+
+func NewCombinedQCmd(config CommandConfig) Command {
+	return &combinedQCmd{
+		cmdCommon: makeCmdCommon(config),
+	}
+}
+
+func fetchStartingThetaPower(task *types.Task) (int, error) {
+	aggThetasFile, err := findDependencyResult(task, types.AggregatedChallenge, types.AggregatedThetaPowers)
+	if err != nil {
+		return 0, err
+	}
+	var aggregatedThetas []int
+	marshaledThetas, err := os.ReadFile(aggThetasFile)
+	if err != nil {
+		return 0, fmt.Errorf("Unable to read aggregated theta file: %w", err)
+	}
+	if err := json.Unmarshal(marshaledThetas, &aggregatedThetas); err != nil {
+		return 0, fmt.Errorf("Unable to unmarshal aggregated theta file: %w", err)
+	}
+	return aggregatedThetas[uint8(task.CircuitType)-types.CircuitStartIndex], nil
+}
+
+func (cmd *combinedQCmd) MakeCommandDefinition(task *types.Task) (*CommandDefinition, error) {
+	binary := cmd.binary
+	stage := []string{"--stage", "compute-combined-Q"}
+	commitmentStateFile, err := findDependencyResult(task, types.PartialProve, types.CommitmentState)
+	if err != nil {
+		return nil, err
+	}
+	commitmentState := []string{"--commitment-state-file", commitmentStateFile}
+
+	aggChallengesFile, err := findDependencyResult(task, types.AggregatedChallenge, types.AggregatedChallenges)
+	if err != nil {
+		return nil, err
+	}
+	aggregateChallenges := []string{"--aggregated-challenge-file", aggChallengesFile}
+
+	// Fetch starting theta power from file
+	startingPower, err := fetchStartingThetaPower(task)
+	if err != nil {
+		return nil, err
+	}
+	startingPowerArg := []string{"--combined-Q-starting-power", strconv.Itoa(startingPower)}
+	outFile := filepath.Join(cmd.outDir,
+		fmt.Sprintf("combined_Q.%v.%v.%v", circuitIdx(task.CircuitType), task.ShardId, task.BlockHash.String()))
+	outArg := []string{"--combined-Q-polynomial-file", outFile}
+
+	allArgs := slices.Concat(stage, commitmentState, aggregateChallenges, startingPowerArg, outArg)
+	execCmd := exec.Command(binary, allArgs...)
+	return &CommandDefinition{
+		ExecCommands:   []*exec.Cmd{execCmd},
+		ExpectedResult: types.TaskOutputArtifacts{types.CombinedQPolynomial: outFile},
+	}, execCmd.Err
+}

--- a/nil/services/synccommittee/prover/commands/command_factory.go
+++ b/nil/services/synccommittee/prover/commands/command_factory.go
@@ -1,0 +1,49 @@
+package commands
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
+	"github.com/rs/zerolog"
+)
+
+type CommandFactory struct {
+	config CommandConfig
+	logger zerolog.Logger
+}
+
+func NewCommandFactory(config CommandConfig, logger zerolog.Logger) *CommandFactory {
+	return &CommandFactory{
+		config: config,
+		logger: logger,
+	}
+}
+
+func (factory *CommandFactory) MakeHandlerCommandForTaskType(taskType types.TaskType) (Command, error) {
+	switch taskType {
+	case types.PartialProve:
+		return NewPartialProofCmd(factory.config, factory.logger), nil
+	case types.AggregatedChallenge:
+		return NewAggregateChallengesCmd(factory.config), nil
+	case types.CombinedQ:
+		return NewCombinedQCmd(factory.config), nil
+	case types.AggregatedFRI:
+		return NewAggregateFRICmd(factory.config), nil
+	case types.FRIConsistencyChecks:
+		return NewConsistencyCheckCmd(factory.config), nil
+	case types.MergeProof:
+		return NewMergeProofCmd(factory.config), nil
+	case types.AggregateProofs:
+		return NewAggregateProofCmd(factory.config), nil
+	case types.ProofBlock:
+		err := errors.New("ProofBlock task type is not supposed to be encountered in prover task handler")
+		return nil, err
+	case types.TaskTypeNone:
+		err := errors.New("Task has unspecified type")
+		return nil, err
+	default:
+		err := fmt.Errorf("Unhandled task type: %v", taskType.String())
+		return nil, err
+	}
+}

--- a/nil/services/synccommittee/prover/commands/commands.go
+++ b/nil/services/synccommittee/prover/commands/commands.go
@@ -1,0 +1,112 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
+)
+
+type CommandDefinition struct {
+	ExecCommands   []*exec.Cmd
+	ExpectedResult types.TaskOutputArtifacts
+}
+
+type CommandConfig struct {
+	NilRpcEndpoint      string
+	ProofProducerBinary string
+	OutDir              string
+}
+
+type Command interface {
+	MakeCommandDefinition(task *types.Task) (*CommandDefinition, error)
+}
+
+type BeforeCommandExecuted interface {
+	BeforeCommandExecuted(ctx context.Context, task *types.Task, results types.TaskOutputArtifacts) error
+}
+
+type AfterCommandExecuted interface {
+	AfterCommandExecuted(task *types.Task, results types.TaskOutputArtifacts) (types.TaskResultData, error)
+}
+
+type cmdCommon struct {
+	binary string
+	outDir string
+}
+
+func makeCmdCommon(config CommandConfig) cmdCommon {
+	return cmdCommon{binary: config.ProofProducerBinary, outDir: config.OutDir}
+}
+
+func circuitTypeToArg(ct types.CircuitType) string {
+	switch ct {
+	case types.None:
+		return "none"
+	case types.CircuitBytecode:
+		return "bytecode"
+	case types.CircuitReadWrite:
+		return "rw"
+	case types.CircuitZKEVM:
+		return "zkevm"
+	case types.CircuitCopy:
+		return "copy"
+	default:
+		panic("Unknown circuit type")
+	}
+}
+
+func circuitIdx(ct types.CircuitType) uint8 {
+	return uint8(ct)
+}
+
+func aggregateCircuitDependencies(task *types.Task, dependencyType types.TaskType, resultType types.ProverResultType) ([]string, error) {
+	depFiles := make(map[types.CircuitType]string)
+	for _, res := range task.DependencyResults {
+		if res.TaskType == dependencyType {
+			path, ok := res.OutputArtifacts[resultType]
+			if !ok {
+				return nil,
+					fmt.Errorf("Inconsistent task %v , dependencyType %v has no expected result %v",
+						task.Id.String(),
+						dependencyType.String(),
+						resultType.String())
+			}
+			depFiles[res.CircuitType] = path
+		}
+	}
+	if len(depFiles) != int(types.CircuitAmount) {
+		return nil,
+			fmt.Errorf("Insufficient input for task %v with type %v on %v dependency: expected %d, actual %d",
+				task.Id.String(),
+				task.TaskType.String(),
+				dependencyType,
+				types.CircuitAmount,
+				len(depFiles))
+	}
+	// Dependency files must be arranged in the same order for each task
+	// We use the order of ascending circuit indices
+	arrangedInputs := make([]string, 0)
+	for ct := range types.Circuits() {
+		arrangedInputs = append(arrangedInputs, depFiles[ct])
+	}
+	return arrangedInputs, nil
+}
+
+func findDependencyResult(task *types.Task, dependencyType types.TaskType, resultType types.ProverResultType) (string, error) {
+	foundFile := ""
+	for _, res := range task.DependencyResults {
+		if res.TaskType == dependencyType {
+			if foundFile != "" {
+				return "", fmt.Errorf("More then one %v files was found as a result for %v dependency", resultType.String(), dependencyType.String())
+			}
+			path, ok := res.OutputArtifacts[resultType]
+			if !ok {
+				return "", fmt.Errorf("DependencyType %v  has no expected result %v", dependencyType.String(), resultType.String())
+			}
+			foundFile = path
+		}
+	}
+	return foundFile, nil
+}

--- a/nil/services/synccommittee/prover/commands/consistency_check.go
+++ b/nil/services/synccommittee/prover/commands/consistency_check.go
@@ -1,0 +1,51 @@
+package commands
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"slices"
+
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
+)
+
+type consistencyCheckCmd struct {
+	cmdCommon
+}
+
+func NewConsistencyCheckCmd(config CommandConfig) Command {
+	return &consistencyCheckCmd{
+		cmdCommon: makeCmdCommon(config),
+	}
+}
+
+func (cmd *consistencyCheckCmd) MakeCommandDefinition(task *types.Task) (*CommandDefinition, error) {
+	binary := cmd.binary
+	stage := []string{"--stage", "consistency-checks"}
+	commitmentStateFile, err := findDependencyResult(task, types.PartialProve, types.CommitmentState)
+	if err != nil {
+		return nil, err
+	}
+	commitmentState := []string{"--commitment-state-file", commitmentStateFile}
+	combinedQFile, err := findDependencyResult(task, types.CombinedQ, types.CombinedQPolynomial)
+	if err != nil {
+		return nil, err
+	}
+	combinedQ := []string{"--combined-Q-polynomial-file", combinedQFile}
+	consistencyChallengeFile, err := findDependencyResult(task, types.AggregatedFRI, types.ConsistencyCheckChallenges)
+	if err != nil {
+		return nil, err
+	}
+	consistencyChallenges := []string{"--consistency-checks-challenges-file", consistencyChallengeFile}
+
+	outFile := filepath.Join(cmd.outDir,
+		fmt.Sprintf("LPC_consistency_check_proof.%v.%v.%v", circuitIdx(task.CircuitType), task.ShardId, task.BlockHash.String()))
+	outArg := []string{"--proof", outFile}
+
+	allArgs := slices.Concat(stage, commitmentState, combinedQ, consistencyChallenges, outArg)
+	execCmd := exec.Command(binary, allArgs...)
+	return &CommandDefinition{
+		ExecCommands:   []*exec.Cmd{execCmd},
+		ExpectedResult: types.TaskOutputArtifacts{types.LPCConsistencyCheckProof: outFile},
+	}, execCmd.Err
+}

--- a/nil/services/synccommittee/prover/commands/merge_proof.go
+++ b/nil/services/synccommittee/prover/commands/merge_proof.go
@@ -1,0 +1,65 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
+)
+
+type mergeProofCmd struct {
+	cmdCommon
+}
+
+func NewMergeProofCmd(config CommandConfig) Command {
+	return &mergeProofCmd{
+		cmdCommon: makeCmdCommon(config),
+	}
+}
+
+var _ AfterCommandExecuted = new(mergeProofCmd)
+
+func (cmd *mergeProofCmd) MakeCommandDefinition(task *types.Task) (*CommandDefinition, error) {
+	binary := cmd.binary
+	stage := []string{"--stage", "merge-proofs"}
+	partialProofFiles, err := aggregateCircuitDependencies(task, types.PartialProve, types.PartialProof)
+	if err != nil {
+		return nil, err
+	}
+	partialProofs := append([]string{"--partial-proof"}, partialProofFiles...)
+
+	LPCCheckFiles, err := aggregateCircuitDependencies(task, types.FRIConsistencyChecks, types.LPCConsistencyCheckProof)
+	if err != nil {
+		return nil, err
+	}
+	LPCChecks := append([]string{"--initial-proof"}, LPCCheckFiles...)
+
+	aggFRIFile, err := findDependencyResult(task, types.AggregatedFRI, types.AggregatedFRIProof)
+	if err != nil {
+		return nil, err
+	}
+	aggFRI := []string{"--aggregated-FRI-proof", aggFRIFile}
+
+	outFile := filepath.Join(cmd.outDir,
+		fmt.Sprintf("final-proof.%v.%v", task.ShardId, task.BlockHash.String()))
+	outArg := []string{"--proof", outFile}
+
+	allArgs := slices.Concat(stage, partialProofs, LPCChecks, aggFRI, outArg)
+	execCmd := exec.Command(binary, allArgs...)
+	return &CommandDefinition{
+		ExecCommands:   []*exec.Cmd{execCmd},
+		ExpectedResult: types.TaskOutputArtifacts{types.FinalProof: outFile},
+	}, execCmd.Err
+}
+
+func (*mergeProofCmd) AfterCommandExecuted(task *types.Task, results types.TaskOutputArtifacts) (types.TaskResultData, error) {
+	mergedProofFile := results[types.FinalProof]
+	proofContent, err := os.ReadFile(mergedProofFile)
+	if err != nil {
+		return nil, fmt.Errorf("cannot fetch final proof data: %w", err)
+	}
+	return proofContent, nil
+}

--- a/nil/services/synccommittee/prover/commands/partial_proof.go
+++ b/nil/services/synccommittee/prover/commands/partial_proof.go
@@ -1,0 +1,97 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"slices"
+
+	"github.com/NilFoundation/nil/nil/client"
+	"github.com/NilFoundation/nil/nil/common/logging"
+	"github.com/NilFoundation/nil/nil/services/rpc/transport"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/rpc"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/prover/tracer"
+	"github.com/rs/zerolog"
+)
+
+type partialProofCmd struct {
+	client         client.Client
+	logger         zerolog.Logger
+	nilRpcEndpoint string
+	cmdCommon
+}
+
+func NewPartialProofCmd(config CommandConfig, logger zerolog.Logger) Command {
+	return &partialProofCmd{
+		client:         rpc.NewRetryClient(config.NilRpcEndpoint, logging.NewLogger("client")),
+		nilRpcEndpoint: config.NilRpcEndpoint,
+		cmdCommon:      makeCmdCommon(config),
+		logger:         logger,
+	}
+}
+
+var _ BeforeCommandExecuted = new(partialProofCmd)
+
+func (cmd *partialProofCmd) MakeCommandDefinition(task *types.Task) (*CommandDefinition, error) {
+	resultFiles := make(types.TaskOutputArtifacts)
+	proofProducerBinary := cmd.binary
+	stage := []string{"--stage", "fast-generate-partial-proof"}
+	filePostfix := fmt.Sprintf(".%v.%v.%v", circuitIdx(task.CircuitType), task.ShardId, task.BlockHash.String())
+	circuitName := []string{"--circuit-name", circuitTypeToArg(task.CircuitType)}
+
+	assignmentDescFile := filepath.Join(cmd.outDir, "assignment_table_description"+filePostfix)
+	assignmentDescArg := []string{"--assignment-description-file", assignmentDescFile}
+	resultFiles[types.AssignmentTableDescription] = assignmentDescFile
+
+	traceArg := []string{"--trace", cmd.getTraceFileName(task)}
+
+	partialProofFile := filepath.Join(cmd.outDir, "partial_proof"+filePostfix)
+	partialProofArg := []string{"--proof", partialProofFile}
+	resultFiles[types.PartialProof] = partialProofFile
+
+	challengeFile := filepath.Join(cmd.outDir, "challenge"+filePostfix)
+	challengeArg := []string{"--challenge-file", challengeFile}
+	resultFiles[types.PartialProofChallenges] = challengeFile
+
+	thetaPowerFile := filepath.Join(cmd.outDir, "theta_power"+filePostfix)
+	thetaPowerArg := []string{"--theta-power-file", thetaPowerFile}
+	resultFiles[types.ThetaPower] = thetaPowerFile
+
+	commonDataFile := filepath.Join(cmd.outDir, "preprocessed_common_data"+filePostfix)
+	commonDataArg := []string{"--common-data", commonDataFile}
+	resultFiles[types.PreprocessedCommonData] = commonDataFile
+
+	commitmentStateFile := filepath.Join(cmd.outDir, "commitment_state"+filePostfix)
+	commitmentStateArg := []string{"--updated-commitment-state-file", commitmentStateFile}
+	resultFiles[types.CommitmentState] = commitmentStateFile
+
+	allArgs := slices.Concat(stage, circuitName, assignmentDescArg, traceArg, partialProofArg, challengeArg, thetaPowerArg, commitmentStateArg, commonDataArg)
+	execCmd := exec.Command(proofProducerBinary, allArgs...)
+	if execCmd.Err != nil {
+		return nil, execCmd.Err
+	}
+
+	return &CommandDefinition{
+		ExecCommands:   []*exec.Cmd{execCmd},
+		ExpectedResult: resultFiles,
+	}, nil
+}
+
+func (cmd *partialProofCmd) getTraceFileName(task *types.Task) string {
+	return filepath.Join(cmd.outDir, fmt.Sprintf("trace.%v.%v", task.ShardId, task.BlockHash))
+}
+
+func (cmd *partialProofCmd) BeforeCommandExecuted(ctx context.Context, task *types.Task, results types.TaskOutputArtifacts) error {
+	traceFileName := cmd.getTraceFileName(task)
+	cmd.logger.Info().Msgf("Tracer arguments: trace --nil-endpoint %v %v %v %v", cmd.nilRpcEndpoint, traceFileName, task.ShardId, task.BlockHash.String())
+
+	tracerConfig := tracer.TraceConfig{
+		MarshalMode:  tracer.MarshalModeBinary,
+		ShardID:      task.ShardId,
+		BaseFileName: traceFileName,
+		BlockIDs:     []transport.BlockReference{transport.HashBlockReference(task.BlockHash)},
+	}
+	return tracer.GenerateTrace(ctx, cmd.client, &tracerConfig)
+}

--- a/nil/services/synccommittee/prover/task_handler.go
+++ b/nil/services/synccommittee/prover/task_handler.go
@@ -3,23 +3,18 @@ package prover
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"os"
-	"os/exec"
-	"path/filepath"
-	"slices"
 	"strings"
 
 	"github.com/NilFoundation/nil/nil/client"
 	"github.com/NilFoundation/nil/nil/common"
 	"github.com/NilFoundation/nil/nil/common/logging"
-	"github.com/NilFoundation/nil/nil/services/rpc/transport"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/api"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/log"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/storage"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
-	"github.com/NilFoundation/nil/nil/services/synccommittee/prover/tracer"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/prover/commands"
 	"github.com/rs/zerolog"
 )
 
@@ -46,393 +41,13 @@ func newTaskHandler(
 	}
 }
 
-type taskHandlerConfig struct {
-	NilRpcEndpoint      string
-	ProofProducerBinary string
-	OutDir              string
-}
+type taskHandlerConfig = commands.CommandConfig
 
 func newTaskHandlerConfig(nilRpcEndpoint string) taskHandlerConfig {
 	return taskHandlerConfig{
 		NilRpcEndpoint:      nilRpcEndpoint,
 		ProofProducerBinary: "proof-producer-multi-threaded",
 		OutDir:              os.TempDir(), // TODO: replace with shared folder
-	}
-}
-
-type commandDescription struct {
-	runCommands           []*exec.Cmd
-	expectedResult        types.TaskResultAddresses
-	binaryExpectedResults types.TaskResultData
-}
-
-func circuitTypeToArg(ct types.CircuitType) string {
-	switch ct {
-	case types.None:
-		return "none"
-	case types.CircuitBytecode:
-		return "bytecode"
-	case types.CircuitMPT:
-		return "mpt"
-	case types.CircuitReadWrite:
-		return "rw"
-	case types.CircuitZKEVM:
-		return "zkevm"
-	case types.CircuitCopy:
-		return "copy"
-	default:
-		panic("Unknown circuit type")
-	}
-}
-
-func circuitIdx(ct types.CircuitType) uint8 {
-	return uint8(ct)
-}
-
-func collectDependencyFiles(task *types.Task, dependencyType types.TaskType, resultType types.ProverResultType) ([]string, error) {
-	depFiles := []string{}
-	for _, res := range task.DependencyResults {
-		if res.TaskType == dependencyType {
-			path, ok := res.DataAddresses[resultType]
-			if !ok {
-				return depFiles, errors.New("Inconsistent task " + task.Id.String() +
-					", dependencyType " + dependencyType.String() + " has no expected result " + resultType.String())
-			}
-			depFiles = append(depFiles, path)
-		}
-	}
-	return depFiles, nil
-}
-
-func insufficientTaskInputMsg(task *types.Task, dependencyType string, expected int, actual int) string {
-	return fmt.Sprintf("Insufficient input for task %v with type %v on %v dependency: expected %d, actual %d",
-		task.Id.String(),
-		task.TaskType.String(),
-		dependencyType,
-		expected,
-		actual,
-	)
-}
-
-func (h *taskHandler) generateTraces(ctx context.Context, task *types.Task) (string, error) {
-	traceFile := filepath.Join(h.config.OutDir, fmt.Sprintf("trace.%v.%v", task.ShardId, task.BlockHash))
-
-	h.logger.Info().Msgf("Tracer arguments: trace --nil-endpoint %v %v %v %v", h.config.NilRpcEndpoint, traceFile, task.ShardId, task.BlockHash.String())
-
-	tracerConfig := tracer.TraceConfig{
-		MarshalMode:  tracer.MarshalModeBinary,
-		ShardID:      task.ShardId,
-		BaseFileName: traceFile,
-		BlockIDs:     []transport.BlockReference{transport.HashBlockReference(task.BlockHash)},
-	}
-	err := tracer.GenerateTrace(ctx, h.client, &tracerConfig)
-	return traceFile, err
-}
-
-func makePartialProofRunCommand(task *types.Task, traceFile string, config taskHandlerConfig) (*exec.Cmd, types.TaskResultAddresses, error) {
-	resultFiles := make(types.TaskResultAddresses)
-	proofProducerBinary := config.ProofProducerBinary
-	stage := []string{"--stage", "fast-generate-partial-proof"}
-	filePostfix := fmt.Sprintf(".%v.%v.%v", circuitIdx(task.CircuitType), task.ShardId, task.BlockHash.String())
-	circuitName := []string{"--circuit-name", circuitTypeToArg(task.CircuitType)}
-
-	assignmentDescFile := filepath.Join(config.OutDir, "assignment_table_description"+filePostfix)
-	assignmentDescArg := []string{"--assignment-description-file", assignmentDescFile}
-	resultFiles[types.AssignmentTableDescription] = assignmentDescFile
-
-	traceArg := []string{"--trace", traceFile}
-
-	partialProofFile := filepath.Join(config.OutDir, "partial_proof"+filePostfix)
-	partialProofArg := []string{"--proof", partialProofFile}
-	resultFiles[types.PartialProof] = partialProofFile
-
-	challengeFile := filepath.Join(config.OutDir, "challenge"+filePostfix)
-	challengeArg := []string{"--challenge-file", challengeFile}
-	resultFiles[types.PartialProofChallenges] = challengeFile
-
-	thetaPowerFile := filepath.Join(config.OutDir, "theta_power"+filePostfix)
-	thetaPowerArg := []string{"--theta-power-file", thetaPowerFile}
-	resultFiles[types.ThetaPower] = thetaPowerFile
-
-	commonDataFile := filepath.Join(config.OutDir, "preprocessed_common_data"+filePostfix)
-	commonDataArg := []string{"--common-data", commonDataFile}
-	resultFiles[types.PreprocessedCommonData] = commonDataFile
-
-	commitmentStateFile := filepath.Join(config.OutDir, "commitment_state"+filePostfix)
-	commitmentStateArg := []string{"--updated-commitment-state-file", commitmentStateFile}
-	resultFiles[types.CommitmentState] = commitmentStateFile
-
-	allArgs := slices.Concat(stage, circuitName, assignmentDescArg, traceArg, partialProofArg, challengeArg, thetaPowerArg, commitmentStateArg, commonDataArg)
-	cmd := exec.Command(proofProducerBinary, allArgs...)
-	return cmd, resultFiles, cmd.Err
-}
-
-func (h *taskHandler) makePartialProofCommand(ctx context.Context, task *types.Task) (commandDescription, error) {
-	// First we run tracer right away, since it's a part of prover binary, so no need for separate command
-	traceFile, err := h.generateTraces(ctx, task)
-	if err != nil {
-		return commandDescription{}, err
-	}
-
-	// Now we are ready to generate the partial proof
-	proofProducerCmd, resultFiles, err := makePartialProofRunCommand(task, traceFile, h.config)
-	if err != nil {
-		return commandDescription{}, err
-	}
-	resultCommandSet := commandDescription{
-		runCommands:    []*exec.Cmd{proofProducerCmd},
-		expectedResult: resultFiles,
-	}
-	return resultCommandSet, err
-}
-
-func (h *taskHandler) makeAggregateChallengesCommand(task *types.Task) (commandDescription, error) {
-	binary := h.config.ProofProducerBinary
-	stage := []string{"--stage", "generate-aggregated-challenge"}
-	inputFiles, err := collectDependencyFiles(task, types.PartialProve, types.PartialProofChallenges)
-	if err != nil {
-		return commandDescription{}, err
-	}
-	if len(inputFiles) != int(types.CircuitAmount) {
-		err = errors.New(insufficientTaskInputMsg(task, "PartialProofChallenges", int(types.CircuitAmount), len(inputFiles)))
-		return commandDescription{}, err
-	}
-	inputs := append([]string{"--input-challenge-files"}, inputFiles...)
-	outFile := filepath.Join(h.config.OutDir,
-		fmt.Sprintf("aggregated_challenges.%v.%v", task.ShardId, task.BlockHash.String()))
-	outArg := []string{"--aggregated-challenge-file", outFile}
-	allArgs := slices.Concat(stage, inputs, outArg)
-	cmd := exec.Command(binary, allArgs...)
-	return commandDescription{
-		runCommands:    []*exec.Cmd{cmd},
-		expectedResult: types.TaskResultAddresses{types.AggregatedChallenges: outFile},
-	}, cmd.Err
-}
-
-func (h *taskHandler) makeCombinedQCommand(task *types.Task) (commandDescription, error) {
-	binary := h.config.ProofProducerBinary
-	stage := []string{"--stage", "compute-combined-Q"}
-	commitmentStateFile, err := collectDependencyFiles(task, types.PartialProve, types.CommitmentState)
-	if err != nil {
-		return commandDescription{}, err
-	}
-	if len(commitmentStateFile) != 1 {
-		err = errors.New(insufficientTaskInputMsg(task, "CommitmentState", 1, len(commitmentStateFile)))
-		return commandDescription{}, err
-	}
-	commitmentState := []string{"--commitment-state-file", commitmentStateFile[0]}
-
-	aggChallengesFile, err := collectDependencyFiles(task, types.AggregatedChallenge, types.AggregatedChallenges)
-	if err != nil {
-		return commandDescription{}, err
-	}
-	if len(aggChallengesFile) != 1 {
-		err = errors.New(insufficientTaskInputMsg(task, "AggregatedChallenges", 1, len(aggChallengesFile)))
-		return commandDescription{}, err
-	}
-	aggregateChallenges := []string{"--aggregated-challenge-file", aggChallengesFile[0]}
-
-	startingPower := []string{"--combined-Q-starting-power=0"} // TODO: compute it properly from dependencies
-	outFile := filepath.Join(h.config.OutDir,
-		fmt.Sprintf("combined_Q.%v.%v.%v", circuitIdx(task.CircuitType), task.ShardId, task.BlockHash.String()))
-	outArg := []string{"--combined-Q-polynomial-file", outFile}
-
-	allArgs := slices.Concat(stage, commitmentState, aggregateChallenges, startingPower, outArg)
-	cmd := exec.Command(binary, allArgs...)
-	return commandDescription{
-		runCommands:    []*exec.Cmd{cmd},
-		expectedResult: types.TaskResultAddresses{types.CombinedQPolynomial: outFile},
-	}, cmd.Err
-}
-
-func (h *taskHandler) makeAggregateFRICommand(task *types.Task) (commandDescription, error) {
-	binary := h.config.ProofProducerBinary
-	stage := []string{"--stage", "aggregated-FRI"}
-	assignmentTableFile, err := collectDependencyFiles(task, types.PartialProve, types.AssignmentTableDescription)
-	if err != nil {
-		return commandDescription{}, err
-	}
-	if len(assignmentTableFile) != int(types.CircuitAmount) {
-		err = errors.New(insufficientTaskInputMsg(task, "AssignmentTableDescription", int(types.CircuitAmount), len(assignmentTableFile)))
-		return commandDescription{}, err
-	}
-	assignmentTable := []string{"--assignment-description-file", assignmentTableFile[0]}
-
-	aggChallengeFile, err := collectDependencyFiles(task, types.AggregatedChallenge, types.AggregatedChallenges)
-	if err != nil {
-		return commandDescription{}, err
-	}
-	if len(aggChallengeFile) != 1 {
-		err = errors.New(insufficientTaskInputMsg(task, "AggregatedChallenges", 1, len(aggChallengeFile)))
-		return commandDescription{}, err
-	}
-	aggregatedChallenge := []string{"--aggregated-challenge-file", aggChallengeFile[0]}
-
-	combinedQFiles, err := collectDependencyFiles(task, types.CombinedQ, types.CombinedQPolynomial)
-	if err != nil {
-		return commandDescription{}, err
-	}
-	if len(combinedQFiles) != int(types.CircuitAmount) {
-		err = errors.New(insufficientTaskInputMsg(task, "CombinedQPolynomial", int(types.CircuitAmount), len(combinedQFiles)))
-		return commandDescription{}, err
-	}
-	combinedQ := append([]string{"--input-combined-Q-polynomial-files"}, combinedQFiles...)
-
-	resFiles := make(types.TaskResultAddresses)
-	filePostfix := fmt.Sprintf(".%v.%v", task.ShardId, task.BlockHash.String())
-	resFiles[types.AggregatedFRIProof] = filepath.Join(h.config.OutDir, "aggregated_FRI_proof"+filePostfix)
-	resFiles[types.ProofOfWork] = filepath.Join(h.config.OutDir, "POW"+filePostfix)
-	resFiles[types.ConsistencyCheckChallenges] = filepath.Join(h.config.OutDir, "challenges"+filePostfix)
-
-	aggFRI := []string{"--proof", resFiles[types.AggregatedFRIProof]}
-	POW := []string{"--proof-of-work-file", resFiles[types.ProofOfWork]}
-	consistencyChallenges := []string{"--consistency-checks-challenges-file", resFiles[types.ConsistencyCheckChallenges]}
-	allArgs := slices.Concat(stage, assignmentTable, aggregatedChallenge, combinedQ, aggFRI, POW, consistencyChallenges)
-	cmd := exec.Command(binary, allArgs...)
-	return commandDescription{runCommands: []*exec.Cmd{cmd}, expectedResult: resFiles}, cmd.Err
-}
-
-func (h *taskHandler) makeConsistencyCheckCommand(task *types.Task) (commandDescription, error) {
-	binary := h.config.ProofProducerBinary
-	stage := []string{"--stage", "consistency-checks"}
-	commitmentStateFile, err := collectDependencyFiles(task, types.PartialProve, types.CommitmentState)
-	if err != nil {
-		return commandDescription{}, err
-	}
-	if len(commitmentStateFile) != 1 {
-		err = errors.New(insufficientTaskInputMsg(task, "CommitmentState", 1, len(commitmentStateFile)))
-		return commandDescription{}, err
-	}
-	commitmentState := []string{"--commitment-state-file", commitmentStateFile[0]}
-	combinedQFile, err := collectDependencyFiles(task, types.CombinedQ, types.CombinedQPolynomial)
-	if err != nil {
-		return commandDescription{}, err
-	}
-	if len(combinedQFile) != 1 {
-		err = errors.New(insufficientTaskInputMsg(task, "CombinedQPolynomial", 1, len(combinedQFile)))
-		return commandDescription{}, err
-	}
-	combinedQ := []string{"--combined-Q-polynomial-file", combinedQFile[0]}
-	consistencyChallengeFiles, err := collectDependencyFiles(task, types.AggregatedFRI, types.ConsistencyCheckChallenges)
-	if err != nil {
-		return commandDescription{}, err
-	}
-	if len(consistencyChallengeFiles) != 1 {
-		err = errors.New(insufficientTaskInputMsg(task, "ConsistencyCheckChallenges", 1, len(consistencyChallengeFiles)))
-		return commandDescription{}, err
-	}
-	consistencyChallenges := []string{"--consistency-checks-challenges-file", consistencyChallengeFiles[0]}
-
-	outFile := filepath.Join(h.config.OutDir,
-		fmt.Sprintf("LPC_consistency_check_proof.%v.%v.%v", circuitIdx(task.CircuitType), task.ShardId, task.BlockHash.String()))
-	outArg := []string{"--proof", outFile}
-
-	allArgs := slices.Concat(stage, commitmentState, combinedQ, consistencyChallenges, outArg)
-	cmd := exec.Command(binary, allArgs...)
-	return commandDescription{
-		runCommands:    []*exec.Cmd{cmd},
-		expectedResult: types.TaskResultAddresses{types.LPCConsistencyCheckProof: outFile},
-	}, cmd.Err
-}
-
-func (h *taskHandler) makeMergeProofCommand(task *types.Task) (commandDescription, error) {
-	binary := h.config.ProofProducerBinary
-	stage := []string{"--stage", "merge-proofs"}
-	partialProofFiles, err := collectDependencyFiles(task, types.PartialProve, types.PartialProof)
-	if err != nil {
-		return commandDescription{}, err
-	}
-	if len(partialProofFiles) != int(types.CircuitAmount) {
-		err = errors.New(insufficientTaskInputMsg(task, "PartialProof", int(types.CircuitAmount), len(partialProofFiles)))
-		return commandDescription{}, err
-	}
-	partialProofs := append([]string{"--partial-proof"}, partialProofFiles...)
-
-	LPCCheckFiles, err := collectDependencyFiles(task, types.FRIConsistencyChecks, types.LPCConsistencyCheckProof)
-	if err != nil {
-		return commandDescription{}, err
-	}
-	if len(LPCCheckFiles) != int(types.CircuitAmount) {
-		err = errors.New(insufficientTaskInputMsg(task, "LPCConsistencyCheckProof", int(types.CircuitAmount), len(LPCCheckFiles)))
-		return commandDescription{}, err
-	}
-	LPCChecks := append([]string{"--initial-proof"}, LPCCheckFiles...)
-
-	aggFRIFile, err := collectDependencyFiles(task, types.AggregatedFRI, types.AggregatedFRIProof)
-	if err != nil {
-		return commandDescription{}, err
-	}
-	if len(aggFRIFile) != 1 {
-		err = errors.New(insufficientTaskInputMsg(task, "AggregatedFRIProof", int(types.CircuitAmount), len(aggFRIFile)))
-		return commandDescription{}, err
-	}
-	aggFRI := []string{"--aggregated-FRI-proof", aggFRIFile[0]}
-
-	outFile := filepath.Join(h.config.OutDir,
-		fmt.Sprintf("final-proof.%v.%v", task.ShardId, task.BlockHash.String()))
-	outArg := []string{"--proof", outFile}
-
-	allArgs := slices.Concat(stage, partialProofs, LPCChecks, aggFRI, outArg)
-	cmd := exec.Command(binary, allArgs...)
-	return commandDescription{
-		runCommands:    []*exec.Cmd{cmd},
-		expectedResult: types.TaskResultAddresses{types.FinalProof: outFile},
-	}, cmd.Err
-}
-
-func (h *taskHandler) makeAggregateProofCommand(task *types.Task) (commandDescription, error) {
-	binary := "echo" // TODO: enable aggregate proof command once it will be implemented
-	stage := []string{"--stage", "aggregate-proofs"}
-	blockProofFiles, err := collectDependencyFiles(task, types.MergeProof, types.FinalProof)
-	if err != nil {
-		return commandDescription{}, err
-	}
-	blockProofs := append([]string{"--block-proof"}, blockProofFiles...)
-
-	outFile := filepath.Join(h.config.OutDir,
-		fmt.Sprintf("aggregated-proof.%v.%v", task.ShardId, task.BlockHash.String()))
-	outArg := []string{"--proof", outFile}
-
-	allArgs := slices.Concat(stage, blockProofs, outArg)
-	var aggregatedProof []byte
-	for _, dependency := range task.DependencyResults {
-		aggregatedProof = append(aggregatedProof, dependency.Data...)
-	}
-	cmd := exec.Command(binary, allArgs...)
-	return commandDescription{
-		runCommands:           []*exec.Cmd{cmd},
-		expectedResult:        types.TaskResultAddresses{types.AggregatedProof: outFile},
-		binaryExpectedResults: aggregatedProof,
-	}, cmd.Err
-}
-
-func (h *taskHandler) makeCommandForTask(ctx context.Context, task *types.Task) (commandDescription, error) {
-	switch task.TaskType {
-	case types.PartialProve:
-		return h.makePartialProofCommand(ctx, task)
-	case types.AggregatedChallenge:
-		return h.makeAggregateChallengesCommand(task)
-	case types.CombinedQ:
-		return h.makeCombinedQCommand(task)
-	case types.AggregatedFRI:
-		return h.makeAggregateFRICommand(task)
-	case types.FRIConsistencyChecks:
-		return h.makeConsistencyCheckCommand(task)
-	case types.MergeProof:
-		return h.makeMergeProofCommand(task)
-	case types.AggregateProofs:
-		return h.makeAggregateProofCommand(task)
-	case types.ProofBlock:
-		err := errors.New("ProofBlock task type is not supposed to be encountered in prover task handler for task " + task.Id.String() +
-			" type " + task.TaskType.String())
-		return commandDescription{}, err
-	case types.TaskTypeNone:
-		err := fmt.Errorf("task with id=%s has unspecified type", task.Id.String())
-		return commandDescription{}, err
-	default:
-		err := errors.New("Unknown type for task " + task.Id.String() +
-			" type " + task.TaskType.String())
-		return commandDescription{}, err
 	}
 }
 
@@ -443,7 +58,17 @@ func (h *taskHandler) Handle(ctx context.Context, executorId types.TaskExecutorI
 		log.NewTaskEvent(h.logger, zerolog.ErrorLevel, task).Err(err).Msg("failed to create command for task")
 		return h.resultStorage.Put(ctx, taskResult)
 	}
-	desc, err := h.makeCommandForTask(ctx, task)
+	commandFactory := commands.NewCommandFactory(h.config, h.logger)
+	cmd, err := commandFactory.MakeHandlerCommandForTaskType(task.TaskType)
+	if err != nil {
+		taskResult := types.NewFailureProverTaskResult(task.Id, executorId, fmt.Errorf("unable to instantiate handler for task: %w", err))
+		log.NewTaskEvent(h.logger, zerolog.ErrorLevel, task).
+			Err(err).
+			Msg("unable to instantiate handler for task")
+		return h.resultStorage.Put(ctx, taskResult)
+	}
+
+	commandDefinition, err := cmd.MakeCommandDefinition(task)
 	if err != nil {
 		taskResult := types.NewFailureProverTaskResult(task.Id, executorId, fmt.Errorf("failed to create command for task: %w", err))
 		log.NewTaskEvent(h.logger, zerolog.ErrorLevel, task).
@@ -453,14 +78,21 @@ func (h *taskHandler) Handle(ctx context.Context, executorId types.TaskExecutorI
 	}
 	startTime := h.timer.NowTime()
 	log.NewTaskEvent(h.logger, zerolog.InfoLevel, task).Msg("Starting task execution")
-	for _, cmd := range desc.runCommands {
+	if before, ok := cmd.(commands.BeforeCommandExecuted); ok {
+		log.NewTaskEvent(h.logger, zerolog.DebugLevel, task).Msg("Running action before task command")
+		if err := before.BeforeCommandExecuted(ctx, task, commandDefinition.ExpectedResult); err != nil {
+			log.NewTaskEvent(h.logger, zerolog.ErrorLevel, task).Msg("Action before task execution failed")
+			return h.resultStorage.Put(ctx, types.NewFailureProverTaskResult(task.Id, executorId, fmt.Errorf("action before task execution failed: %w", err)))
+		}
+	}
+	for _, execCmd := range commandDefinition.ExecCommands {
 		var stdout bytes.Buffer
 		var stderr bytes.Buffer
-		cmd.Stdout = &stdout
-		cmd.Stderr = &stderr
-		cmdString := strings.Join(cmd.Args, " ")
+		execCmd.Stdout = &stdout
+		execCmd.Stderr = &stderr
+		cmdString := strings.Join(execCmd.Args, " ")
 		h.logger.Info().Msgf("Run command %v\n", cmdString)
-		err := cmd.Run()
+		err := execCmd.Run()
 		h.logger.Trace().Msgf("Task execution stdout:\n%v\n", stdout.String())
 		if err != nil {
 			taskResult := types.NewFailureProverTaskResult(task.Id, executorId, fmt.Errorf("task execution failed: %w", err))
@@ -473,11 +105,21 @@ func (h *taskHandler) Handle(ctx context.Context, executorId types.TaskExecutorI
 		}
 	}
 
+	taskBinaryResult := types.TaskResultData{}
+	if after, ok := cmd.(commands.AfterCommandExecuted); ok {
+		log.NewTaskEvent(h.logger, zerolog.DebugLevel, task).Msg("Running action after task command")
+		taskBinaryResult, err = after.AfterCommandExecuted(task, commandDefinition.ExpectedResult)
+		if err != nil {
+			log.NewTaskEvent(h.logger, zerolog.ErrorLevel, task).Msg("Action after task command failed")
+			return h.resultStorage.Put(ctx, types.NewFailureProverTaskResult(task.Id, executorId, fmt.Errorf("Action after task command failed: %w", err)))
+		}
+	}
+
 	executionTime := h.timer.NowTime().Sub(startTime)
 	log.NewTaskEvent(h.logger, zerolog.InfoLevel, task).
 		Dur(logging.FieldTaskExecTime, executionTime).
 		Msg("Task execution completed successfully")
 
-	taskResult := types.NewSuccessProverTaskResult(task.Id, executorId, desc.expectedResult, desc.binaryExpectedResults)
+	taskResult := types.NewSuccessProverTaskResult(task.Id, executorId, commandDefinition.ExpectedResult, taskBinaryResult)
 	return h.resultStorage.Put(ctx, taskResult)
 }


### PR DESCRIPTION
- Splitted task handler commands by subfiles
- Supported before- and after-actions for commands
- Arranged order of circuit-specific dependencies for aggregation stages
- Computed theta-power arguments as partial sums
- Simplified error handling