### PR TITLE
Move flaky tests from the "nil" group

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,7 +51,7 @@
           });
 
           # split tests into groups
-          ibft = nil.override { testGroup = "ibft"; };
+          ibft = nil.override { testGroup = "ibft"; parallelTesting = true; };
           heavy = nil.override { testGroup = "heavy"; parallelTesting = true; };
           others = nil.override { testGroup = "others"; parallelTesting = true; };
 

--- a/nix/tests-heavy.txt
+++ b/nix/tests-heavy.txt
@@ -1,6 +1,5 @@
 nil/tests/economy
 nil/tests/faucet
-nil/tests/rpc_node
 nil/internal/execution
 nil/tests/async_await
 nil/tests/basic

--- a/nix/tests-ibft.txt
+++ b/nix/tests-ibft.txt
@@ -1,3 +1,4 @@
 nil/go-ibft/core
 nil/tests/archive_node
 nil/services/txnpool
+nil/tests/rpc_node

--- a/nix/tests-ibft.txt
+++ b/nix/tests-ibft.txt
@@ -1,1 +1,3 @@
 nil/go-ibft/core
+nil/tests/archive_node
+nil/services/txnpool


### PR DESCRIPTION
Let's hope that they will execute fine with lower parallelism.