### PR TITLE
Remove failed txns from proposal

### DIFF
--- a/nil/internal/collate/proposer_test.go
+++ b/nil/internal/collate/proposer_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/NilFoundation/nil/nil/internal/db"
 	"github.com/NilFoundation/nil/nil/internal/execution"
 	"github.com/NilFoundation/nil/nil/internal/types"
+	"github.com/NilFoundation/nil/nil/services/txnpool"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/suite"
 )
@@ -123,7 +124,6 @@ func (s *ProposerTestSuite) TestCollator() {
 		r1 := s.checkReceipt(shardId, m1)
 		r2 := s.checkReceipt(shardId, m2)
 		s.Equal(pool.Txns, proposal.InTxns)
-		s.Equal(pool.Txns, proposal.RemoveFromPool)
 
 		pool.Txns = nil
 
@@ -170,9 +170,8 @@ func (s *ProposerTestSuite) TestCollator() {
 		proposal := generateBlock()
 		s.Empty(proposal.InTxns)
 		s.Empty(proposal.ForwardTxns)
-		s.Equal(pool.Txns, proposal.RemoveFromPool)
-
-		pool.Txns = nil
+		s.Equal(pool.Txns, pool.LastDiscarded)
+		s.Equal(txnpool.DuplicateHash, pool.LastReason)
 	})
 
 	s.Run("Deploy", func() {

--- a/nil/internal/collate/scheduler.go
+++ b/nil/internal/collate/scheduler.go
@@ -17,6 +17,7 @@ import (
 
 type TxnPool interface {
 	Peek(ctx context.Context, n int) ([]*types.Transaction, error)
+	Discard(ctx context.Context, txns []*types.Transaction, reason txnpool.DiscardReason) error
 	OnCommitted(ctx context.Context, committed []*types.Transaction) error
 }
 

--- a/nil/internal/collate/testaide.go
+++ b/nil/internal/collate/testaide.go
@@ -6,19 +6,35 @@ import (
 	"context"
 
 	"github.com/NilFoundation/nil/nil/internal/types"
+	"github.com/NilFoundation/nil/nil/services/txnpool"
 )
 
 type MockTxnPool struct {
 	Txns []*types.Transaction
+
+	LastDiscarded []*types.Transaction
+	LastReason    txnpool.DiscardReason
 }
 
 var _ TxnPool = (*MockTxnPool)(nil)
+
+func (m *MockTxnPool) Reset() {
+	m.Txns = nil
+	m.LastDiscarded = nil
+	m.LastReason = 0
+}
 
 func (m *MockTxnPool) Peek(_ context.Context, n int) ([]*types.Transaction, error) {
 	if n > len(m.Txns) {
 		return m.Txns, nil
 	}
 	return m.Txns[:n], nil
+}
+
+func (m *MockTxnPool) Discard(_ context.Context, txns []*types.Transaction, reason txnpool.DiscardReason) error {
+	m.LastDiscarded = txns
+	m.LastReason = reason
+	return nil
 }
 
 func (m *MockTxnPool) OnCommitted(context.Context, []*types.Transaction) error {

--- a/nil/internal/collate/validator.go
+++ b/nil/internal/collate/validator.go
@@ -56,8 +56,9 @@ func (s *Validator) InsertProposal(ctx context.Context, proposal *execution.Prop
 		return fmt.Errorf("failed to generate block: %w", err)
 	}
 
-	if err := s.pool.OnCommitted(ctx, proposal.RemoveFromPool); err != nil {
-		s.logger.Warn().Err(err).Msgf("Failed to remove %d committed transactions from pool", len(proposal.RemoveFromPool))
+	if err := s.pool.OnCommitted(ctx, proposal.InTxns); err != nil {
+		s.logger.Warn().Err(err).
+			Msgf("Failed to remove %d committed transactions from pool", len(proposal.InTxns))
 	}
 
 	return PublishBlock(ctx, s.networkManager, s.params.ShardId, &types.BlockWithExtractedData{

--- a/nil/internal/execution/block_generator.go
+++ b/nil/internal/execution/block_generator.go
@@ -33,10 +33,6 @@ type Proposal struct {
 
 	InTxns      []*types.Transaction `json:"inTxns" ssz-max:"4096"`
 	ForwardTxns []*types.Transaction `json:"forwardTxns" ssz-max:"4096"`
-
-	// In the future, collator should remove transactions from the pool itself after the consensus on the proposal.
-	// Currently, we need to remove them after the block was committed, or they may be lost.
-	RemoveFromPool []*types.Transaction `json:"removeFromPool" ssz-max:"4096"`
 }
 
 func NewEmptyProposal() *Proposal {

--- a/nil/services/txnpool/txnpoolcfg.go
+++ b/nil/services/txnpool/txnpoolcfg.go
@@ -34,6 +34,7 @@ const (
 	SeqnoTooLow         DiscardReason = 18
 	NotReplaced         DiscardReason = 20 // There was an existing transaction with the same sender and seqno, not enough price bump to replace
 	DuplicateHash       DiscardReason = 21 // There was an existing transaction with the same hash
+	Unverified          DiscardReason = 22 // Transaction verification failed
 )
 
 func (r DiscardReason) String() string {
@@ -60,6 +61,8 @@ func (r DiscardReason) String() string {
 		return "seqno too low"
 	case DuplicateHash:
 		return "duplicate hash"
+	case Unverified:
+		return "verification failed"
 	default:
 		panic(fmt.Sprintf("discard reason: %d", r))
 	}


### PR DESCRIPTION
This PR depends on the proposer refactoring: https://github.com/NilFoundation/nil/pull/66

When the proposal was used synchronously, it used to carry the list of txns to be removed from the pool.
This list consisted of all the committed txns + all failed (duplicates and those that failed external verifications).

Validators can remove committed txns from their pools.
Failed txns (duplicates and unverified) should be removed only from the proposer's pool (they might not even exist in other validators' pools). And it can be done before the consensus because they are invalid regardless.

1. Removed `RemoveFromPool` from the proposal.
2. Added `Discard` to the pool interface and implemented.
3. Used the added method to discard failed txns from the proposer's pool.
4. Switched `OnCommitted` to actually committed txns only.