### PR TITLE
[GH-#] Estimate feeCredit for wallet deployment automatically

### DIFF
--- a/niljs/src/contracts/SmartAccountV1/SmartAccountV1.ts
+++ b/niljs/src/contracts/SmartAccountV1/SmartAccountV1.ts
@@ -366,14 +366,14 @@ export class SmartAccountV1 implements SmartAccountInterface {
     const hexData = refineFunctionHexData({ data, abi, functionName, args });
     let refinedCredit = feeCredit;
 
+    const callData = encodeFunctionData({
+      abi: SmartAccount.abi,
+      functionName: "asyncCall",
+      args: [hexTo, hexRefundTo, hexBounceTo, tokens ?? [], value ?? 0n, hexData],
+    });
+
     if (!refinedCredit) {
       const balance = await this.getBalance();
-
-      const callData = encodeFunctionData({
-        abi: SmartAccount.abi,
-        functionName: "asyncCall",
-        args: [hexTo, hexRefundTo, hexBounceTo, tokens ?? [], value ?? 0n, hexData],
-      });
 
       refinedCredit = await this.client.estimateGas(
         {
@@ -388,12 +388,6 @@ export class SmartAccountV1 implements SmartAccountInterface {
         throw new Error("Insufficient balance");
       }
     }
-
-    const callData = encodeFunctionData({
-      abi: SmartAccount.abi,
-      functionName: "asyncCall",
-      args: [hexTo, hexRefundTo, hexBounceTo, tokens ?? [], value ?? 0n, hexData],
-    });
 
     const { hash } = await this.requestToSmartAccount({
       data: hexToBytes(callData),


### PR DESCRIPTION
I was dealing with the problems of creating a wallet in `clijs` and noticed that unlike Go CLI, we don't use automatic `feeCredit` calculation when creating a wallet in `nil.js`. It so happened that in my case the naive calculation was giving a figure higher than the amount we were funding the wallet with. I did not simply increase the amount of topping up, but made the logic similar to that in Go.

I only have a doubt whether it is worth leaving the possibility of manually specifying `feeCredit` in the `selfDeploy` function? On the one hand, in Go we allow this to be controlled. On the other hand, will it ever be useful or only confuse users?