### PR TITLE
Explorer bugs

### DIFF
--- a/explorer_frontend/src/features/account-connector/init.ts
+++ b/explorer_frontend/src/features/account-connector/init.ts
@@ -91,7 +91,7 @@ createSmartAccountFx.use(async ({ privateKey, endpoint }) => {
 
     await faucetClient.topUpAndWaitUntilCompletion(
       {
-        smartAccount: smartAccount.address,
+        smartAccountAddress: smartAccount.address,
         faucetAddress: faucets.NIL,
         amount: 1e18,
       },

--- a/explorer_frontend/src/features/contracts/models/base.ts
+++ b/explorer_frontend/src/features/contracts/models/base.ts
@@ -22,7 +22,7 @@ export type DeployedApp = App & {
 };
 
 export const $contracts = createStore<App[]>([]);
-export const $state = createStore<{ [code: string]: Address[] }>({});
+export const $deployedContracts = createStore<{ [code: string]: Address[] }>({});
 export const $activeApp = createStore<{
   bytecode: `0x${string}`;
   address?: Address;
@@ -36,7 +36,7 @@ export const closeApp = createEvent();
 
 export const resetApps = createEvent();
 
-export const $contractWithState = combine($contracts, $state, (contracts, state) => {
+export const $contractWithState = combine($contracts, $deployedContracts, (contracts, state) => {
   const contractsWithAddress: (App & { address?: Address })[] = [];
   for (const contract of contracts) {
     if (state[contract.bytecode]) {
@@ -286,7 +286,7 @@ export const sendMethodFx = createEffect<
       if (parsedLog == null) {
         return null;
       }
-      return `${parsedLog!.name} with args [${parsedLog!.args.join(", ")}]`;
+      return `${parsedLog?.name} with args [${parsedLog?.args.join(", ")}]`;
     })
     .filter((log): log is string => log !== null);
 


### PR DESCRIPTION
Changed AssignTab explicitly to disallow duplication of contracts and clearing of address on modal close. 
- Changed assign tab to not show addresses persisting from previous interaction. Upon close of modal, you have a clear input tab. 
- This PR also adds logic to not allow duplication of contracts which is, once you have deployed a contract, you cannot use the same address to assign it again when the deployed contract still exists in the sandbox. 