### PR TITLE
Make transaction invariant during execution

### DIFF
--- a/nil/internal/collate/collator.go
+++ b/nil/internal/collate/collator.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 
 	"github.com/NilFoundation/nil/nil/common"
+	"github.com/NilFoundation/nil/nil/common/assert"
+	"github.com/NilFoundation/nil/nil/common/check"
 	"github.com/NilFoundation/nil/nil/common/logging"
 	"github.com/NilFoundation/nil/nil/internal/config"
 	"github.com/NilFoundation/nil/nil/internal/db"
@@ -150,8 +152,12 @@ func (c *collator) fetchLastBlockHashes() error {
 }
 
 func (c *collator) handleTransaction(txn *types.Transaction, payer execution.Payer) error {
-	// The transaction may be modified during execution, so we need to copy it.
-	txn = common.CopyPtr(txn)
+	if assert.Enable {
+		txnHash := txn.Hash()
+		defer func() {
+			check.PanicIfNotf(txnHash == txn.Hash(), "Transaction hash changed during execution")
+		}()
+	}
 
 	c.executionState.AddInTransaction(txn)
 

--- a/nil/internal/collate/scheduler.go
+++ b/nil/internal/collate/scheduler.go
@@ -165,7 +165,6 @@ func (s *Scheduler) VerifyProposal(ctx context.Context, proposal *execution.Prop
 	}
 	defer gen.Rollback()
 
-	// NB: the proposal may be modified
 	res, err := gen.BuildBlock(proposal, s.logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate block: %w", err)
@@ -180,7 +179,6 @@ func (s *Scheduler) InsertProposal(ctx context.Context, proposal *execution.Prop
 	}
 	defer gen.Rollback()
 
-	// NB: the proposal may be modified
 	res, err := gen.GenerateBlock(proposal, s.logger, sig)
 	if err != nil {
 		return fmt.Errorf("failed to generate block: %w", err)

--- a/nil/internal/execution/block_generator.go
+++ b/nil/internal/execution/block_generator.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/NilFoundation/nil/nil/common"
+	"github.com/NilFoundation/nil/nil/common/assert"
 	"github.com/NilFoundation/nil/nil/common/check"
 	"github.com/NilFoundation/nil/nil/common/logging"
 	"github.com/NilFoundation/nil/nil/internal/config"
@@ -225,6 +226,12 @@ func (g *BlockGenerator) prepareExecutionState(proposal *Proposal, counters *Blo
 		if txn.IsExecution() {
 			counters.ExecTransactions++
 		}
+
+		var txnHash common.Hash
+		if assert.Enable {
+			txnHash = txn.Hash()
+		}
+
 		g.executionState.AddInTransaction(txn)
 		if txn.IsInternal() {
 			res = g.handleInternalInTransaction(txn)
@@ -233,6 +240,11 @@ func (g *BlockGenerator) prepareExecutionState(proposal *Proposal, counters *Blo
 			res = g.handleExternalTransaction(txn)
 			counters.ExternalTransactions++
 		}
+
+		if assert.Enable {
+			check.PanicIfNotf(txnHash == txn.Hash(), "Transaction hash changed during execution")
+		}
+
 		if res.FatalError != nil {
 			return res.FatalError
 		}

--- a/nil/internal/execution/zerostate_test.go
+++ b/nil/internal/execution/zerostate_test.go
@@ -81,7 +81,7 @@ func (suite *SuiteZeroState) TestWithdrawFromFaucet() {
 		},
 		From: suite.faucetAddr,
 	}
-	res := suite.state.handleExecutionTransaction(suite.ctx, callTransaction)
+	res := suite.state.HandleTransaction(suite.ctx, callTransaction, dummyPayer{})
 	suite.Require().False(res.Failed())
 
 	outTxnHash, ok := reflect.ValueOf(suite.state.OutTransactions).MapKeys()[0].Interface().(common.Hash)
@@ -89,7 +89,7 @@ func (suite *SuiteZeroState) TestWithdrawFromFaucet() {
 	outTxn := suite.state.OutTransactions[outTxnHash][0]
 	suite.Require().NotNil(outTxn)
 
-	res = suite.state.handleExecutionTransaction(suite.ctx, outTxn.Transaction)
+	res = suite.state.HandleTransaction(suite.ctx, outTxn.Transaction, dummyPayer{})
 	suite.Require().False(res.Failed())
 
 	faucetBalance = faucetBalance.Sub64(100)


### PR DESCRIPTION
Previously, it could be changed due to response transactions. Now, this issue has been fixed, and an assertion has been added to enforce the transaction invariant.