### PR TITLE
Refactor proposer

### DIFF
--- a/nil/internal/collate/replay_scheduler.go
+++ b/nil/internal/collate/replay_scheduler.go
@@ -141,7 +141,7 @@ func (s *ReplayScheduler) buildProposalFromPrevBlock(ctx context.Context, blockI
 	s.logger.Trace().Msgf("Last block is %s, last MC block is %s", proposal.PrevBlockHash, proposal.MainChainHash)
 
 	// we could also consider option with fairly collecting these transactions
-	// from neighbor shards and running collator
+	// from neighbor shards and running proposer
 	// however it's not a purpose of replay mode (at least now)
 	inTxnsReader := execution.NewDbTransactionTrieReader(roTx, s.params.ShardId)
 	inTxnsReader.SetRootHash(blockToReplay.InTransactionsRoot)

--- a/nil/internal/collate/syncer.go
+++ b/nil/internal/collate/syncer.go
@@ -121,7 +121,7 @@ func (s *Syncer) Run(ctx context.Context, wgFetch *sync.WaitGroup) error {
 	s.logger.Debug().
 		Stringer(logging.FieldBlockHash, s.lastBlockHash).
 		Uint64(logging.FieldBlockNumber, s.lastBlockNumber.Uint64()).
-		Msgf("Initialized sync collator at starting block")
+		Msgf("Initialized sync proposer at starting block")
 
 	s.logger.Info().Msg("Starting sync")
 
@@ -135,7 +135,7 @@ func (s *Syncer) Run(ctx context.Context, wgFetch *sync.WaitGroup) error {
 	for {
 		select {
 		case <-ctx.Done():
-			s.logger.Debug().Msg("Sync collator is terminated")
+			s.logger.Debug().Msg("Sync proposer is terminated")
 			return nil
 		case data := <-ch:
 			saved, err := s.processTopicTransaction(ctx, data)

--- a/nil/internal/collate/validator.go
+++ b/nil/internal/collate/validator.go
@@ -1,0 +1,69 @@
+package collate
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/NilFoundation/nil/nil/internal/db"
+	"github.com/NilFoundation/nil/nil/internal/execution"
+	"github.com/NilFoundation/nil/nil/internal/network"
+	"github.com/NilFoundation/nil/nil/internal/types"
+	"github.com/rs/zerolog"
+)
+
+type Validator struct {
+	params Params
+
+	txFabric       db.DB
+	pool           TxnPool
+	networkManager *network.Manager
+
+	logger zerolog.Logger
+}
+
+func (s *Validator) BuildProposal(ctx context.Context) (*execution.Proposal, error) {
+	proposer := newProposer(s.params, s.params.Topology, s.pool, s.logger)
+	proposal, err := proposer.GenerateProposal(ctx, s.txFabric)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate proposal: %w", err)
+	}
+	return proposal, nil
+}
+
+func (s *Validator) VerifyProposal(ctx context.Context, proposal *execution.Proposal) (*types.Block, error) {
+	gen, err := execution.NewBlockGenerator(ctx, s.params.BlockGeneratorParams, s.txFabric)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create block generator: %w", err)
+	}
+	defer gen.Rollback()
+
+	res, err := gen.BuildBlock(proposal, s.logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate block: %w", err)
+	}
+	return res, nil
+}
+
+func (s *Validator) InsertProposal(ctx context.Context, proposal *execution.Proposal, sig types.Signature) error {
+	gen, err := execution.NewBlockGenerator(ctx, s.params.BlockGeneratorParams, s.txFabric)
+	if err != nil {
+		return fmt.Errorf("failed to create block generator: %w", err)
+	}
+	defer gen.Rollback()
+
+	res, err := gen.GenerateBlock(proposal, s.logger, sig)
+	if err != nil {
+		return fmt.Errorf("failed to generate block: %w", err)
+	}
+
+	if err := s.pool.OnCommitted(ctx, proposal.RemoveFromPool); err != nil {
+		s.logger.Warn().Err(err).Msgf("Failed to remove %d committed transactions from pool", len(proposal.RemoveFromPool))
+	}
+
+	return PublishBlock(ctx, s.networkManager, s.params.ShardId, &types.BlockWithExtractedData{
+		Block:           res.Block,
+		InTransactions:  res.InTxns,
+		OutTransactions: res.OutTxns,
+		ChildBlocks:     proposal.ShardHashes,
+	})
+}

--- a/nil/internal/consensus/ibft/messages.go
+++ b/nil/internal/consensus/ibft/messages.go
@@ -40,7 +40,7 @@ func (i *backendIBFT) BuildPrePrepareMessage(
 		return nil
 	}
 
-	block, err := i.scheduler.VerifyProposal(i.ctx, proposal)
+	block, err := i.validator.VerifyProposal(i.ctx, proposal)
 	if err != nil {
 		return nil
 	}

--- a/nil/internal/consensus/ibft/verifier.go
+++ b/nil/internal/consensus/ibft/verifier.go
@@ -14,7 +14,7 @@ func (i *backendIBFT) IsValidProposal(rawProposal []byte) bool {
 		return false
 	}
 
-	_, err = i.scheduler.VerifyProposal(i.ctx, proposal)
+	_, err = i.validator.VerifyProposal(i.ctx, proposal)
 	return err == nil
 }
 
@@ -47,7 +47,7 @@ func (i *backendIBFT) IsValidProposalHash(proposal *protoIBFT.Proposal, hash []b
 		return false
 	}
 
-	block, err := i.scheduler.VerifyProposal(i.ctx, prop)
+	block, err := i.validator.VerifyProposal(i.ctx, prop)
 	if err != nil {
 		return false
 	}

--- a/nil/services/nilservice/service.go
+++ b/nil/services/nilservice/service.go
@@ -481,15 +481,13 @@ func createShards(
 			if err != nil {
 				return nil, nil, err
 			}
-			collator, err := createActiveCollator(shardId, cfg, collatorTickPeriod, database, networkManager, txnPool)
-			if err != nil {
-				return nil, nil, err
-			}
+
+			collator := createActiveCollator(shardId, cfg, collatorTickPeriod, database, networkManager, txnPool)
 
 			consensus := ibft.NewConsensus(&ibft.ConsensusParams{
 				ShardId:    shardId,
 				Db:         database,
-				Scheduler:  collator,
+				Validator:  collator.Validator(),
 				NetManager: networkManager,
 				PrivateKey: pKey,
 			})
@@ -552,7 +550,7 @@ func createShards(
 	return funcs, pools, nil
 }
 
-func createActiveCollator(shard types.ShardId, cfg *Config, collatorTickPeriod time.Duration, database db.DB, networkManager *network.Manager, txnPool txnpool.Pool) (*collate.Scheduler, error) {
+func createActiveCollator(shard types.ShardId, cfg *Config, collatorTickPeriod time.Duration, database db.DB, networkManager *network.Manager, txnPool txnpool.Pool) *collate.Scheduler {
 	collatorCfg := collate.Params{
 		BlockGeneratorParams: execution.BlockGeneratorParams{
 			ShardId:       shard,


### PR DESCRIPTION
In anticipation of the new implementation of sequencing and as a cleanup after the introduction of consensus:

1. Renamed collator to proposer (that's its actual function).
2. Extracted "validator" part from the scheduler. Maybe the name is not the best. It handles proposals for consensus.
3. Removed the flag enabling consensus as it was already set to true anyway.