### PR TITLE
Rename getMessageReceiptByHash to getTransactionReceiptByHash

### DIFF
--- a/explorer_frontend/src/features/contracts/models/base.ts
+++ b/explorer_frontend/src/features/contracts/models/base.ts
@@ -271,7 +271,7 @@ export const sendMethodFx = createEffect<
 
   await waitTillCompleted(smartAccount.client, hash);
   const contractIface = new ethers.Interface(abi);
-  const receipts = await smartAccount.client.getMessageReceiptByHash(hash);
+  const receipts = await smartAccount.client.getTransactionReceiptByHash(hash);
   const logs = receipts
     ? [
         ...(receipts.outputReceipts?.flatMap((receipt) => {


### PR DESCRIPTION
This pull request includes a change to the `explorer_frontend/src/features/contracts/models/base.ts` file to correct the method used for retrieving transaction receipts.

* [`explorer_frontend/src/features/contracts/models/base.ts`](diffhunk://#diff-db44f990ebdaec3245f2c2986a410f1e58b87bd793576613d4c0c2a824f49cfeL274-R274): Changed the method from `getMessageReceiptByHash` to `getTransactionReceiptByHash` to accurately retrieve transaction receipts.

It is incorrect method name, currently we have `getTransactionReceiptByHash` in niljs.
