### PR TITLE
niljs: handle failed external failed

### DIFF
--- a/niljs/test/integration/helpers.ts
+++ b/niljs/test/integration/helpers.ts
@@ -35,12 +35,13 @@ export function generatePublicKey() {
   return getPublicKey(generateRandomPrivateKey());
 }
 
-export async function topUpTest(address: Hex, token = "NIL") {
+export async function topUpTest(address: Hex, token = "NIL", amount = 1e18) {
   await topUp({
     address,
     rpcEndpoint: testEnv.endpoint,
     faucetEndpoint: testEnv.faucetServiceEndpoint,
     token,
+    amount,
   });
 }
 


### PR DESCRIPTION
Optimisation and speeding for contact deployment and sending transactions

- WaitTillMainShard default set to false
- Fix cases for failed external transactions

Fixed https://github.com/NilFoundation/nil/issues/125