### PR TITLE
Sync Committee: Task-related Refactoring

### DIFF
--- a/nil/services/synccommittee/Makefile.inc
+++ b/nil/services/synccommittee/Makefile.inc
@@ -10,19 +10,27 @@ generate_synccommittee_mocks: \
     $(root_sce)/internal/test_utils/op_context_generated_mock.go \
     $(root_sce)/prover/tracer/storage_getter_setter_generated_mock.go
 
-$(root_sce)/internal/api/task_handler_generated_mock.go: $(root_sce)/internal/api/task_handler.go $(root_sce)/internal/types/prover_tasks.go
+$(root_sce)/internal/api/task_handler_generated_mock.go: \
+	$(root_sce)/internal/api/task_handler.go \
+	$(root_sce)/internal/types/prover_tasks.go
 	go generate $(root_sce)/internal/api/task_handler.go
 
-$(root_sce)/internal/api/task_request_handler_generated_mock.go: $(root_sce)/internal/api/task_request_handler.go $(root_sce)/internal/types/prover_tasks.go
+$(root_sce)/internal/api/task_request_handler_generated_mock.go: \
+	$(root_sce)/internal/api/task_request_handler.go \
+	$(root_sce)/internal/types/task_result.go \
+	$(root_sce)/internal/types/prover_tasks.go
 	go generate $(root_sce)/internal/api/task_request_handler.go
 
-$(root_sce)/internal/api/task_state_change_handler_generated_mock.go: $(root_sce)/internal/api/task_state_change_handler.go $(root_sce)/internal/types/prover_tasks.go
+$(root_sce)/internal/api/task_state_change_handler_generated_mock.go: \
+	$(root_sce)/internal/api/task_state_change_handler.go \
+	$(root_sce)/internal/types/prover_tasks.go
 	go generate $(root_sce)/internal/api/task_state_change_handler.go
 
 $(root_sce)/internal/scheduler/task_scheduler_generated_mock.go: \
 	$(root_sce)/internal/scheduler/task_scheduler.go \
 	$(root_sce)/internal/api/task_request_handler.go \
 	$(root_sce)/internal/types/prover_tasks.go \
+	$(root_sce)/internal/types/task_result.go \
 	$(root_sce)/public/task_debug_api.go \
 	$(root_sce)/public/task_view.go
 	go generate $(root_sce)/internal/scheduler
@@ -50,11 +58,11 @@ synccommittee_types: \
 	$(root_sce)/internal/types/circuittype_string.go \
 	$(root_sce)/public/taskdebugorder_string.go
 
-$(root_sce)/internal/types/tasktype_string.go: $(root_sce)/internal/types/prover_tasks.go
+$(root_sce)/internal/types/tasktype_string.go: $(root_sce)/internal/types/task_type.go
 	go generate -run="TaskType" $(root_sce)/internal/types/generate.go
-$(root_sce)/internal/types/proverresulttype_string.go: $(root_sce)/internal/types/prover_tasks.go
+$(root_sce)/internal/types/proverresulttype_string.go: $(root_sce)/internal/types/task_result.go
 	go generate -run="ProverResultType" $(root_sce)/internal/types/generate.go
-$(root_sce)/internal/types/taskstatus_string.go: $(root_sce)/internal/types/prover_tasks.go
+$(root_sce)/internal/types/taskstatus_string.go: $(root_sce)/internal/types/task_status.go
 	go generate -run="TaskStatus" $(root_sce)/internal/types/generate.go
 $(root_sce)/internal/types/circuittype_string.go: $(root_sce)/internal/types/prover_tasks.go
 	go generate -run="CircuitType" $(root_sce)/internal/types/generate.go

--- a/nil/services/synccommittee/core/aggregator.go
+++ b/nil/services/synccommittee/core/aggregator.go
@@ -206,7 +206,7 @@ func (agg *Aggregator) createProofTasks(ctx context.Context, batch *types.BlockB
 		return fmt.Errorf("error creating proof tasks, mainHash=%s: %w", batch.MainShardBlock.Hash, err)
 	}
 
-	if err := agg.taskStorage.AddTaskEntries(ctx, proofTasks); err != nil {
+	if err := agg.taskStorage.AddTaskEntries(ctx, proofTasks...); err != nil {
 		return fmt.Errorf("error adding task entries, mainHash=%s: %w", batch.MainShardBlock.Hash, err)
 	}
 

--- a/nil/services/synccommittee/core/block_tasks_integration_test.go
+++ b/nil/services/synccommittee/core/block_tasks_integration_test.go
@@ -79,7 +79,7 @@ func (s *BlockTasksIntegrationTestSuite) Test_Provide_Tasks_And_Handle_Success_R
 	proofTasks, err := batch.CreateProofTasks(s.timer.NowTime())
 	s.Require().NoError(err)
 
-	err = s.taskStorage.AddTaskEntries(s.ctx, proofTasks)
+	err = s.taskStorage.AddTaskEntries(s.ctx, proofTasks...)
 	s.Require().NoError(err)
 
 	executorId := testaide.RandomExecutorId()
@@ -131,7 +131,7 @@ func (s *BlockTasksIntegrationTestSuite) Test_Provide_Tasks_And_Handle_Failure_R
 	proofTasks, err := batch.CreateProofTasks(s.timer.NowTime())
 	s.Require().NoError(err)
 
-	err = s.taskStorage.AddTaskEntries(s.ctx, proofTasks)
+	err = s.taskStorage.AddTaskEntries(s.ctx, proofTasks...)
 	s.Require().NoError(err)
 
 	executorId := testaide.RandomExecutorId()

--- a/nil/services/synccommittee/internal/rpc/task_debug_rpc_test.go
+++ b/nil/services/synccommittee/internal/rpc/task_debug_rpc_test.go
@@ -135,7 +135,7 @@ type getTaskTestCase struct {
 
 func (s *TaskSchedulerDebugRpcTestSuite) Test_Get_Tasks() {
 	entries := newTaskEntries(s.timer.NowTime())
-	err := s.storage.AddTaskEntries(s.context, entries)
+	err := s.storage.AddTaskEntries(s.context, entries...)
 	s.Require().NoError(err)
 
 	testCases := []getTaskTestCase{
@@ -234,7 +234,7 @@ func (s *TaskSchedulerDebugRpcTestSuite) Test_Get_Task_Tree_Empty_Storage() {
 
 func (s *TaskSchedulerDebugRpcTestSuite) Test_Get_Task_Tree_Not_Found() {
 	entries := newTaskEntries(s.timer.NowTime())
-	err := s.storage.AddTaskEntries(s.context, entries)
+	err := s.storage.AddTaskEntries(s.context, entries...)
 	s.Require().NoError(err)
 
 	someRootId := types.NewTaskId()
@@ -246,7 +246,7 @@ func (s *TaskSchedulerDebugRpcTestSuite) Test_Get_Task_Tree_Not_Found() {
 func (s *TaskSchedulerDebugRpcTestSuite) Test_Get_Task_Tree_No_Dependencies() {
 	now := s.timer.NowTime()
 	entry := testaide.NewTaskEntry(now, running, testaide.RandomExecutorId())
-	err := s.storage.AddSingleTaskEntry(s.context, *entry)
+	err := s.storage.AddTaskEntries(s.context, entry)
 	s.Require().NoError(err)
 
 	taskTree, err := s.rpcClient.GetTaskTree(s.context, entry.Task.Id)
@@ -282,7 +282,7 @@ func (s *TaskSchedulerDebugRpcTestSuite) Test_Get_Task_Tree_With_Dependencies() 
 	taskE := testaide.NewTaskEntry(now, types.Running, testaide.RandomExecutorId())
 	taskC.AddDependency(taskE)
 
-	err := s.storage.AddTaskEntries(s.context, []*types.TaskEntry{taskA, taskB, taskC, taskD, taskE})
+	err := s.storage.AddTaskEntries(s.context, taskA, taskB, taskC, taskD, taskE)
 	s.Require().NoError(err)
 
 	taskATree, err := s.rpcClient.GetTaskTree(s.context, taskA.Task.Id)
@@ -326,7 +326,7 @@ func (s *TaskSchedulerDebugRpcTestSuite) Test_Get_Task_Tree_With_Terminated_Depe
 	taskC := testaide.NewTaskEntry(now.Add(-1*time.Minute), types.WaitingForExecutor, types.UnknownExecutorId)
 	taskA.AddDependency(taskC)
 
-	err := s.storage.AddTaskEntries(s.context, []*types.TaskEntry{taskA, taskB, taskC})
+	err := s.storage.AddTaskEntries(s.context, taskA, taskB, taskC)
 	s.Require().NoError(err)
 
 	executor := testaide.RandomExecutorId()

--- a/nil/services/synccommittee/internal/storage/block_storage_test.go
+++ b/nil/services/synccommittee/internal/storage/block_storage_test.go
@@ -120,6 +120,21 @@ func (s *BlockStorageTestSuite) TestSetBlockAsProved() {
 	s.Require().NoError(err)
 }
 
+func (s *BlockStorageTestSuite) Test_SetBlockAsProved_Multiple_Times() {
+	batch := testaide.NewBlockBatch(3)
+	mainBlockId := scTypes.IdFromBlock(batch.MainShardBlock)
+	err := s.bs.SetBlockBatch(s.ctx, batch)
+	s.Require().NoError(err)
+
+	for range 3 {
+		err := s.bs.SetBlockAsProved(s.ctx, mainBlockId)
+		s.Require().NoError(err)
+	}
+
+	err = s.bs.SetBlockAsProposed(s.ctx, mainBlockId)
+	s.Require().NoError(err)
+}
+
 func (s *BlockStorageTestSuite) TestSetBlockAsProposed_DoesNotExist() {
 	randomId := testaide.RandomBlockId()
 	err := s.bs.SetBlockAsProposed(s.ctx, randomId)

--- a/nil/services/synccommittee/internal/storage/errors.go
+++ b/nil/services/synccommittee/internal/storage/errors.go
@@ -2,4 +2,8 @@ package storage
 
 import "errors"
 
-var ErrSerializationFailed = errors.New("failed to serialize/deserialize object")
+var (
+	ErrTaskAlreadyExists   = errors.New("task with a given identifier already exists")
+	ErrSerializationFailed = errors.New("failed to serialize/deserialize object")
+	errNilTaskEntry        = errors.New("task entry cannot be nil")
+)

--- a/nil/services/synccommittee/internal/testaide/prover_tasks.go
+++ b/nil/services/synccommittee/internal/testaide/prover_tasks.go
@@ -14,6 +14,15 @@ import (
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
 )
 
+func NewPendingTaskEntries(modifiedAt time.Time, count int) []*types.TaskEntry {
+	tasks := make([]*types.TaskEntry, 0, count)
+	for range count {
+		task := NewTaskEntry(modifiedAt, types.WaitingForExecutor, types.UnknownExecutorId)
+		tasks = append(tasks, task)
+	}
+	return tasks
+}
+
 func NewTaskEntry(modifiedAt time.Time, status types.TaskStatus, owner types.TaskExecutorId) *types.TaskEntry {
 	return NewTaskEntryOfType(types.PartialProve, modifiedAt, status, owner)
 }

--- a/nil/services/synccommittee/internal/types/task_result.go
+++ b/nil/services/synccommittee/internal/types/task_result.go
@@ -1,0 +1,115 @@
+package types
+
+import (
+	"fmt"
+	"time"
+)
+
+type ProverResultType uint8
+
+const (
+	_ ProverResultType = iota
+	PartialProof
+	CommitmentState
+	PartialProofChallenges
+	AssignmentTableDescription
+	ThetaPower
+	AggregatedThetaPowers
+	PreprocessedCommonData
+	AggregatedChallenges
+	CombinedQPolynomial
+	AggregatedFRIProof
+	ProofOfWork
+	ConsistencyCheckChallenges
+	LPCConsistencyCheckProof
+	FinalProof
+	BlockProof
+	AggregatedProof
+)
+
+type TaskOutputArtifacts map[ProverResultType]string
+
+type TaskResultData []byte
+
+// TaskResult represents the result of a task provided via RPC by the executor with id = TaskResult.Sender.
+type TaskResult struct {
+	TaskId          TaskId              `json:"taskId"`
+	IsSuccess       bool                `json:"isSuccess"`
+	ErrorText       string              `json:"errorText,omitempty"`
+	Sender          TaskExecutorId      `json:"sender"`
+	OutputArtifacts TaskOutputArtifacts `json:"dataAddresses,omitempty"`
+	Data            TaskResultData      `json:"binaryData,omitempty"`
+}
+
+func NewSuccessProviderTaskResult(
+	taskId TaskId,
+	proofProviderId TaskExecutorId,
+	outputArtifacts TaskOutputArtifacts,
+	binaryData TaskResultData,
+) *TaskResult {
+	return &TaskResult{
+		TaskId:          taskId,
+		IsSuccess:       true,
+		Sender:          proofProviderId,
+		OutputArtifacts: outputArtifacts,
+		Data:            binaryData,
+	}
+}
+
+func NewFailureProviderTaskResult(
+	taskId TaskId,
+	proofProviderId TaskExecutorId,
+	err error,
+) *TaskResult {
+	return &TaskResult{
+		TaskId:    taskId,
+		IsSuccess: false,
+		Sender:    proofProviderId,
+		ErrorText: fmt.Sprintf("failed to proof block: %v", err),
+	}
+}
+
+func NewSuccessProverTaskResult(
+	taskId TaskId,
+	sender TaskExecutorId,
+	outputArtifacts TaskOutputArtifacts,
+	binaryData TaskResultData,
+) *TaskResult {
+	return &TaskResult{
+		TaskId:          taskId,
+		IsSuccess:       true,
+		Sender:          sender,
+		OutputArtifacts: outputArtifacts,
+		Data:            binaryData,
+	}
+}
+
+func NewFailureProverTaskResult(
+	taskId TaskId,
+	sender TaskExecutorId,
+	err error,
+) *TaskResult {
+	return &TaskResult{
+		TaskId:    taskId,
+		Sender:    sender,
+		IsSuccess: false,
+		ErrorText: fmt.Sprintf("failed to generate proof: %v", err),
+	}
+}
+
+// TaskResultDetails represents the result of a task, extending TaskResult with additional task-specific metadata.
+type TaskResultDetails struct {
+	TaskResult
+	TaskType      TaskType      `json:"type"`
+	CircuitType   CircuitType   `json:"circuitType"`
+	ExecutionTime time.Duration `json:"executionTime"`
+}
+
+func NewTaskResultDetails(result *TaskResult, taskEntry *TaskEntry, currentTime time.Time) *TaskResultDetails {
+	return &TaskResultDetails{
+		TaskResult:    *result,
+		TaskType:      taskEntry.Task.TaskType,
+		CircuitType:   taskEntry.Task.CircuitType,
+		ExecutionTime: *taskEntry.ExecutionTime(currentTime),
+	}
+}

--- a/nil/services/synccommittee/internal/types/task_status.go
+++ b/nil/services/synccommittee/internal/types/task_status.go
@@ -1,0 +1,41 @@
+package types
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+)
+
+type TaskStatus uint8
+
+const (
+	TaskStatusNone TaskStatus = iota
+	WaitingForInput
+	WaitingForExecutor
+	Running
+	Failed
+	Completed
+)
+
+var TaskStatuses = map[string]TaskStatus{
+	"WaitingForInput":    WaitingForInput,
+	"WaitingForExecutor": WaitingForExecutor,
+	"Running":            Running,
+	"Failed":             Failed,
+}
+
+func (t *TaskStatus) Set(str string) error {
+	if v, ok := TaskStatuses[str]; ok {
+		*t = v
+		return nil
+	}
+	return fmt.Errorf("unknown task status: %s", str)
+}
+
+func (*TaskStatus) Type() string {
+	return "TaskStatus"
+}
+
+func (*TaskStatus) PossibleValues() []string {
+	return slices.Collect(maps.Keys(TaskStatuses))
+}

--- a/nil/services/synccommittee/internal/types/task_type.go
+++ b/nil/services/synccommittee/internal/types/task_type.go
@@ -1,0 +1,49 @@
+package types
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+)
+
+// TaskType Tasks have different types, it affects task input and priority
+type TaskType uint8
+
+const (
+	TaskTypeNone TaskType = iota
+	AggregateProofs
+	ProofBlock
+	PartialProve
+	AggregatedChallenge
+	CombinedQ
+	AggregatedFRI
+	FRIConsistencyChecks
+	MergeProof
+)
+
+var TaskTypes = map[string]TaskType{
+	"AggregateProofs":      AggregateProofs,
+	"ProofBlock":           ProofBlock,
+	"PartialProve":         PartialProve,
+	"AggregatedChallenge":  AggregatedChallenge,
+	"CombinedQ":            CombinedQ,
+	"AggregatedFRI":        AggregatedFRI,
+	"FRIConsistencyChecks": FRIConsistencyChecks,
+	"MergeProof":           MergeProof,
+}
+
+func (t *TaskType) Set(str string) error {
+	if v, ok := TaskTypes[str]; ok {
+		*t = v
+		return nil
+	}
+	return fmt.Errorf("unknown task type: %s", str)
+}
+
+func (*TaskType) Type() string {
+	return "TaskType"
+}
+
+func (*TaskType) PossibleValues() []string {
+	return slices.Collect(maps.Keys(TaskTypes))
+}

--- a/nil/services/synccommittee/proofprovider/task_handler.go
+++ b/nil/services/synccommittee/proofprovider/task_handler.go
@@ -42,11 +42,11 @@ func (h *taskHandler) Handle(ctx context.Context, _ types.TaskExecutorId, task *
 			taskEntry.Task.ParentTaskId = &task.Id
 		}
 
-		err = h.taskStorage.AddTaskEntries(ctx, blockTasks)
+		err = h.taskStorage.AddTaskEntries(ctx, blockTasks...)
 	} else {
 		currentTime := h.timer.NowTime()
 		aggregateTaskEntry := task.AsNewChildEntry(currentTime)
-		err = h.taskStorage.AddSingleTaskEntry(ctx, *aggregateTaskEntry)
+		err = h.taskStorage.AddTaskEntries(ctx, aggregateTaskEntry)
 	}
 
 	if err != nil {


### PR DESCRIPTION
### Sync Committee: Task-related Refactoring

* `TaskStorage`: Replaced two `AddSingle(...)` and `AddTaskEntries(..)` methods with single variadic one;
* `AddTaskEntries(...)` methods now return `ErrTaskAlreadyExists` is case if task with a given id already exists;
* `BlockStorage.SetBlockAsProved`: checking if block is already marked as proved;
* Extracted `TaskResult`, `TaskStatus` and `TaskType` into separate files;