### PR TITLE
Allow to pass custom headers to http-transport in niljs

### DIFF
--- a/niljs/src/rpc/rpcClient.test.ts
+++ b/niljs/src/rpc/rpcClient.test.ts
@@ -8,3 +8,21 @@ test("creates a new RPC client with the correct endpoint", () => {
 
   expect(actualClient).not.toBeUndefined();
 });
+
+test("creates a new RPC client with the correct endpoint and headers", () => {
+  const actualClient = createRPCClient(endpoint, {
+    headers: {
+      "My-header": "my-value",
+    },
+  });
+
+  expect(actualClient).not.toBeUndefined();
+});
+
+test("throws an error when the headers are invalid (helps in JavaScript)", () => {
+  const headers = {
+    "Invalid-header": 333,
+  } as unknown as Record<string, string>;
+
+  expect(() => createRPCClient(endpoint, { headers })).toThrow();
+});

--- a/niljs/src/rpc/rpcClient.ts
+++ b/niljs/src/rpc/rpcClient.ts
@@ -1,5 +1,6 @@
 import { Client, HTTPTransport, RequestManager } from "@open-rpc/client-js";
 import fetch from "isomorphic-fetch";
+import { isValidHttpHeaders } from "../utils/rpc.js";
 import { version } from "../version.js";
 
 /**
@@ -7,6 +8,7 @@ import { version } from "../version.js";
  */
 type RPCClientOptions = {
   signal?: AbortSignal;
+  headers?: Record<string, string>;
 };
 
 /**
@@ -15,14 +17,17 @@ type RPCClientOptions = {
  * HTTP is currently the only supported transport.
  * @example const client = createRPCClient(RPC_ENDPOINT);
  */
-const createRPCClient = (endpoint: string, { signal }: RPCClientOptions = {}) => {
+const createRPCClient = (endpoint: string, { signal, headers = {} }: RPCClientOptions = {}) => {
   const fetcher: typeof fetch = (url, options) => {
     return fetch(url, { ...options, signal });
   };
 
+  isValidHttpHeaders(headers);
+
   const transport = new HTTPTransport(endpoint, {
     headers: {
       "Client-Version": version,
+      ...headers,
     },
     fetcher,
   });

--- a/niljs/src/transport/HttpTransport.ts
+++ b/niljs/src/transport/HttpTransport.ts
@@ -33,8 +33,8 @@ class HttpTransport implements ITransport {
    * @constructor
    * @param {IHttpTransportConfig} config The transport config. See {@link IHttpTransportConfig}.
    */
-  constructor({ endpoint, signal, timeout = 20000 }: IHttpTransportConfig) {
-    this.rpcClient = createRPCClient(endpoint, { signal });
+  constructor({ endpoint, signal, timeout = 20000, headers }: IHttpTransportConfig) {
+    this.rpcClient = createRPCClient(endpoint, { signal, headers });
     this.timeout = timeout;
   }
 

--- a/niljs/src/transport/types/IHttpTransportConfig.ts
+++ b/niljs/src/transport/types/IHttpTransportConfig.ts
@@ -21,6 +21,12 @@ type IHttpTransportConfig = {
    * @default undefined
    */
   signal?: AbortSignal;
+  /**
+   * The headers to be sent with the request.
+   * @example { 'My-header': 'my-value' }
+   * @default {}
+   */
+  headers?: Record<string, string>;
 };
 
 export type { IHttpTransportConfig };

--- a/niljs/src/utils/rpc.ts
+++ b/niljs/src/utils/rpc.ts
@@ -1,0 +1,15 @@
+function isValidHttpHeaders(headers: unknown) {
+  if (headers === null || typeof headers !== "object" || Array.isArray(headers)) {
+    throw new Error("Invalid headers provided to the RPC client.");
+  }
+
+  const isValidObj = Object.entries(headers).every(
+    ([key, value]) => typeof key === "string" && typeof value === "string",
+  );
+
+  if (!isValidObj) {
+    throw new Error("Invalid http headers provided to the RPC client.");
+  }
+}
+
+export { isValidHttpHeaders };


### PR DESCRIPTION
This pull request introduces several changes to enhance the handling of HTTP headers in the RPC client and transport layer. The most important changes include adding support for custom headers, validating headers, and updating the relevant tests.

Enhancements to HTTP headers handling:

* [`niljs/src/rpc/rpcClient.ts`](diffhunk://#diff-99c944131423541a8baddcc26ac57d0674b5baa283fdfc482382942501b60de8R4-R11): Introduced an optional `headers` parameter in the `RPCClientOptions` type and updated the `createRPCClient` function to include these headers in the HTTP transport configuration. Added a call to `isValidHttpHeaders` to validate the headers. [[1]](diffhunk://#diff-99c944131423541a8baddcc26ac57d0674b5baa283fdfc482382942501b60de8R4-R11) [[2]](diffhunk://#diff-99c944131423541a8baddcc26ac57d0674b5baa283fdfc482382942501b60de8L18-R30)
* [`niljs/src/transport/HttpTransport.ts`](diffhunk://#diff-f553b4cc26cdc0e129b21c7b1d15975db1c709395619d327081df32225ffb5b8L36-R37): Updated the `HttpTransport` class constructor to accept and pass the `headers` parameter to the `createRPCClient` function.
* [`niljs/src/transport/types/IHttpTransportConfig.ts`](diffhunk://#diff-b60bd08c8fc52cadc86ef16e91c65ea579ae2b6d71426658591d6ca5f58832ebR24-R29): Added an optional `headers` property to the `IHttpTransportConfig` type to support custom headers in the transport configuration.

Validation and utility functions:

* [`niljs/src/utils/rpc.ts`](diffhunk://#diff-3e23a9583f39323e0f281875eb9e53e5a13a2218c6c7e206a253090f3b5348dcR1-R18): Added the `isValidHttpHeaders` function to validate the structure and values of the provided headers. This function ensures that headers are either strings or arrays of strings.

Testing improvements:

* [`niljs/src/rpc/rpcClient.test.ts`](diffhunk://#diff-772781aeb7471c867e01df334c5c9b291447c3a763b5e61a66d9fd50c599ac8dR11-R28): Added new tests to verify the creation of an RPC client with custom headers and to ensure that invalid headers throw an error.