### PR TITLE
sc: add blob send to L1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,8 @@ require (
 	github.com/dgraph-io/badger/v4 v4.2.0
 	github.com/ethereum/go-ethereum v1.14.12
 	github.com/hashicorp/golang-lru/v2 v2.0.7
+	github.com/icza/bitio v1.1.0
+	github.com/klauspost/compress v1.17.11
 	github.com/shopspring/decimal v1.4.0
 	github.com/spf13/viper v1.19.0
 	golang.org/x/term v0.26.0
@@ -139,7 +141,6 @@ require (
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
 	github.com/jbenet/go-temp-err-catcher v0.1.0 // indirect
 	github.com/jbenet/goprocess v0.1.4 // indirect
-	github.com/klauspost/compress v1.17.11 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.8 // indirect
 	github.com/koron/go-ssdp v0.0.4 // indirect
 	github.com/kr/pretty v0.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -303,6 +303,10 @@ github.com/huin/goupnp v1.3.0/go.mod h1:gnGPsThkYa7bFi/KWmEysQRf48l2dvR5bxr2OFck
 github.com/iancoleman/strcase v0.0.0-20180726023541-3605ed457bf7/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
 github.com/iancoleman/strcase v0.2.0 h1:05I4QRnGpI0m37iZQRuskXh+w77mr6Z41lwQzuHLwW0=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
+github.com/icza/bitio v1.1.0 h1:ysX4vtldjdi3Ygai5m1cWy4oLkhWTAi+SyO6HC8L9T0=
+github.com/icza/bitio v1.1.0/go.mod h1:0jGnlLAx8MKMr9VGnn/4YrvZiprkvBelsVIbA9Jjr9A=
+github.com/icza/mighty v0.0.0-20180919140131-cfd07d671de6 h1:8UsGZ2rr2ksmEru6lToqnXgA8Mz1DP11X4zSJ159C3k=
+github.com/icza/mighty v0.0.0-20180919140131-cfd07d671de6/go.mod h1:xQig96I1VNBDIWGCdTt54nHt6EeI639SmHycLYL7FkA=
 github.com/iden3/go-iden3-crypto v0.0.16 h1:zN867xiz6HgErXVIV/6WyteGcOukE9gybYTorBMEdsk=
 github.com/iden3/go-iden3-crypto v0.0.16/go.mod h1:dLpM4vEPJ3nDHzhWFXDjzkn1qHoBeOT/3UEhXsEsP3E=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/nil/services/synccommittee/Makefile.inc
+++ b/nil/services/synccommittee/Makefile.inc
@@ -71,11 +71,15 @@ $(root_sce)/public/taskdebugorder_string.go: $(root_sce)/public/task_debug_api.g
 	go generate $(root_sce)/public
 
 .PHONY: pb_synccommittee
-pb_synccommittee: $(root_sce)/prover/proto/traces.pb.go
+pb_synccommittee: $(root_sce)/prover/proto/traces.pb.go \
+                  $(root_sce)/internal/types/proto/blob_transaction.pb.go
 
 $(root_sce)/prover/proto/traces.pb.go: $(root_sce)/prover/proto/traces.proto
 	protoc --proto_path=$(root_sce)/prover/proto --go_out=$(root_sce)/prover/ $(root_sce)/prover/proto/traces.proto $(root_sce)/prover/proto/verbose_mpt.proto
 
+
+$(root_sce)/internal/types/proto/blob_transaction.pb.go: $(root_sce)/internal/types/proto/blob_transaction.proto
+	protoc --go_out=$(root_sce)/internal/types/ $(root_sce)/internal/types/proto/blob_transaction.proto
 
 .PHONY: generate_contract_from_abi
 generate_contract_from_abi:

--- a/nil/services/synccommittee/core/batches/blob/builder.go
+++ b/nil/services/synccommittee/core/batches/blob/builder.go
@@ -1,0 +1,99 @@
+package blob
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/ethereum/go-ethereum/crypto/kzg4844"
+	"github.com/icza/bitio"
+)
+
+const blobSize = len(kzg4844.Blob{})
+
+type builder struct{}
+
+func NewBuilder() *builder {
+	return &builder{}
+}
+
+func (bb *builder) MakeBlobs(rd io.Reader, blobLimit int) ([]kzg4844.Blob, error) {
+	const blobSize = len(kzg4844.Blob{})
+
+	var blobs []kzg4844.Blob
+	eof := false
+	writtenBits := 0
+
+	bitReader := bitio.NewReader(rd) // bit wrapper for reading 254-bit pieces of data to place into the blobs
+
+	var blobBuf bytes.Buffer
+	blobBuf.Grow(blobSize)
+
+	ignoreEOF := func(err error) error {
+		if errors.Is(err, io.EOF) {
+			eof = true
+			return nil
+		}
+		return err
+	}
+
+	align := 0
+	for i := 0; !eof && i < blobLimit; i++ {
+		blobBuf.Reset()
+
+		blobWriter := bitio.NewWriter(&blobBuf)
+		writtenInBlob := 0
+		for writtenInBlob < blobSize && !eof {
+			var ethWordBuf [31]byte
+
+			read, err := bitReader.Read(ethWordBuf[:])
+			if err := ignoreEOF(err); err != nil {
+				return nil, err
+			}
+
+			wr, err := blobWriter.Write(ethWordBuf[:read])
+			if err != nil {
+				return nil, err
+			}
+			writtenInBlob += wr
+
+			if read < len(ethWordBuf) {
+				writtenBits += read * 8
+				eof = true
+				break
+			}
+
+			const lastByteBits = 6 // each 2 last bits of every u256 word cannot be used
+
+			lastbyte, err := bitReader.ReadBits(lastByteBits)
+			if err := ignoreEOF(err); err != nil {
+				return nil, err
+			}
+
+			if err := blobWriter.WriteBits(lastbyte, lastByteBits); err != nil {
+				return nil, err
+			}
+
+			aligned, err := blobWriter.Align()
+			if err != nil {
+				return nil, err
+			}
+			align += int(aligned)
+			writtenInBlob++
+
+			writtenBits += 32*8 - 2
+		}
+
+		if writtenBits > 0 {
+			var blob kzg4844.Blob
+			copy(blob[:], blobBuf.Bytes())
+			blobs = append(blobs, blob)
+		}
+	}
+	if !eof {
+		return nil, fmt.Errorf("provided batch does not fit into %d blobs (%d bytes) [written = %d bits] [align = %d bits]",
+			blobLimit, blobSize*blobLimit, writtenBits, align)
+	}
+	return blobs, nil
+}

--- a/nil/services/synccommittee/core/batches/blob/builder_test.go
+++ b/nil/services/synccommittee/core/batches/blob/builder_test.go
@@ -1,0 +1,73 @@
+package blob
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeBlobs_ValidInput(t *testing.T) {
+	t.Parallel()
+	builder := NewBuilder()
+	input := bytes.Repeat([]byte{0xFF}, blobSize+blobSize/2) // 1.5 blobs of 0xFF bytes
+	rd := bytes.NewReader(input)
+
+	blobs, err := builder.MakeBlobs(rd, 2)
+	require.NoError(t, err)
+	require.Len(t, blobs, 2)
+
+	const u256word = 32
+
+	fullWordWithPadding := bytes.Repeat([]byte{0xFF}, u256word)
+	fullWordWithPadding[len(fullWordWithPadding)-1] = 0xFC
+
+	// check that first blob is fully filled with data
+	for word := range blobSize / u256word {
+		start := word * u256word
+		end := start + u256word
+		require.Equal(t, fullWordWithPadding, blobs[0][start:end], "invalid data or padding word %d", word)
+	}
+
+	bytesUsedInSecondBlob := len(input) + ((len(input) / u256word) / 4)
+	wordsUsedInSecondBlob := (bytesUsedInSecondBlob - blobSize) / u256word
+
+	// check that first 2095 words of the second blob are filled with data
+	for word := range wordsUsedInSecondBlob {
+		start := word * u256word
+		end := start + u256word
+		require.Equal(t, fullWordWithPadding, blobs[1][start:end], "invalid data or padding, word %d", word)
+	}
+
+	// check that first 12 bytes of the last word are
+	lastWordStart := wordsUsedInSecondBlob * u256word
+	lastWordEnd := lastWordStart + 12
+	require.Equal(t, blobs[1][lastWordStart:lastWordEnd], bytes.Repeat([]byte{0xFF}, 12), "invalid end of data")
+
+	// check that the rest of the buffer is empty
+	require.Equal(t, blobs[1][lastWordEnd:], bytes.Repeat([]byte{0x00}, blobSize-lastWordEnd), "end of blob is not zero padded")
+}
+
+func TestMakeBlobs_InputExceedsBlobLimit(t *testing.T) {
+	t.Parallel()
+
+	builder := NewBuilder()
+	input := bytes.Repeat([]byte{0x01}, blobSize*10) // too much data to be placed into 2 blobs
+	rd := bytes.NewReader(input)
+
+	blobs, err := builder.MakeBlobs(rd, 2)
+	require.Error(t, err)
+	require.Nil(t, blobs)
+}
+
+func TestEmptyData(t *testing.T) {
+	t.Parallel()
+
+	builder := NewBuilder()
+	var input []byte
+	rd := bytes.NewReader(input)
+	blobs, err := builder.MakeBlobs(rd, 2)
+	require.NoError(t, err)
+	assert.Empty(t, blobs)
+}

--- a/nil/services/synccommittee/core/batches/commiter.go
+++ b/nil/services/synccommittee/core/batches/commiter.go
@@ -1,0 +1,81 @@
+package batches
+
+import (
+	"bytes"
+	"context"
+	"io"
+
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto/kzg4844"
+	"github.com/rs/zerolog"
+)
+
+type BatchCommitter interface {
+	Commit(ctx context.Context, batch *types.PrunedBatch) error
+}
+
+type batchEncoder interface {
+	Encode(in *types.PrunedBatch, out io.Writer) error
+}
+
+type blobBuilder interface {
+	MakeBlobs(in io.Reader, limit int) ([]kzg4844.Blob, error)
+}
+
+type ethCommitter interface {
+	CommitBatch(ctx context.Context, blobs []kzg4844.Blob, batchIndex string) (*ethtypes.Transaction, error)
+}
+
+type batchCommitter struct {
+	encoder      batchEncoder
+	blobBuilder  blobBuilder
+	ethCommitter ethCommitter
+	logger       zerolog.Logger
+	options      *commitOptions
+}
+
+func NewBatchCommitter(
+	encoder batchEncoder,
+	blobBuilder blobBuilder,
+	ethCommitter ethCommitter,
+	logger zerolog.Logger,
+	options *commitOptions,
+) BatchCommitter {
+	return &batchCommitter{
+		encoder:      encoder,
+		blobBuilder:  blobBuilder,
+		ethCommitter: ethCommitter,
+		logger:       logger,
+		options:      options,
+	}
+}
+
+type commitOptions struct {
+	maxBlobCount int
+}
+
+func DefaultCommitOptions() *commitOptions {
+	return &commitOptions{
+		maxBlobCount: 6,
+	}
+}
+
+func (bc *batchCommitter) Commit(ctx context.Context, batch *types.PrunedBatch) error {
+	var binTransactions bytes.Buffer
+	if err := bc.encoder.Encode(batch, &binTransactions); err != nil {
+		return err
+	}
+	bc.logger.Debug().Int("compressed_batch_len", binTransactions.Len()).Msg("encoded transaction")
+
+	blobs, err := bc.blobBuilder.MakeBlobs(&binTransactions, bc.options.maxBlobCount)
+	if err != nil {
+		return err
+	}
+	bc.logger.Debug().Int("batch_blob_count", len(blobs)).Msg("packed batch blobs")
+
+	// TODO add ethCommiter.CommitBatch() call
+	bc.logger.Info().Int("blob_count", len(blobs)).Msg("committed batch")
+
+	return nil
+}

--- a/nil/services/synccommittee/core/batches/encode/header.go
+++ b/nil/services/synccommittee/core/batches/encode/header.go
@@ -1,0 +1,30 @@
+package encode
+
+import (
+	"encoding/binary"
+	"io"
+)
+
+const BatchMagic uint16 = 0xDEFA
+
+type BatchHeader struct {
+	Magic   uint16
+	Version uint16
+}
+
+func NewBatchHeader(version uint16) BatchHeader {
+	return BatchHeader{
+		Magic:   BatchMagic,
+		Version: version,
+	}
+}
+
+func (bh BatchHeader) EncodeTo(out io.Writer) error {
+	if err := binary.Write(out, binary.LittleEndian, bh.Magic); err != nil {
+		return err
+	}
+	if err := binary.Write(out, binary.LittleEndian, bh.Version); err != nil {
+		return err
+	}
+	return nil
+}

--- a/nil/services/synccommittee/core/batches/encode/v1/encoder.go
+++ b/nil/services/synccommittee/core/batches/encode/v1/encoder.go
@@ -1,0 +1,49 @@
+package v1
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/NilFoundation/nil/nil/services/synccommittee/core/batches/encode"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
+	"github.com/rs/zerolog"
+	"google.golang.org/protobuf/proto"
+)
+
+const version uint16 = 0x0001
+
+type compressor interface {
+	Compress(from io.Reader, to io.Writer) error
+}
+
+type batchEncoder struct {
+	compressor compressor
+	logger     zerolog.Logger
+}
+
+func NewEncoder(logger zerolog.Logger) *batchEncoder {
+	return &batchEncoder{
+		compressor: NewZstdCompressor(logger),
+	}
+}
+
+func (be *batchEncoder) Encode(batch *types.PrunedBatch, out io.Writer) error {
+	header := encode.NewBatchHeader(version)
+	if err := header.EncodeTo(out); err != nil {
+		return err
+	}
+
+	protoBatch := ConvertToProto(batch)
+	be.logger.Info().Uint64("transaction_count", protoBatch.TotalTxCount).Msg("packed transactions to batch")
+
+	serialized, err := proto.Marshal(protoBatch)
+	if err != nil {
+		return err
+	}
+
+	if err := be.compressor.Compress(bytes.NewReader(serialized), out); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/nil/services/synccommittee/core/batches/encode/v1/encoder_test.go
+++ b/nil/services/synccommittee/core/batches/encode/v1/encoder_test.go
@@ -1,0 +1,58 @@
+package v1
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"testing"
+
+	"github.com/NilFoundation/nil/nil/common/logging"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/core/batches/encode"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/testaide"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
+	scProto "github.com/NilFoundation/nil/nil/services/synccommittee/internal/types/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+type noopCompressor struct{}
+
+func (nopc *noopCompressor) Compress(in io.Reader, out io.Writer) error {
+	_, err := io.Copy(out, in)
+	return err
+}
+
+func TestEncoderSimple(t *testing.T) {
+	t.Parallel()
+
+	const blockPerShard = 3
+	batch := testaide.NewBlockBatch(blockPerShard)
+	logger := logging.NewLogger("sc_batch_encoder_test")
+	encoder := NewEncoder(logger)
+	encoder.compressor = &noopCompressor{}
+
+	prunedBatch := types.NewPrunedBatch(batch)
+
+	var out bytes.Buffer
+	err := encoder.Encode(prunedBatch, &out)
+	require.NoError(t, err)
+
+	var temp uint16
+
+	require.NoError(t, binary.Read(&out, binary.LittleEndian, &temp))
+	assert.Equal(t, encode.BatchMagic, temp)
+
+	require.NoError(t, binary.Read(&out, binary.LittleEndian, &temp))
+	assert.Equal(t, version, temp)
+
+	var unwrappedBatch scProto.Batch
+	err = proto.Unmarshal(out.Bytes(), &unwrappedBatch)
+	require.NoError(t, err)
+
+	deserializedBatch, err := ConvertFromProto(&unwrappedBatch)
+	require.NoError(t, err)
+	require.Len(t, deserializedBatch.Blocks, len(batch.ChildBlocks)+1)
+	assert.Equal(t, batch.Id, deserializedBatch.BatchId)
+	assert.ElementsMatch(t, prunedBatch.Blocks, deserializedBatch.Blocks)
+}

--- a/nil/services/synccommittee/core/batches/encode/v1/serialization.go
+++ b/nil/services/synccommittee/core/batches/encode/v1/serialization.go
@@ -1,0 +1,105 @@
+package v1
+
+import (
+	"github.com/NilFoundation/nil/nil/common"
+	"github.com/NilFoundation/nil/nil/common/hexutil"
+	coreTypes "github.com/NilFoundation/nil/nil/internal/types"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types/proto"
+)
+
+func uint256ToProtoUint256(u coreTypes.Uint256) *proto.Uint256 {
+	return &proto.Uint256{
+		WordParts: u[:],
+	}
+}
+
+func protoUint256ToUint256(pb *proto.Uint256) coreTypes.Uint256 {
+	var u coreTypes.Uint256
+	copy(u[:], pb.WordParts)
+	return u
+}
+
+func ConvertToProto(batch *types.PrunedBatch) *proto.Batch {
+	var (
+		lastTs       uint64
+		totalTxCount uint64
+		protoBlocks  = make([]*proto.BlobBlock, 0, len(batch.Blocks))
+	)
+	for _, l2Blk := range batch.Blocks {
+		b := &proto.BlobBlock{
+			ShardId:       uint32(l2Blk.ShardId),
+			BlockNumber:   l2Blk.BlockNumber.Uint64(),
+			Timestamp:     l2Blk.Timestamp,
+			PrevBlockHash: l2Blk.PrevBlockHash.Bytes(),
+		}
+		for _, l2Tx := range l2Blk.Transactions {
+			tx := &proto.BlobTransaction{
+				Flags: uint32(l2Tx.Flags.Bits),
+				SeqNo: l2Tx.Seqno.Uint64(),
+				AddrFrom: &proto.Address{
+					AddressBytes: l2Tx.From.Bytes(),
+				},
+				AddrTo: &proto.Address{
+					AddressBytes: l2Tx.To.Bytes(),
+				},
+				Value: uint256ToProtoUint256(*l2Tx.Value.Uint256),
+				Data:  []byte(l2Tx.Data),
+			}
+
+			if !l2Tx.RefundTo.IsEmpty() && !l2Tx.From.Equal(l2Tx.RefundTo) {
+				tx.AddrRefundTo = &proto.Address{AddressBytes: l2Tx.RefundTo.Bytes()}
+			}
+			if !l2Tx.BounceTo.IsEmpty() && !l2Tx.From.Equal(l2Tx.BounceTo) {
+				tx.AddrBounceTo = &proto.Address{AddressBytes: l2Tx.BounceTo.Bytes()}
+			}
+			b.Transactions = append(b.Transactions, tx)
+		}
+		lastTs = max(lastTs, b.Timestamp)
+		totalTxCount += uint64(len(b.Transactions))
+		protoBlocks = append(protoBlocks, b)
+	}
+
+	return &proto.Batch{
+		BatchId:            batch.BatchId.String(),
+		LastBlockTimestamp: lastTs,
+		Blocks:             protoBlocks,
+	}
+}
+
+func ConvertFromProto(batch *proto.Batch) (*types.PrunedBatch, error) {
+	blocks := make([]*types.PrunedBlock, 0, len(batch.Blocks))
+	for _, pblk := range batch.Blocks {
+		b := &types.PrunedBlock{
+			ShardId:       coreTypes.ShardId(pblk.ShardId),
+			BlockNumber:   coreTypes.BlockNumber(pblk.BlockNumber),
+			Timestamp:     pblk.Timestamp,
+			PrevBlockHash: common.BytesToHash(pblk.PrevBlockHash),
+		}
+		for _, ptx := range pblk.Transactions {
+			tx := &types.PrunedTransaction{
+				Flags: coreTypes.NewTransactionFlagsFromBits(uint8(ptx.GetFlags())),
+				Seqno: hexutil.Uint64(ptx.GetSeqNo()),
+				From:  coreTypes.BytesToAddress(ptx.AddrFrom.AddressBytes),
+				To:    coreTypes.BytesToAddress(ptx.AddrTo.AddressBytes),
+				Data:  ptx.GetData(),
+			}
+			pValue := protoUint256ToUint256(ptx.Value)
+			tx.Value = coreTypes.Value{Uint256: &pValue}
+			if ptx.AddrRefundTo != nil {
+				tx.RefundTo = coreTypes.BytesToAddress(ptx.AddrFrom.AddressBytes)
+			}
+			if ptx.AddrBounceTo != nil {
+				tx.BounceTo = coreTypes.BytesToAddress(ptx.AddrFrom.AddressBytes)
+			}
+			b.Transactions = append(b.Transactions, tx)
+		}
+		blocks = append(blocks, b)
+	}
+
+	var id types.BatchId
+	if err := id.UnmarshalText([]byte(batch.BatchId)); err != nil {
+		return nil, err
+	}
+	return &types.PrunedBatch{BatchId: id, Blocks: blocks}, nil
+}

--- a/nil/services/synccommittee/core/batches/encode/v1/zstd.go
+++ b/nil/services/synccommittee/core/batches/encode/v1/zstd.go
@@ -1,0 +1,55 @@
+package v1
+
+import (
+	"io"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/rs/zerolog"
+)
+
+// some aux interfaces for operating on memory buffers
+type LenAware interface {
+	Len() int
+}
+
+type Growable interface {
+	Grow(int)
+}
+
+type zstdCompressor struct {
+	logger zerolog.Logger
+}
+
+func NewZstdCompressor(logger zerolog.Logger) *zstdCompressor {
+	return &zstdCompressor{
+		logger: logger,
+	}
+}
+
+func (zc *zstdCompressor) Compress(from io.Reader, to io.Writer) (err error) {
+	impl, err := zstd.NewWriter(to, zstd.WithEncoderLevel(zstd.SpeedBetterCompression))
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		closeErr := impl.Close()
+		if err == nil {
+			err = closeErr
+		}
+	}()
+
+	var maxEstimatedSize int
+	if lenAware, ok := from.(LenAware); ok {
+		maxEstimatedSize = lenAware.Len()
+		zc.logger.Trace().Int("estimated_size", maxEstimatedSize).Send()
+	}
+
+	// adjust the sizes if we are operating with memory buffers
+	if growable, ok := to.(Growable); maxEstimatedSize > 0 && ok {
+		growable.Grow(maxEstimatedSize)
+	}
+
+	_, err = impl.ReadFrom(from)
+	return
+}

--- a/nil/services/synccommittee/internal/types/block_batch.go
+++ b/nil/services/synccommittee/internal/types/block_batch.go
@@ -118,3 +118,19 @@ func (b *BlockBatch) CreateProofTasks(currentTime time.Time) ([]*TaskEntry, erro
 
 	return taskEntries, nil
 }
+
+type PrunedBatch struct {
+	BatchId BatchId
+	Blocks  []*PrunedBlock
+}
+
+func NewPrunedBatch(batch *BlockBatch) *PrunedBatch {
+	out := &PrunedBatch{
+		BatchId: batch.Id,
+	}
+	for _, blk := range batch.ChildBlocks {
+		out.Blocks = append(out.Blocks, NewPrunedBlock(blk))
+	}
+	out.Blocks = append(out.Blocks, NewPrunedBlock(batch.MainShardBlock))
+	return out
+}

--- a/nil/services/synccommittee/internal/types/blocks.go
+++ b/nil/services/synccommittee/internal/types/blocks.go
@@ -141,13 +141,33 @@ func (bk BlockId) String() string {
 	return hex.EncodeToString(bk.Bytes())
 }
 
+type PrunedBlock struct {
+	ShardId       types.ShardId
+	BlockNumber   types.BlockNumber
+	Timestamp     uint64
+	PrevBlockHash common.Hash
+	Transactions  []*PrunedTransaction
+}
+
+func NewPrunedBlock(block *jsonrpc.RPCBlock) *PrunedBlock {
+	return &PrunedBlock{
+		ShardId:       block.ShardId,
+		BlockNumber:   block.Number,
+		Timestamp:     block.DbTimestamp,
+		PrevBlockHash: block.ParentHash,
+		Transactions:  BlockTransactions(block),
+	}
+}
+
 type PrunedTransaction struct {
-	Flags types.TransactionFlags
-	Seqno hexutil.Uint64
-	From  types.Address
-	To    types.Address
-	Value types.Value
-	Data  hexutil.Bytes
+	Flags    types.TransactionFlags
+	Seqno    hexutil.Uint64
+	From     types.Address
+	To       types.Address
+	BounceTo types.Address
+	RefundTo types.Address
+	Value    types.Value
+	Data     hexutil.Bytes
 }
 
 func BlockTransactions(block *jsonrpc.RPCBlock) []*PrunedTransaction {
@@ -160,12 +180,14 @@ func BlockTransactions(block *jsonrpc.RPCBlock) []*PrunedTransaction {
 
 func NewTransaction(transaction *jsonrpc.RPCInTransaction) *PrunedTransaction {
 	return &PrunedTransaction{
-		Flags: transaction.Flags,
-		Seqno: transaction.Seqno,
-		From:  transaction.From,
-		To:    transaction.To,
-		Value: transaction.Value,
-		Data:  transaction.Data,
+		Flags:    transaction.Flags,
+		Seqno:    transaction.Seqno,
+		From:     transaction.From,
+		To:       transaction.To,
+		BounceTo: transaction.BounceTo,
+		RefundTo: transaction.RefundTo,
+		Value:    transaction.Value,
+		Data:     transaction.Data,
 	}
 }
 

--- a/nil/services/synccommittee/internal/types/proto/blob_transaction.proto
+++ b/nil/services/synccommittee/internal/types/proto/blob_transaction.proto
@@ -1,0 +1,41 @@
+syntax = "proto3";
+
+package sync_committee_types;
+option go_package = "/proto";
+
+// Uint256 represents a 256-bit unsigned integer as a sequence of uint64 parts
+message Uint256 {
+    repeated uint64 word_parts = 1;  // 4 uint64 parts composing the 256-bit number
+}
+
+// Address represents an Ethereum address
+message Address {
+    bytes address_bytes = 1;  // 20-byte address
+}
+
+// Nil transaction binary representation which is going to be stored on the L1 in blob format
+message BlobTransaction {
+    uint32 flags = 1;
+    uint64 seq_no = 2;
+    Address addr_from = 3;
+    Address addr_to = 4;
+    optional Address addr_bounce_to = 5;
+    optional Address addr_refund_to = 6;
+    Uint256 value = 7;
+    bytes Data = 8;
+}
+
+message BlobBlock {
+    uint32 shard_id = 1;
+    uint64 block_number = 2;
+    bytes prev_block_hash = 3;
+    uint64 timestamp = 4;
+    repeated BlobTransaction transactions = 5;
+}
+
+message Batch {
+    string batch_id = 1;
+    uint64 last_block_timestamp = 2;
+    uint64 total_tx_count = 3;
+    repeated BlobBlock blocks = 4;
+}

--- a/nix/nil.nix
+++ b/nix/nil.nix
@@ -49,7 +49,7 @@ buildGo123Module rec {
   ];
 
   # to obtain run `nix build` with vendorHash = "";
-  vendorHash = "sha256-iCLippQ5yNsFzgQ6QdmyCvMZ52rftKPlWXrlwuQPYbU=";
+  vendorHash = "sha256-uTlUBRF9BZ9Lql2A875o3GqqVH4Scwwist8PopuhI2s=";
   hardeningDisable = [ "all" ];
 
   postInstall = ''


### PR DESCRIPTION
Transition of https://github.com/NilFoundation/nil-old/pull/1564

Added initial support for committing transaction batch to L1

Logic is:

- pick batch from aggregator
- serialize it to protobuf
- compress with zstd
- pack to blobs (according to spec each u256 element is 254 bits of payload and 2 bits of padding)
- commit with blob tx to L1 (TBD, waiting for L1 contract update)

Batch encoder is isolated into separate interface in order to be able to do batch serialization/encoding verisioning