### PR TITLE
fix load gen race condition on requesting accounts before initialization

### DIFF
--- a/nil/services/nil_load_generator/jsonrpc.go
+++ b/nil/services/nil_load_generator/jsonrpc.go
@@ -18,10 +18,14 @@ func NewNilLoadGeneratorAPI() *NilLoadGeneratorAPIImpl {
 }
 
 func (c NilLoadGeneratorAPIImpl) HealthCheck() bool {
-	return true
+	return isInitialized.Load()
 }
 
 func (c NilLoadGeneratorAPIImpl) SmartAccountsAddr() []types.Address {
+	if !isInitialized.Load() {
+		return nil
+	}
+
 	smartAccountsAddr := make([]types.Address, len(smartAccounts))
 	for i, smartAccount := range smartAccounts {
 		smartAccountsAddr[i] = smartAccount.Addr

--- a/nil/services/nil_load_generator/service.go
+++ b/nil/services/nil_load_generator/service.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 	"os/signal"
 	"strconv"
+	"sync/atomic"
 	"syscall"
 
 	rpc_client "github.com/NilFoundation/nil/nil/client/rpc"
@@ -40,7 +41,10 @@ const (
 	swapAmount       = 1000
 )
 
-var smartAccounts []uniswap.SmartAccount
+var (
+	smartAccounts []uniswap.SmartAccount
+	isInitialized atomic.Bool
+)
 
 func calculateOutputAmount(amountIn, reserveIn, reserveOut *big.Int) *big.Int {
 	feeMultiplier := big.NewInt(997)
@@ -173,6 +177,8 @@ func Run(ctx context.Context, cfg Config, logger zerolog.Logger) error {
 		logger.Error().Err(err).Msg("Failed to compile contracts")
 		return err
 	}
+
+	isInitialized.Store(true)
 
 	tokens := make([]*uniswap.Token, len(shardIdList)*2)
 	factories := make([]*uniswap.Factory, len(shardIdList))


### PR DESCRIPTION
This patch fixes following issue:
```
nil> ==================
nil> WARNING: DATA RACE
nil> Read at 0x0000045ce420 by goroutine 4916:
nil>   github.com/NilFoundation/nil/nil/services/nil_load_generator.NilLoadGeneratorAPIImpl.SmartAccountsAddr()
nil>       /build/source/nil/services/nil_load_generator/jsonrpc.go:25 +0x47
nil>   github.com/NilFoundation/nil/nil/services/nil_load_generator.(*NilLoadGeneratorAPIImpl).SmartAccountsAddr()
nil>       <autogenerated>:1 +0x1f
nil>   runtime.call16()
nil>       /nix/store/jfv85qbj4vb1dafcg6kncg4vrbq2bbxv-go-1.23.4/share/go/src/runtime/asm_amd64.s:775 +0x42
nil>   reflect.Value.Call()
nil>       /nix/store/jfv85qbj4vb1dafcg6kncg4vrbq2bbxv-go-1.23.4/share/go/src/reflect/value.go:365 +0xb5
nil>   github.com/NilFoundation/nil/nil/services/rpc/transport.(*callback).call()
nil>       /build/source/nil/services/rpc/transport/service.go:194 +0x6b1
nil>   github.com/NilFoundation/nil/nil/services/rpc/transport.(*handler).runMethod()
nil>       /build/source/nil/services/rpc/transport/handler.go:263 +0x3ab
nil>   github.com/NilFoundation/nil/nil/services/rpc/transport.(*handler).handleCall()
nil>       /build/source/nil/services/rpc/transport/handler.go:257 +0x2ad
nil>   github.com/NilFoundation/nil/nil/services/rpc/transport.(*handler).handleCallMsg()
nil>       /build/source/nil/services/rpc/transport/handler.go:220 +0x704
nil>   github.com/NilFoundation/nil/nil/services/rpc/transport.(*handler).handleMsg()
nil>       /build/source/nil/services/rpc/transport/handler.go:196 +0x230
nil>   github.com/NilFoundation/nil/nil/services/rpc/transport.(*Server).ServeSingleRequest()
nil>       /build/source/nil/services/rpc/transport/server.go:127 +0x2ea
nil>   github.com/NilFoundation/nil/nil/services/rpc/internal/http.(*Server).ServeHTTP()
nil>       /build/source/nil/services/rpc/internal/http/server.go:66 +0x567
nil>   golang.org/x/net/http2/h2c.h2cHandler.ServeHTTP()
nil>       /build/source/vendor/golang.org/x/net/http2/h2c/h2c.go:125 +0xdfb
nil>   golang.org/x/net/http2/h2c.(*h2cHandler).ServeHTTP()
nil>       <autogenerated>:1 +0x74
nil>   net/http.serverHandler.ServeHTTP()
nil>       /nix/store/jfv85qbj4vb1dafcg6kncg4vrbq2bbxv-go-1.23.4/share/go/src/net/http/server.go:3210 +0x2a1
nil>   net/http.(*conn).serve()
nil>       /nix/store/jfv85qbj4vb1dafcg6kncg4vrbq2bbxv-go-1.23.4/share/go/src/net/http/server.go:2092 +0x12a4
nil>   net/http.(*Server).Serve.gowrap3()
nil>       /nix/store/jfv85qbj4vb1dafcg6kncg4vrbq2bbxv-go-1.23.4/share/go/src/net/http/server.go:3360 +0x4f
nil> Previous write at 0x0000045ce420 by goroutine 4066:
nil>   github.com/NilFoundation/nil/nil/services/nil_load_generator.Run()
nil>       /build/source/nil/services/nil_load_generator/service.go:163 +0x866
nil>   github.com/NilFoundation/nil/nil/tests/nil_load_generator_service.(*NilLoadGeneratorRpc).SetupTest.func1()
nil>       /build/source/nil/tests/nil_load_generator_service/nil_load_generator_test.go:42 +0x25e
nil> Goroutine 4916 (running) created at:
nil>   net/http.(*Server).Serve()
nil>       /nix/store/jfv85qbj4vb1dafcg6kncg4vrbq2bbxv-go-1.23.4/share/go/src/net/http/server.go:3360 +0x8ec
nil>   github.com/NilFoundation/nil/nil/services/rpc/internal/http.StartHTTPEndpoint.func2()
nil>       /build/source/nil/services/rpc/internal/http/endpoints.go:65 +0x64
nil> Goroutine 4066 (running) created at:
nil>   github.com/NilFoundation/nil/nil/tests/nil_load_generator_service.(*NilLoadGeneratorRpc).SetupTest()
nil>       /build/source/nil/tests/nil_load_generator_service/nil_load_generator_test.go:40 +0x492
nil>   github.com/stretchr/testify/suite.Run.func1()
nil>       /build/source/vendor/github.com/stretchr/testify/suite/suite.go:192 +0x30f
nil>   testing.tRunner()
nil>       /nix/store/jfv85qbj4vb1dafcg6kncg4vrbq2bbxv-go-1.23.4/share/go/src/testing/testing.go:1690 +0x226
nil>   testing.(*T).Run.gowrap1()
nil>       /nix/store/jfv85qbj4vb1dafcg6kncg4vrbq2bbxv-go-1.23.4/share/go/src/testing/testing.go:1743 +0x44
nil> ==================
nil> ==================
nil> WARNING: DATA RACE
nil> Read at 0x00c00b4002e0 by goroutine 4916:
nil>   github.com/NilFoundation/nil/nil/services/nil_load_generator.NilLoadGeneratorAPIImpl.SmartAccountsAddr()
nil>       /build/source/nil/services/nil_load_generator/jsonrpc.go:26 +0x109
nil>   github.com/NilFoundation/nil/nil/services/nil_load_generator.(*NilLoadGeneratorAPIImpl).SmartAccountsAddr()
nil>       <autogenerated>:1 +0x1f
nil>   runtime.call16()
nil>       /nix/store/jfv85qbj4vb1dafcg6kncg4vrbq2bbxv-go-1.23.4/share/go/src/runtime/asm_amd64.s:775 +0x42
nil>   reflect.Value.Call()
nil>       /nix/store/jfv85qbj4vb1dafcg6kncg4vrbq2bbxv-go-1.23.4/share/go/src/reflect/value.go:365 +0xb5
nil>   github.com/NilFoundation/nil/nil/services/rpc/transport.(*callback).call()
nil>       /build/source/nil/services/rpc/transport/service.go:194 +0x6b1
nil>   github.com/NilFoundation/nil/nil/services/rpc/transport.(*handler).runMethod()
nil>       /build/source/nil/services/rpc/transport/handler.go:263 +0x3ab
nil>   github.com/NilFoundation/nil/nil/services/rpc/transport.(*handler).handleCall()
nil>       /build/source/nil/services/rpc/transport/handler.go:257 +0x2ad
nil>   github.com/NilFoundation/nil/nil/services/rpc/transport.(*handler).handleCallMsg()
nil>       /build/source/nil/services/rpc/transport/handler.go:220 +0x704
nil>   github.com/NilFoundation/nil/nil/services/rpc/transport.(*handler).handleMsg()
nil>       /build/source/nil/services/rpc/transport/handler.go:196 +0x230
nil>   github.com/NilFoundation/nil/nil/services/rpc/transport.(*Server).ServeSingleRequest()
nil>       /build/source/nil/services/rpc/transport/server.go:127 +0x2ea
nil>   github.com/NilFoundation/nil/nil/services/rpc/internal/http.(*Server).ServeHTTP()
nil>       /build/source/nil/services/rpc/internal/http/server.go:66 +0x567
nil>   golang.org/x/net/http2/h2c.h2cHandler.ServeHTTP()
nil>       /build/source/vendor/golang.org/x/net/http2/h2c/h2c.go:125 +0xdfb
nil>   golang.org/x/net/http2/h2c.(*h2cHandler).ServeHTTP()
nil>       <autogenerated>:1 +0x74
nil>   net/http.serverHandler.ServeHTTP()
nil>       /nix/store/jfv85qbj4vb1dafcg6kncg4vrbq2bbxv-go-1.23.4/share/go/src/net/http/server.go:3210 +0x2a1
nil>   net/http.(*conn).serve()
nil>       /nix/store/jfv85qbj4vb1dafcg6kncg4vrbq2bbxv-go-1.23.4/share/go/src/net/http/server.go:2092 +0x12a4
nil>   net/http.(*Server).Serve.gowrap3()
nil>       /nix/store/jfv85qbj4vb1dafcg6kncg4vrbq2bbxv-go-1.23.4/share/go/src/net/http/server.go:3360 +0x4f
nil> Previous write at 0x00c00b4002e0 by goroutine 4066:
nil>   github.com/NilFoundation/nil/nil/services/nil_load_generator.initializeSmartAccountsAndServices()
nil>       /build/source/nil/services/nil_load_generator/service.go:76 +0x198
nil>   github.com/NilFoundation/nil/nil/services/nil_load_generator.Run()
nil>       /build/source/nil/services/nil_load_generator/service.go:163 +0x81a
nil>   github.com/NilFoundation/nil/nil/tests/nil_load_generator_service.(*NilLoadGeneratorRpc).SetupTest.func1()
nil>       /build/source/nil/tests/nil_load_generator_service/nil_load_generator_test.go:42 +0x25e
nil> Goroutine 4916 (running) created at:
nil>   net/http.(*Server).Serve()
nil>       /nix/store/jfv85qbj4vb1dafcg6kncg4vrbq2bbxv-go-1.23.4/share/go/src/net/http/server.go:3360 +0x8ec
nil>   github.com/NilFoundation/nil/nil/services/rpc/internal/http.StartHTTPEndpoint.func2()
nil>       /build/source/nil/services/rpc/internal/http/endpoints.go:65 +0x64
nil> Goroutine 4066 (running) created at:
nil>   github.com/NilFoundation/nil/nil/tests/nil_load_generator_service.(*NilLoadGeneratorRpc).SetupTest()
nil>       /build/source/nil/tests/nil_load_generator_service/nil_load_generator_test.go:40 +0x492
nil>   github.com/stretchr/testify/suite.Run.func1()
nil>       /build/source/vendor/github.com/stretchr/testify/suite/suite.go:192 +0x30f
nil>   testing.tRunner()
nil>       /nix/store/jfv85qbj4vb1dafcg6kncg4vrbq2bbxv-go-1.23.4/share/go/src/testing/testing.go:1690 +0x226
nil>   testing.(*T).Run.gowrap1()
nil>       /nix/store/jfv85qbj4vb1dafcg6kncg4vrbq2bbxv-go-1.23.4/share/go/src/testing/testing.go:1743 +0x44
nil> ==================
```