### PR TITLE
Make cometa contract register optional

### DIFF
--- a/explorer_frontend/src/features/contracts/init.ts
+++ b/explorer_frontend/src/features/contracts/init.ts
@@ -42,6 +42,7 @@ import {
   deploySmartContractFx,
   fetchBalanceFx,
   incrementShardId,
+  registerContractInCometaFx,
   removeValueInput,
   sendMethod,
   sendMethodFx,
@@ -132,9 +133,7 @@ sample({
     $deploymentArgs,
     $smartAccount,
     $shardId,
-    $cometaService,
-    $solidityVersion,
-    (app, args, smartAccount, shardId, cometaService, solidityVersion) => {
+    (app, args, smartAccount, shardId) => {
       if (!app) {
         return null;
       }
@@ -158,8 +157,6 @@ sample({
           args: [],
           smartAccount,
           shardId,
-          cometaService,
-          solidityVersion,
         };
       }
 
@@ -200,8 +197,6 @@ sample({
         args: result,
         smartAccount,
         shardId,
-        cometaService,
-        solidityVersion,
       };
     },
   ),
@@ -209,18 +204,15 @@ sample({
     $smartAccount,
     $activeApp,
     $shardId,
-    $cometaService,
-    (smartAccount, app, shardId, cometa) => !!smartAccount && !!app && shardId !== null && !!cometa,
+    (smartAccount, app, shardId) => !!smartAccount && !!app && shardId !== null,
   ),
   fn: (data) => {
-    const { app, args, smartAccount, shardId, cometaService, solidityVersion } = data!;
+    const { app, args, smartAccount, shardId } = data!;
     return {
       app,
       args,
       smartAccount,
       shardId: shardId as number, // we have filter
-      cometaService: cometaService as CometaService, // we have filter
-      solidityVersion,
     };
   },
   clock: deploySmartContract,
@@ -581,3 +573,27 @@ exportAppFx.use(async (app) => {
 });
 
 $activeComponent.on(setActiveComponent, (_, payload) => payload);
+
+sample({
+  clock: deploySmartContractFx.doneData,
+  target: registerContractInCometaFx,
+  source: combine({
+    app: $activeAppWithState,
+    cometaService: $cometaService,
+    solidityVersion: $solidityVersion,
+  }),
+  filter: combine(
+    $activeAppWithState,
+    $cometaService,
+    (app, cometaService) => !!app && !!cometaService,
+  ),
+  fn: ({ app, cometaService, solidityVersion }, { address, name }) => {
+    return {
+      app: app as App,
+      name: name,
+      address: address as Hex,
+      cometaService: cometaService as CometaService,
+      solidityVersion,
+    };
+  },
+});

--- a/explorer_frontend/src/features/logs/init.tsx
+++ b/explorer_frontend/src/features/logs/init.tsx
@@ -6,6 +6,7 @@ import {
   assignSmartContractFx,
   callFx,
   deploySmartContractFx,
+  registerContractInCometaFx,
   sendMethodFx,
 } from "../contracts/models/base";
 import { ContractDeployedLog } from "./components/ContractDeployedLog";
@@ -13,7 +14,7 @@ import { LogTitleWithDetails } from "./components/LogTitleWithDetails";
 import { TransactionEventLog } from "./components/TransactionEventLog.tsx";
 import { TransactionSentLog } from "./components/TransactionSentLog";
 import { TxDetials } from "./components/TxDetails";
-import { $logs, LogTopic, LogType, clearLogs } from "./model";
+import { $logs, type Log, LogTopic, LogType, clearLogs } from "./model";
 import { formatSolidityError } from "./utils";
 
 $logs.on(deploySmartContractFx.doneData, (logs, { address, name, deployedFrom, txHash }) => {
@@ -203,6 +204,24 @@ $logs.on(sendMethodFx.failData, (logs, error) => {
         <MonoParagraphMedium color={COLORS.red200}>Transaction failed</MonoParagraphMedium>
       ),
       payload: <MonoParagraphMedium color={COLORS.red200}>{String(error)}</MonoParagraphMedium>,
+      timestamp: Date.now(),
+    },
+  ];
+});
+
+$logs.on(registerContractInCometaFx.failData, (logs, error) => {
+  return [
+    ...logs,
+    {
+      id: nanoid(),
+      topic: LogTopic.Deployment,
+      type: LogType.Warn,
+      shortDescription: (
+        <MonoParagraphMedium color={COLORS.yellow200}>
+          Contract registration in Cometa failed. You won't be able to view the source code.
+        </MonoParagraphMedium>
+      ),
+      payload: <MonoParagraphMedium color={COLORS.gray50}>{String(error)}</MonoParagraphMedium>,
       timestamp: Date.now(),
     },
   ];


### PR DESCRIPTION
This diff makes contract registration in cometa service optional. This improves user flow by decreasing amount of potential pain points. It contract was deployed but not registered in cometa - user is going to see warning in console.

### Contracts Feature Changes:

* Added `registerContractInCometaFx` to the list of imported effects and included it in the `sample` function to register contracts upon successful deployment. (`explorer_frontend/src/features/contracts/init.ts`, [[1]](diffhunk://#diff-0520c98b0b5c9b833307795bdd3996a1399307502de66eea027793ec52a663baR45) [[2]](diffhunk://#diff-0520c98b0b5c9b833307795bdd3996a1399307502de66eea027793ec52a663baR576-R599)
* Removed `cometaService` and `solidityVersion` from the `sample` function parameters and the `deploySmartContractFx` effect. (`explorer_frontend/src/features/contracts/init.ts`, [[1]](diffhunk://#diff-0520c98b0b5c9b833307795bdd3996a1399307502de66eea027793ec52a663baL135-R136) [[2]](diffhunk://#diff-0520c98b0b5c9b833307795bdd3996a1399307502de66eea027793ec52a663baL161-L162) [[3]](diffhunk://#diff-0520c98b0b5c9b833307795bdd3996a1399307502de66eea027793ec52a663baL203-L223); `explorer_frontend/src/features/contracts/models/base.ts`, [[4]](diffhunk://#diff-db44f990ebdaec3245f2c2986a410f1e58b87bd793576613d4c0c2a824f49cfeL94-L95) [[5]](diffhunk://#diff-db44f990ebdaec3245f2c2986a410f1e58b87bd793576613d4c0c2a824f49cfeL104-R102)
* Added a new effect `registerContractInCometaFx` to handle contract registration in Cometa, including logging and error handling. (`explorer_frontend/src/features/contracts/models/base.ts`, [explorer_frontend/src/features/contracts/models/base.tsR116-R148](diffhunk://#diff-db44f990ebdaec3245f2c2986a410f1e58b87bd793576613d4c0c2a824f49cfeR116-R148))

### Logs Feature Changes:

* Added `registerContractInCometaFx` to the list of imported effects and included error handling for failed contract registration in the logs. (`explorer_frontend/src/features/logs/init.tsx`, [[1]](diffhunk://#diff-a8d87d7e901c352330435a55df3c5fa0b9bd6a8e30c7953f0390fe9fbc78e652R9-R17) [[2]](diffhunk://#diff-a8d87d7e901c352330435a55df3c5fa0b9bd6a8e30c7953f0390fe9fbc78e652R212-R229)