### PR TITLE
use one key to validate different shards

### DIFF
--- a/nil/cmd/nild/devnet.go
+++ b/nil/cmd/nild/devnet.go
@@ -98,8 +98,8 @@ func validatorKeysFile(credsDir string) string {
 }
 
 func (spec *devnetSpec) ensureValidatorKeys(srv *server) (*keys.ValidatorKeysManager, error) {
-	vkm := keys.NewValidatorKeyManager(validatorKeysFile(srv.credsDir), spec.NShards)
-	if err := vkm.InitKeys(); err != nil {
+	vkm := keys.NewValidatorKeyManager(validatorKeysFile(srv.credsDir))
+	if err := vkm.InitKey(); err != nil {
 		return nil, err
 	}
 	return vkm, nil
@@ -108,14 +108,13 @@ func (spec *devnetSpec) ensureValidatorKeys(srv *server) (*keys.ValidatorKeysMan
 func (devnet devnet) collectPublicKeys(servers []server) (map[types.ShardId][]config.ValidatorInfo, error) {
 	validator := make(map[types.ShardId][]config.ValidatorInfo, devnet.spec.NShards)
 	for _, srv := range servers {
+		key, err := srv.vkm.GetPublicKey()
+		if err != nil {
+			return nil, err
+		}
+
 		for _, id := range srv.nodeSpec.Shards {
 			shardId := types.ShardId(id)
-
-			key, err := srv.vkm.GetPublicKey(shardId)
-			if err != nil {
-				return nil, err
-			}
-
 			validator[shardId] = append(validator[shardId], config.ValidatorInfo{
 				PublicKey: config.Pubkey(key),
 			})

--- a/nil/internal/keys/keys_test.go
+++ b/nil/internal/keys/keys_test.go
@@ -11,17 +11,16 @@ func TestInitKeys(t *testing.T) {
 
 	tempDir := t.TempDir()
 	fileName := tempDir + "/keys.yaml"
-	const nShards = 5
-	validatorKeysManager := NewValidatorKeyManager(fileName, nShards)
-	require.NoError(t, validatorKeysManager.InitKeys())
+	validatorKeysManager := NewValidatorKeyManager(fileName)
+	require.NoError(t, validatorKeysManager.InitKey())
 
-	keys, err := validatorKeysManager.GetKeys()
+	keys, err := validatorKeysManager.GetKey()
 	require.NoError(t, err)
 
-	validatorKeysManager2 := NewValidatorKeyManager(fileName, nShards)
-	require.NoError(t, validatorKeysManager2.InitKeys())
+	validatorKeysManager2 := NewValidatorKeyManager(fileName)
+	require.NoError(t, validatorKeysManager2.InitKey())
 
-	keys2, err := validatorKeysManager2.GetKeys()
+	keys2, err := validatorKeysManager2.GetKey()
 	require.NoError(t, err)
 
 	require.Equal(t, keys, keys2)

--- a/nil/services/nilservice/config.go
+++ b/nil/services/nilservice/config.go
@@ -171,11 +171,10 @@ func (c *Config) Validate() error {
 	return nil
 }
 
-func (c *Config) LoadValidatorPrivateKey(shardId types.ShardId) (key *ecdsa.PrivateKey, err error) {
+func (c *Config) LoadValidatorPrivateKey() (key *ecdsa.PrivateKey, err error) {
 	defer func() {
 		if err == nil {
 			Logger.Trace().
-				Stringer(logging.FieldShardId, shardId).
 				Hex(logging.FieldPublicKey, crypto.FromECDSAPub(&key.PublicKey)).
 				Msg("Loaded validator key")
 		}
@@ -185,13 +184,13 @@ func (c *Config) LoadValidatorPrivateKey(shardId types.ShardId) (key *ecdsa.Priv
 	}
 
 	if c.ValidatorKeysManager == nil {
-		c.ValidatorKeysManager = keys.NewValidatorKeyManager(c.ValidatorKeysPath, c.NShards)
-		if err := c.ValidatorKeysManager.InitKeys(); err != nil {
+		c.ValidatorKeysManager = keys.NewValidatorKeyManager(c.ValidatorKeysPath)
+		if err := c.ValidatorKeysManager.InitKey(); err != nil {
 			return nil, err
 		}
 	}
 
-	return c.ValidatorKeysManager.GetKey(shardId)
+	return c.ValidatorKeysManager.GetKey()
 }
 
 func (c *Config) BlockGeneratorParams(shardId types.ShardId) execution.BlockGeneratorParams {

--- a/nil/services/nilservice/service.go
+++ b/nil/services/nilservice/service.go
@@ -466,17 +466,17 @@ func createShards(
 	var wgFetch sync.WaitGroup
 	wgFetch.Add(int(cfg.NShards) - len(cfg.GetMyShards()))
 
+	pKey, err := cfg.LoadValidatorPrivateKey()
+	if err != nil {
+		return nil, nil, err
+	}
+
 	for i := range cfg.NShards {
 		shardId := types.ShardId(i)
 
 		blockVerifier := signer.NewBlockVerifier(shardId, cfg.Validators[shardId])
 
 		if cfg.IsShardActive(shardId) {
-			pKey, err := cfg.LoadValidatorPrivateKey(shardId)
-			if err != nil {
-				return nil, nil, err
-			}
-
 			txnPool, err := txnpool.New(ctx, txnpool.NewConfig(shardId), networkManager)
 			if err != nil {
 				return nil, nil, err

--- a/nil/tests/sharded_suite.go
+++ b/nil/tests/sharded_suite.go
@@ -76,7 +76,7 @@ func (s *ShardedSuite) createOneShardOneValidatorCfg(
 
 	validators := make(map[types.ShardId][]config.ValidatorInfo)
 	for kmShardId, km := range keyManagers {
-		pkey, err := km.GetPublicKey(kmShardId)
+		pkey, err := km.GetPublicKey()
 		s.Require().NoError(err)
 		validators[kmShardId] = []config.ValidatorInfo{
 			{PublicKey: config.Pubkey(pkey)},
@@ -119,9 +119,9 @@ func (s *ShardedSuite) start(cfg *nilservice.Config, port int) {
 		shardId := types.ShardId(i)
 
 		keysPath := s.T().TempDir() + fmt.Sprintf("/validator-keys-%d.yaml", i)
-		km := keys.NewValidatorKeyManager(keysPath, cfg.NShards)
+		km := keys.NewValidatorKeyManager(keysPath)
 		s.Require().NotNil(km)
-		s.Require().NoError(km.InitKeys())
+		s.Require().NoError(km.InitKey())
 		keysManagers[shardId] = km
 
 		url := rpc.GetSockPathIdx(s.T(), int(i))

--- a/nil/tools/confgen/main.go
+++ b/nil/tools/confgen/main.go
@@ -45,14 +45,14 @@ func do(nShards uint, dir string) error {
 	for i := range nShards {
 		suffix := shardSuffix(nShards, i)
 		validatorKeysPath := "validator-keys" + suffix + ".yaml"
-		validatorKeysManager := keys.NewValidatorKeyManager(validatorKeysPath, uint32(nShards))
-		if err := validatorKeysManager.InitKeys(); err != nil {
+		validatorKeysManager := keys.NewValidatorKeyManager(validatorKeysPath)
+		if err := validatorKeysManager.InitKey(); err != nil {
 			return err
 		}
 		keysManagers[i] = validatorKeysManager
 
 		shardId := types.ShardId(i)
-		pkey, err := validatorKeysManager.GetPublicKey(shardId)
+		pkey, err := validatorKeysManager.GetPublicKey()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Previously we had a key for each shard. In future we plan to remove separate validators for main shard. So we need to keep only single key for each validator that can be used to sign different shards.