### PR TITLE
[consensus] don't start new round until previous one is not completely finished

### DIFF
--- a/nil/internal/collate/scheduler.go
+++ b/nil/internal/collate/scheduler.go
@@ -125,6 +125,9 @@ func (s *Scheduler) doCollate(ctx context.Context) error {
 
 	select {
 	case <-syncCh:
+		cancelFn()
+		err := <-consCh
+		s.logger.Debug().Err(err).Msg("Consensus interrupted by syncer")
 		return nil
 	case err := <-consCh:
 		return err


### PR DESCRIPTION
It could cause a race condition.

It could cause a race condition.
Imagine following case our validator started RunSequence but for some
reasons syncer got block before InsertProposal.
In that case we need to interrupt consensus sequence. And we do that
in defer (we call context cancel).
But seems some processes don't happen immediately. And we need to wait
for complete termination of RunSequence. Here we add two lines:
the first one cancels context (it will be called second time in defer but
seems it's safe in Go). And the second one just waits for some result from
RunSequence function. This delay should be quite quick.