### PR TITLE
tracer: keccak opcode tracing

### DIFF
--- a/nil/services/synccommittee/prover/proto/traces.proto
+++ b/nil/services/synccommittee/prover/proto/traces.proto
@@ -196,3 +196,14 @@ message ExpTraces {
     uint64 trace_idx = 2; // some randomly chosen value that should be checked in the proof generator to ensure integrity of the passed traces
     string proto_hash = 3;  // hash of this proto specification for compatibility check
 }
+
+message KeccakBuffer {
+    bytes buffer = 1;
+    Uint256 keccak_hash = 2;
+}
+
+message KeccakTraces {
+    repeated KeccakBuffer hashed_buffers = 1;
+    uint64 trace_idx = 2;
+    string proto_hash = 3;
+}

--- a/nil/services/synccommittee/prover/tracer/keccak_tracer.go
+++ b/nil/services/synccommittee/prover/tracer/keccak_tracer.go
@@ -1,0 +1,67 @@
+package tracer
+
+import (
+	"github.com/NilFoundation/nil/nil/common"
+	"github.com/NilFoundation/nil/nil/internal/tracing"
+	"github.com/NilFoundation/nil/nil/internal/vm"
+)
+
+type KeccakBuffer struct {
+	buf  []byte
+	hash common.Hash
+}
+
+type KeccakTracer struct {
+	finalizer func()
+
+	hashes []KeccakBuffer
+}
+
+func NewKeccakTracer() *KeccakTracer {
+	return &KeccakTracer{}
+}
+
+func (kt *KeccakTracer) TraceOp(opCode vm.OpCode, opCtx tracing.OpContext) (bool, error) {
+	if kt.finalizer != nil {
+		return false, ErrTraceNotFinalized
+	}
+
+	if opCode != vm.KECCAK256 {
+		return false, nil
+	}
+
+	stack := NewStackAccessor(opCtx.StackData())
+	var (
+		memOffset = stack.PopUint64()
+		bufSize   = stack.PopUint64()
+	)
+
+	buf := getDataOverflowSafe(opCtx.MemoryData(), memOffset, bufSize)
+	kt.hashes = append(kt.hashes, KeccakBuffer{
+		buf: buf,
+	})
+
+	finIdx := len(kt.hashes) - 1
+	finStack := NewStackAccessor(opCtx.StackData())
+	finStack.Skip(1)
+	kt.finalizer = func() {
+		trace := &kt.hashes[finIdx]
+		trace.hash.SetBytes(finStack.Pop().Bytes())
+	}
+
+	return true, nil
+}
+
+func (kt *KeccakTracer) FinishPrevOpcodeTracing() {
+	if kt.finalizer == nil {
+		return
+	}
+
+	kt.finalizer()
+	kt.finalizer = nil
+}
+
+func (kt *KeccakTracer) Finalize() []KeccakBuffer {
+	kt.FinishPrevOpcodeTracing()
+	return kt.hashes
+}

--- a/nil/services/synccommittee/prover/tracer/keccak_tracer_test.go
+++ b/nil/services/synccommittee/prover/tracer/keccak_tracer_test.go
@@ -1,0 +1,70 @@
+package tracer
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/NilFoundation/nil/nil/internal/vm"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/prover/tracer/internal/testutils"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// traceExpOperation encapsulates the setup and invocation of tracing an KECCAK256 operation.
+func traceKeccakOperation(t *testing.T, tracer *KeccakTracer, opCode vm.OpCode, offset, size uint64, mem []byte) bool {
+	t.Helper()
+	stack := []uint256.Int{*uint256.NewInt(size), *uint256.NewInt(offset)}
+	context := &testutils.OpContextMock{
+		StackDataFunc:  func() []uint256.Int { return stack },
+		MemoryDataFunc: func() []byte { return mem },
+	}
+
+	traced, err := tracer.TraceOp(opCode, context)
+	require.NoError(t, err)
+
+	if opCode == vm.KECCAK256 {
+		stack = stack[:1]
+		hash := crypto.Keccak256(mem[offset : offset+size])
+		var u256val uint256.Int
+		u256val.SetBytes(hash)
+		stack[0] = u256val
+	}
+
+	tracer.FinishPrevOpcodeTracing()
+	return traced
+}
+
+func TestKeccakTracer_HandlesKeccakOperation(t *testing.T) {
+	t.Parallel()
+	tracer := NewKeccakTracer()
+
+	buf := bytes.Repeat([]byte{0xFF}, 8)
+	assert.True(t, traceKeccakOperation(t, tracer, vm.KECCAK256, 0, 4, buf))
+
+	require.Len(t, tracer.hashes, 1)
+	assert.Equal(t, buf[:4], tracer.hashes[0].buf)
+	expectedHash, err := uint256.FromHex("0x29045A592007D0C246EF02C2223570DA9522D0CF0F73282C79A1BC8F0BB2C238")
+	require.NoError(t, err)
+	assert.Equal(t, expectedHash.Bytes(), tracer.hashes[0].hash.Bytes())
+}
+
+func TestKeccakTracer_IgnoresOtherOperations(t *testing.T) {
+	t.Parallel()
+	tracer := NewKeccakTracer()
+
+	assert.False(t, traceKeccakOperation(t, tracer, vm.ADD, 0, 2, []byte{1, 2, 3, 4})) // Non-KECCAK256 opcode should result in no operation captured
+
+	assert.Empty(t, tracer.hashes)
+}
+
+func TestKeccakTracer_MaintainsCorrectStateAcrossCalls(t *testing.T) {
+	t.Parallel()
+	tracer := NewKeccakTracer()
+
+	assert.True(t, traceKeccakOperation(t, tracer, vm.KECCAK256, 1, 4, []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF}))
+	assert.True(t, traceKeccakOperation(t, tracer, vm.KECCAK256, 0, 4, []byte{0xFF, 0xFF, 0xFF, 0xFF}))
+
+	require.Len(t, tracer.hashes, 2)
+}

--- a/nil/services/synccommittee/prover/tracer/memory_op_tracer.go
+++ b/nil/services/synccommittee/prover/tracer/memory_op_tracer.go
@@ -43,8 +43,9 @@ type opRanges struct {
 var opsToMemoryRanges = map[vm.OpCode]func(stack *StackAccessor, memoryLen int) opRanges{
 	vm.KECCAK256: func(stack *StackAccessor, _ int) opRanges {
 		offset := stack.Pop()
+		lengthToRead := stack.Pop()
 		return opRanges{
-			before: memoryRange{offset.Uint64(), 32},
+			before: memoryRange{offset.Uint64(), lengthToRead.Uint64()},
 		}
 	},
 	vm.CALLDATACOPY: func(stack *StackAccessor, _ int) opRanges {

--- a/nil/services/synccommittee/prover/tracer/tracer.go
+++ b/nil/services/synccommittee/prover/tracer/tracer.go
@@ -131,6 +131,7 @@ func (rt *RemoteTracerImpl) GetBlockTraces(
 		Uint("stateOperations", stats.StateOpsN).
 		Uint("copyOperations", stats.CopyOpsN).
 		Uint("expOperations", stats.ExpOpsN).
+		Uint("keccakOperations", stats.KeccakOpsN).
 		Uint("affectedContracts", stats.AffectedContractsN).
 		Msg("Tracer stats")
 

--- a/nil/services/synccommittee/prover/tracer/tracer_mock_client_test.go
+++ b/nil/services/synccommittee/prover/tracer/tracer_mock_client_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/NilFoundation/nil/nil/services/rpc/jsonrpc"
 	"github.com/NilFoundation/nil/nil/services/rpc/transport"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/prover/tracer/api"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -338,10 +339,12 @@ func (s *TracerMockClientTestSuite) TestSwapOperations() {
 }
 
 // Check that copy event finalizer is called
-func (s *TracerMockClientTestSuite) TestCopyEventFinalizer() {
+func (s *TracerMockClientTestSuite) TestKeccakOpCodeTracing() {
 	// Check two keccak opcodes, since they are finalized in different place:
 	// we have finalizer call after the previous opcode and at the end of transaction
 	dataToCopy, err := hex.DecodeString("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f")
+	expectedHash := crypto.Keccak256(dataToCopy)
+
 	s.Require().NoError(err)
 	initPush := append([]byte{byte(vm.PUSH32)}, dataToCopy...)
 	code := slices.Concat(initPush, []byte{
@@ -358,7 +361,15 @@ func (s *TracerMockClientTestSuite) TestCopyEventFinalizer() {
 	})
 	traceData := s.simpleContractCallTrace(code)
 
+	// check copy event tracer finalizer
 	s.Require().Len(traceData.CopyEvents, 2)
-	s.NotNil(traceData.CopyEvents[0].To.KeccakHash)
-	s.NotNil(traceData.CopyEvents[1].To.KeccakHash)
+	s.EqualValues(expectedHash, *traceData.CopyEvents[0].To.KeccakHash)
+	s.EqualValues(expectedHash, *traceData.CopyEvents[1].To.KeccakHash)
+
+	// check keccak tracer
+	s.Require().Len(traceData.KeccakTraces, 2)
+	s.EqualValues(dataToCopy, traceData.KeccakTraces[0].buf)
+	s.EqualValues(expectedHash, traceData.KeccakTraces[0].hash)
+	s.EqualValues(dataToCopy, traceData.KeccakTraces[1].buf)
+	s.EqualValues(expectedHash, traceData.KeccakTraces[1].hash)
 }

--- a/nil/services/synccommittee/prover/tracer/types.go
+++ b/nil/services/synccommittee/prover/tracer/types.go
@@ -10,6 +10,7 @@ type ExecutionTraces interface {
 	AddStackOps(ops []StackOp)
 	AddStorageOps(ops []StorageOp)
 	AddExpOps(ops []ExpOp)
+	AddKeccakOps(ops []KeccakBuffer)
 	AddZKEVMStates(states []ZKEVMState)
 	AddCopyEvents(events []CopyEvent)
 	AddContractBytecode(addr types.Address, code []byte)
@@ -18,13 +19,14 @@ type ExecutionTraces interface {
 
 type executionTracesImpl struct {
 	// Stack/Memory/State Ops are handled for entire block, they share the same counter (rw_circuit)
-	StackOps    []StackOp
-	MemoryOps   []MemoryOp
-	StorageOps  []StorageOp
-	ExpOps      []ExpOp
-	ZKEVMStates []ZKEVMState
-	CopyEvents  []CopyEvent
-	MPTTraces   *mpttracer.MPTTraces
+	StackOps     []StackOp
+	MemoryOps    []MemoryOp
+	StorageOps   []StorageOp
+	ExpOps       []ExpOp
+	ZKEVMStates  []ZKEVMState
+	CopyEvents   []CopyEvent
+	KeccakTraces []KeccakBuffer
+	MPTTraces    *mpttracer.MPTTraces
 
 	ContractsBytecode map[types.Address][]byte
 }
@@ -65,6 +67,10 @@ func (tr *executionTracesImpl) AddExpOps(ops []ExpOp) {
 	tr.ExpOps = append(tr.ExpOps, ops...)
 }
 
+func (tr *executionTracesImpl) AddKeccakOps(ops []KeccakBuffer) {
+	tr.KeccakTraces = append(tr.KeccakTraces, ops...)
+}
+
 func (tr *executionTracesImpl) SetMptTraces(mptTraces *mpttracer.MPTTraces) {
 	tr.MPTTraces = mptTraces
 }
@@ -77,5 +83,6 @@ type Stats struct {
 	StateOpsN          uint
 	CopyOpsN           uint
 	ExpOpsN            uint
+	KeccakOpsN         uint
 	AffectedContractsN uint
 }


### PR DESCRIPTION
Our proof system has independent circuit for proving KECCAK256 opcode execution. Inputs and results of these executions must be stored in traces that sync committee collects from the EVM while re-executing the blocks. 

This PR adds collecting and serializing these traces + fixes couple of bugs found while testing with the placeholder part