### PR TITLE
[loadgen-test] Check for positive balances.

### DIFF
--- a/nil/tests/nil_load_generator_service/nil_load_generator_test.go
+++ b/nil/tests/nil_load_generator_service/nil_load_generator_test.go
@@ -78,6 +78,11 @@ func (s *NilLoadGeneratorRpc) TestSmartAccountBalanceModification() {
 		return len(resSmartAccounts) != 0
 	}, 20*time.Second, 100*time.Millisecond)
 
+	for i, addr := range resSmartAccounts {
+		s.Require().Positive(smartAccountsBalance[i].Uint64(),
+			"Zero balance for smart account %d, addr %s", i, addr)
+	}
+
 	for {
 		select {
 		case <-testTimeout:


### PR DESCRIPTION
Occasionally, the balances turn out to be zero, and the Greater() check below fails later.
This is an attempt to catch this condition earlier, with better logging.

This won't help in all cases:
```
       > --- FAIL: TestNilLoadGeneratorRpcRpc (23.36s)
       >     --- FAIL: TestNilLoadGeneratorRpcRpc/TestSmartAccountBalanceModification (23.27s)
       >         nil_load_generator_test.go:87:
       >                 Error Trace:    /build/source/nil/tests/nil_load_generator_service/nil_load_generator_test.go:87
       >               Error:          "9998724480000000" is not greater than "9998724480000000"
       >              Test:           TestNilLoadGeneratorRpcRpc/TestSmartAccountBalanceModification
       > FAIL
 ```
 (happened [here](https://github.com/NilFoundation/nil/actions/runs/13080458637/job/36502620050?pr=76)).