### PR TITLE
Remove the push trigger to avoid testing merge commits.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,6 @@
 name: Cluster CI
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
   workflow_dispatch:
   merge_group:


### PR DESCRIPTION
The only pushes to main are merge commits by the merge queue bot, so we don't need to test them again.