### PR TITLE
Change of Assign tab to Import Contract tab

### DIFF
--- a/explorer_frontend/src/features/contracts/components/Deploy/DeployContractModal.tsx
+++ b/explorer_frontend/src/features/contracts/components/Deploy/DeployContractModal.tsx
@@ -14,8 +14,8 @@ import type { FC } from "react";
 import {} from "../../models/base";
 import { $activeComponent, setActiveComponent } from "../../models/base";
 import { ActiveComponent } from "./ActiveComponent";
-import { AssignTab } from "./AssignTab";
 import { DeployTab } from "./DeployTab";
+import { ImportContractTab } from "./ImportContractTab";
 
 type DeployContractModalProps = {
   onClose?: () => void;
@@ -68,12 +68,12 @@ export const DeployContractModal: FC<DeployContractModalProps> = ({ onClose, isO
               <DeployTab />
             </Tab>
             <Tab
-              title="Assign address"
+              title="Import Contract"
               kind={TAB_KIND.primary}
               key={ActiveComponent.Assign}
               onClick={() => setActiveComponent(ActiveComponent.Assign)}
             >
-              <AssignTab />
+              <ImportContractTab />
             </Tab>
           </Tabs>
         </ModalBody>

--- a/explorer_frontend/src/features/contracts/components/Deploy/ImportContractTab.tsx
+++ b/explorer_frontend/src/features/contracts/components/Deploy/ImportContractTab.tsx
@@ -7,6 +7,7 @@ import { useCallback, useEffect, useState } from "react";
 import { useStyletron } from "styletron-react";
 import { $smartAccount } from "../../../account-connector/model";
 import {
+  $activeAppWithState,
   $assignedSmartContractAddress,
   $deployedContracts,
   assignSmartContract,
@@ -14,12 +15,13 @@ import {
   setAssignedSmartContractAddress,
 } from "../../models/base";
 
-export const AssignTab = () => {
-  const [smartAccount, pending, deployedContracts, assignedAddress] = useUnit([
+export const ImportContractTab = () => {
+  const [smartAccount, pending, deployedContracts, assignedAddress, activeApp] = useUnit([
     $smartAccount,
     assignSmartContractFx.pending,
     $deployedContracts,
     $assignedSmartContractAddress,
+    $activeAppWithState,
   ]);
 
   const [css] = useStyletron();
@@ -80,6 +82,14 @@ export const AssignTab = () => {
             {error}
           </LabelSmall>
         )}
+        <LabelSmall
+          className={css({
+            color: COLORS.gray400,
+            marginTop: SPACE[4],
+          })}
+        >
+          Import the already deployed {activeApp?.name} smart contract using its address.
+        </LabelSmall>
       </div>
       <div>
         <Button
@@ -89,7 +99,7 @@ export const AssignTab = () => {
           isLoading={pending}
           disabled={pending || !smartAccount || !!error}
         >
-          Assign
+          Import
         </Button>
       </div>
     </>


### PR DESCRIPTION
This PR introduces renaming of "Assign" Tab -> "Import Contract"  and a small hint under the address input to tell the user to insert the address of the already deployed smart contract(with its name).

![image](https://github.com/user-attachments/assets/7a018511-b628-4832-9599-04f64fdb8ed1)
