### PR TITLE
[consensus] run consensus on main shard by all validators

### DIFF
--- a/nil/common/logging/fields.go
+++ b/nil/common/logging/fields.go
@@ -33,9 +33,10 @@ const (
 	FieldAccountAddress = "accountAddress"
 	FieldAccountSeqno   = "accountSeqno"
 
-	FieldBlockHash   = "blockHash"
-	FieldBlockNumber = "blockNumber"
-	FieldBatchId     = "batchId"
+	FieldBlockHash          = "blockHash"
+	FieldBlockMainChainHash = "blockMainChainHash"
+	FieldBlockNumber        = "blockNumber"
+	FieldBatchId            = "batchId"
 
 	FieldTaskId         = "taskId"
 	FieldTaskParentId   = "taskParentId"

--- a/nil/internal/collate/bootstrap.go
+++ b/nil/internal/collate/bootstrap.go
@@ -72,7 +72,7 @@ func fetchShardSnap(ctx context.Context, nm *network.Manager, peerId network.Pee
 }
 
 // Fetch DB snapshot via libp2p.
-func FetchSnapshot(ctx context.Context, nm *network.Manager, peerAddr *network.AddrInfo, shardId types.ShardId, db db.DB) error {
+func fetchSnapshot(ctx context.Context, nm *network.Manager, peerAddr *network.AddrInfo, shardId types.ShardId, db db.DB) error {
 	if nm == nil {
 		return nil
 	}

--- a/nil/internal/execution/state.go
+++ b/nil/internal/execution/state.go
@@ -1705,12 +1705,18 @@ func (es *ExecutionState) resetVm() {
 }
 
 func (es *ExecutionState) MarshalJSON() ([]byte, error) {
+	prevBlock, err := es.shardAccessor.GetBlock().ByHash(es.PrevBlock)
+	if err != nil && !errors.Is(err, db.ErrKeyNotFound) {
+		return nil, err
+	}
+
 	data := struct {
 		ContractTreeRoot       common.Hash                                  `json:"contractTreeRoot"`
 		InTransactionTreeRoot  common.Hash                                  `json:"inTransactionTreeRoot"`
 		OutTransactionTreeRoot common.Hash                                  `json:"outTransactionTreeRoot"`
 		ReceiptTreeRoot        common.Hash                                  `json:"receiptTreeRoot"`
-		PrevBlock              common.Hash                                  `json:"prevBlock"`
+		PrevBlock              *types.Block                                 `json:"prevBlock"`
+		PrevBlockHash          common.Hash                                  `json:"prevBlockHash"`
 		MainChainHash          common.Hash                                  `json:"mainChainHash"`
 		ShardId                types.ShardId                                `json:"shardId"`
 		ChildChainBlocks       map[types.ShardId]common.Hash                `json:"childChainBlocks"`
@@ -1725,7 +1731,8 @@ func (es *ExecutionState) MarshalJSON() ([]byte, error) {
 		InTransactionTreeRoot:  es.InTransactionTree.RootHash(),
 		OutTransactionTreeRoot: es.OutTransactionTree.RootHash(),
 		ReceiptTreeRoot:        es.ReceiptTree.RootHash(),
-		PrevBlock:              es.PrevBlock,
+		PrevBlock:              prevBlock.Block(),
+		PrevBlockHash:          es.PrevBlock,
 		MainChainHash:          es.MainChainHash,
 		ShardId:                es.ShardId,
 		ChildChainBlocks:       es.ChildChainBlocks,

--- a/nil/tests/archive_node/archive_node_test.go
+++ b/nil/tests/archive_node/archive_node_test.go
@@ -18,7 +18,7 @@ type SuiteArchiveNode struct {
 }
 
 func (s *SuiteArchiveNode) SetupTest() {
-	nshards := uint32(5)
+	nshards := uint32(3)
 
 	s.Start(&nilservice.Config{
 		NShards:              nshards,
@@ -33,7 +33,7 @@ func (s *SuiteArchiveNode) TearDownTest() {
 }
 
 func (s *SuiteArchiveNode) TestGetDebugBlock() {
-	for shardId := range len(s.Shards) {
+	for shardId := range s.GetNShards() {
 		debugBlock, err := s.DefaultClient.GetDebugBlock(s.Context, types.ShardId(shardId), "latest", true)
 		s.Require().NoError(err)
 		s.NotNil(debugBlock)

--- a/nil/tests/async_await/async_await_test.go
+++ b/nil/tests/async_await/async_await_test.go
@@ -457,7 +457,8 @@ func (s *SuiteAsyncAwait) TestOnlyResponse() {
 func (s *SuiteAsyncAwait) checkAsyncContextEmpty(address types.Address) {
 	s.T().Helper()
 
-	contract := tests.GetContract(s.T(), s.Context, s.Shards[address.ShardId()].Db, address)
+	index := tests.InstanceId(address.ShardId()) - 1
+	contract := tests.GetContract(s.T(), s.Context, s.Instances[index].Db, address)
 	s.Require().Equal(common.EmptyHash, contract.AsyncContextRoot)
 }
 

--- a/nil/tests/cli/cli_test.go
+++ b/nil/tests/cli/cli_test.go
@@ -47,7 +47,7 @@ func (s *SuiteCliBase) SetupSuite() {
 
 func (s *SuiteCliBase) SetupTest() {
 	s.Start(&nilservice.Config{
-		NShards:              5,
+		NShards:              3,
 		CollatorTickPeriodMs: 200,
 	}, s.basePort)
 

--- a/nil/tests/common.go
+++ b/nil/tests/common.go
@@ -126,6 +126,18 @@ func WaitZerostate(t *testing.T, ctx context.Context, client client.Client, shar
 	WaitBlock(t, ctx, client, shardId, 0)
 }
 
+func WaitShardTick(t *testing.T, ctx context.Context, client client.Client, shardId types.ShardId) {
+	t.Helper()
+
+	block, err := client.GetBlock(ctx, shardId, "latest", false)
+	require.NoError(t, err)
+
+	require.Eventuallyf(t, func() bool {
+		block, err := client.GetBlock(ctx, shardId, transport.BlockNumber(block.Number+1), false)
+		return err == nil && block != nil
+	}, ShardTickWaitTimeout, ShardTickPollInterval, "Failed to wait for shard %d tick after block %d", shardId, block.Number)
+}
+
 func GetBalance(t *testing.T, ctx context.Context, client client.Client, address types.Address) types.Value {
 	t.Helper()
 	balance, err := client.GetBalance(ctx, address, "latest")

--- a/nil/tests/config/config_test.go
+++ b/nil/tests/config/config_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"crypto/rand"
 	"testing"
 
@@ -9,7 +8,6 @@ import (
 	"github.com/NilFoundation/nil/nil/internal/collate"
 	"github.com/NilFoundation/nil/nil/internal/config"
 	"github.com/NilFoundation/nil/nil/internal/contracts"
-	"github.com/NilFoundation/nil/nil/internal/db"
 	"github.com/NilFoundation/nil/nil/internal/execution"
 	"github.com/NilFoundation/nil/nil/internal/keys"
 	"github.com/NilFoundation/nil/nil/internal/types"
@@ -58,13 +56,6 @@ func (s *SuiteConfigParams) SetupSuite() {
 	}
 }
 
-func (s *SuiteConfigParams) SetupTest() {
-	var err error
-	s.Db, err = db.NewBadgerDbInMemory()
-	s.Require().NoError(err)
-	s.Context, s.CtxCancel = context.WithCancel(context.Background())
-}
-
 func (s *SuiteConfigParams) TearDownTest() {
 	s.Cancel()
 }
@@ -89,9 +80,9 @@ func (s *SuiteConfigParams) NewValidator() *config.ValidatorInfo {
 func (s *SuiteConfigParams) makeParamValidators(vals ...config.ValidatorInfo) config.ParamValidators {
 	s.T().Helper()
 
-	validators := make([]config.ListValidators, 0, s.ShardsNum)
-	for range s.ShardsNum {
-		validators = append(validators, config.ListValidators{List: vals})
+	validators := make([]config.ListValidators, s.ShardsNum-1)
+	for i := range validators {
+		validators[i] = config.ListValidators{List: vals}
 	}
 	return config.ParamValidators{Validators: validators}
 }

--- a/nil/tests/consensus/consensus_test.go
+++ b/nil/tests/consensus/consensus_test.go
@@ -30,28 +30,31 @@ func (s *SuiteConsensus) TearDownTest() {
 
 func (s *SuiteConsensus) TestConsensus() {
 	// Check block id grows
-	for shardId, shard := range s.Shards {
-		block, err := shard.Client.GetBlock(s.Context, types.ShardId(shardId), "latest", true)
-		s.Require().NoError(err)
-
-		s.Require().Eventually(func() bool {
-			newBlock, err := shard.Client.GetBlock(s.Context, types.ShardId(shardId), "latest", true)
+	for _, instance := range s.Instances {
+		for _, shardId := range instance.Config.MyShards {
+			block, err := instance.Client.GetBlock(s.Context, types.ShardId(shardId), "latest", true)
 			s.Require().NoError(err)
-			return newBlock != nil && newBlock.Number > block.Number
-		}, 30*time.Second, 1*time.Second)
+
+			s.Require().Eventually(func() bool {
+				newBlock, err := instance.Client.GetBlock(s.Context, types.ShardId(shardId), "latest", true)
+				s.Require().NoError(err)
+				return newBlock != nil && newBlock.Number > block.Number
+			}, 30*time.Second, 1*time.Second)
+		}
 	}
 
 	// Check that all validators have the same block
-	blocks := make([]*jsonrpc.RPCBlock, 0, len(s.Shards))
-	for id := range s.Shards {
-		block, err := s.Shards[0].Client.GetBlock(s.Context, types.ShardId(id), "latest", true)
+	nShards := s.GetNShards()
+	blocks := make([]*jsonrpc.RPCBlock, 0, nShards)
+	for id := range nShards {
+		block, err := s.Instances[0].Client.GetBlock(s.Context, types.ShardId(id), "latest", true)
 		s.Require().NoError(err)
 		blocks = append(blocks, block)
 	}
 
 	for _, block := range blocks {
-		for id := range s.Shards {
-			instanceBlock, err := s.Shards[id].Client.GetBlock(s.Context, block.ShardId, uint64(block.Number), false)
+		for _, instance := range s.Instances {
+			instanceBlock, err := instance.Client.GetBlock(s.Context, block.ShardId, uint64(block.Number), false)
 			s.Require().NoError(err)
 			s.Equal(block.Hash, instanceBlock.Hash)
 		}

--- a/nil/tests/faucet/faucet_test.go
+++ b/nil/tests/faucet/faucet_test.go
@@ -25,7 +25,7 @@ type SuiteFaucet struct {
 
 func (s *SuiteFaucet) SetupSuite() {
 	s.Start(&nilservice.Config{
-		NShards:              5,
+		NShards:              3,
 		CollatorTickPeriodMs: 200,
 	}, 10225)
 

--- a/nil/tests/rpc_node/rpc_node_test.go
+++ b/nil/tests/rpc_node/rpc_node_test.go
@@ -17,7 +17,7 @@ type SuiteRpcNode struct {
 
 func (s *SuiteRpcNode) SetupTest() {
 	port := 11001
-	nShards := uint32(5)
+	nShards := uint32(3)
 
 	s.Start(&nilservice.Config{
 		NShards: nShards,

--- a/nil/tests/rpc_suite.go
+++ b/nil/tests/rpc_suite.go
@@ -94,8 +94,9 @@ func (s *RpcSuite) Start(cfg *nilservice.Config) {
 
 	s.Wg.Add(1)
 	go func() {
-		nilservice.Run(s.Context, cfg, s.Db, serviceInterop)
-		s.Wg.Done()
+		defer s.Wg.Done()
+		rc := nilservice.Run(s.Context, cfg, s.Db, serviceInterop)
+		s.Require().Zero(rc)
 	}()
 
 	if cfg.RunMode == nilservice.CollatorsOnlyRunMode {

--- a/nil/tests/timeouts_no_race.go
+++ b/nil/tests/timeouts_no_race.go
@@ -5,8 +5,10 @@ package tests
 import "time"
 
 const (
-	ReceiptWaitTimeout  = 15 * time.Second
-	ReceiptPollInterval = 250 * time.Millisecond
-	BlockWaitTimeout    = 10 * time.Second
-	BlockPollInterval   = 100 * time.Millisecond
+	ReceiptWaitTimeout    = 15 * time.Second
+	ReceiptPollInterval   = 250 * time.Millisecond
+	BlockWaitTimeout      = 10 * time.Second
+	BlockPollInterval     = 100 * time.Millisecond
+	ShardTickWaitTimeout  = 30 * time.Second
+	ShardTickPollInterval = 1 * time.Second
 )

--- a/nil/tests/timeouts_race.go
+++ b/nil/tests/timeouts_race.go
@@ -5,8 +5,10 @@ package tests
 import "time"
 
 const (
-	ReceiptWaitTimeout  = time.Minute
-	ReceiptPollInterval = time.Second
-	BlockWaitTimeout    = 30 * time.Second
-	BlockPollInterval   = time.Second
+	ReceiptWaitTimeout    = time.Minute
+	ReceiptPollInterval   = time.Second
+	BlockWaitTimeout      = 30 * time.Second
+	BlockPollInterval     = time.Second
+	ShardTickWaitTimeout  = 300 * time.Second
+	ShardTickPollInterval = 10 * time.Second
 )


### PR DESCRIPTION
This patch enables consensus for the main shard. Now, it is validated by all available validators.
The list of validators is simply a collection of validators from all shards without duplicates.
The main issue is the tests since the sharded suite now has to wait for the zero shard to start ticking.

Need for #143