### PR TITLE
[GH-65] Add clijs macOS CI build over nix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,11 +26,55 @@ jobs:
       - name: run check
         run: nix build .#checks.x86_64-linux.${{ matrix.check == 'nil' && 'others' || matrix.check }} -L
 
+  nix_check_macos:
+    name: macOS CI (${{ matrix.platform.os}}, ${{ matrix.platform.arch }}) - ${{ matrix.check }}
+    environment: prod
+    runs-on: ${{ matrix.platform.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Add other checks later, when they are stabilized, and caching will be configured for Nix.
+        check: ["clijs"]
+        platform:
+          # N.B. The architecture is chosen by GitHub at `runs-on` depending on the label (`os`)
+          # See https://github.com/actions/runner-images?tab=readme-ov-file#available-images
+          # The other fields only affect the logic of our steps
+          - os: macos-latest
+            arch: aarch64
+            nixArch: aarch64-darwin
+          - os: macos-13
+            arch: x64
+            nixArch: x86_64-darwin
+    steps:
+      - name: checkout local actions
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run check
+        run: nix build .#checks.${{ matrix.platform.nixArch }}.${{ matrix.check == 'nil' && 'others' || matrix.check }} -L
+
+      - name: Upload nil binary as artifact
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: nil-darwin-${{ matrix.platform.arch }}
+          path: |
+            build/bin/nil
+
   ensure_cluster_builds_macos:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         include:
+          # N.B. The architecture is chosen by GitHub at `runs-on` depending on the label (`os`)
+          # See https://github.com/actions/runner-images?tab=readme-ov-file#available-images
+          # The other fields only affect the logic of our steps
           - os: macos-latest
             arch: aarch64
           - os: macos-13

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
           - os: macos-latest
             arch: aarch64
             nixArch: aarch64-darwin
-          - os: macos-13
+          - os: macos-15-large
             arch: x64
             nixArch: x86_64-darwin
     steps:
@@ -50,6 +50,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      # https://github.com/NixOS/nix/issues/2242#issuecomment-2336841344
+      - name: macOS 15 eDSRecordAlreadyExists workaround
+        run: echo "NIX_FIRST_BUILD_UID=30001" >> "$GITHUB_ENV"
 
       - name: Install Nix
         uses: cachix/install-nix-action@v27

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,6 +59,8 @@ jobs:
         uses: cachix/install-nix-action@v27
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_nix_config: |
+            max-jobs = 1
 
       - name: Run check
         run: nix build .#checks.${{ matrix.platform.nixArch }}.${{ matrix.check == 'nil' && 'others' || matrix.check }} -L

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,4 +1,11 @@
 self: super: {
+  libuv = super.libuv.overrideAttrs (oldAttrs: rec {
+    postPatch = oldAttrs.postPatch + super.lib.optionalString (super.stdenv.hostPlatform.system == "x86_64-darwin") ''
+      # Disable flaky test
+      sed '/spawn_exercise_sigchld_issue/d' -i test/test-list.h
+    '';
+  });
+
   pkgsStatic = super.pkgsStatic // {
     nodejs_22 = super.pkgsStatic.nodejs_22.overrideAttrs (oldAttrs:
       let

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,11 +1,4 @@
 self: super: {
-  libuv = super.libuv.overrideAttrs (oldAttrs: rec {
-    postPatch = oldAttrs.postPatch + super.lib.optionalString (super.stdenv.hostPlatform.system == "x86_64-darwin") ''
-      # Disable flaky test
-      sed '/spawn_exercise_sigchld_issue/d' -i test/test-list.h
-    '';
-  });
-
   pkgsStatic = super.pkgsStatic // {
     nodejs_22 = super.pkgsStatic.nodejs_22.overrideAttrs (oldAttrs:
       let


### PR DESCRIPTION
This PR adds `clijs` builds for macOS (x86_64 and ARM) via Nix.

The builds take a long time (about an hour) due to unconfigured caching in Nix. This will be addressed in a separate task. Builds are not marked required, so we consider this option acceptable for now. For the same reason, we are not adding other checks via Nix yet.

`install-nix-action` uses `max-jobs = auto` by default, which leads to test instability. Took a long time going through images and disabling tests until I got to the cause. The setting was changed to the standard `max-jobs = 1`.

Closes #65.