### PR TITLE
prover: implement token methods, gas price, fix copy tracer on deploy

### DIFF
--- a/nil/internal/collate/proposer.go
+++ b/nil/internal/collate/proposer.go
@@ -78,7 +78,7 @@ func (p *proposer) GenerateProposal(ctx context.Context, txFabric db.DB) (*execu
 	}
 	defer tx.Rollback()
 
-	configAccessor, err := config.NewConfigAccessorTx(ctx, tx, nil)
+	configAccessor, err := config.NewConfigAccessorTx(tx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create config accessor: %w", err)
 	}

--- a/nil/internal/config/params.go
+++ b/nil/internal/config/params.go
@@ -174,7 +174,7 @@ func GetValidatorListForShard(
 		}
 	}
 
-	c, err := NewConfigAccessorTx(ctx, tx, &mainShardHash)
+	c, err := NewConfigAccessorTx(tx, &mainShardHash)
 	if errors.Is(err, db.ErrKeyNotFound) {
 		// It is possible that the needed main chain block has not arrived yet, or that this one is some byzantine block.
 		// Because right now the config is actually constant, we can use whatever version we like in this case,
@@ -184,7 +184,7 @@ func GetValidatorListForShard(
 			Stringer(logging.FieldBlockNumber, block.Id).
 			Stringer(logging.FieldBlockMainChainHash, mainShardHash).
 			Msg("Main chain block not found, using the latest accessible config")
-		c, err = NewConfigAccessorTx(ctx, tx, nil)
+		c, err = NewConfigAccessorTx(tx, nil)
 	}
 	if err != nil {
 		return nil, err

--- a/nil/internal/execution/transactions.go
+++ b/nil/internal/execution/transactions.go
@@ -7,6 +7,7 @@ import (
 	"github.com/NilFoundation/nil/nil/common/logging"
 	"github.com/NilFoundation/nil/nil/internal/tracing"
 	"github.com/NilFoundation/nil/nil/internal/types"
+	"github.com/NilFoundation/nil/nil/internal/vm"
 )
 
 var sharedLogger = logging.NewLogger("execution")
@@ -35,10 +36,10 @@ func (m dummyPayer) String() string {
 
 type transactionPayer struct {
 	transaction *types.Transaction
-	es          *ExecutionState
+	es          vm.StateDB
 }
 
-func NewTransactionPayer(transaction *types.Transaction, es *ExecutionState) Payer {
+func NewTransactionPayer(transaction *types.Transaction, es vm.StateDB) Payer {
 	// We don't charge system transactions
 	if transaction.IsSystem() {
 		return dummyPayer{}

--- a/nil/internal/types/block.go
+++ b/nil/internal/types/block.go
@@ -64,6 +64,7 @@ type RawBlockWithExtractedData struct {
 	Errors          map[common.Hash]string
 	ChildBlocks     []common.Hash
 	DbTimestamp     uint64
+	Config          map[string][]byte
 }
 
 type BlockWithExtractedData struct {
@@ -74,6 +75,7 @@ type BlockWithExtractedData struct {
 	Errors          map[common.Hash]string `json:"errors,omitempty"`
 	ChildBlocks     []common.Hash          `json:"childBlocks"`
 	DbTimestamp     uint64                 `json:"dbTimestamp"`
+	Config          map[string][]byte      `json:"config"`
 }
 
 // interfaces
@@ -111,6 +113,7 @@ func (b *RawBlockWithExtractedData) DecodeSSZ() (*BlockWithExtractedData, error)
 		Errors:          b.Errors,
 		ChildBlocks:     b.ChildBlocks,
 		DbTimestamp:     b.DbTimestamp,
+		Config:          b.Config,
 	}, nil
 }
 
@@ -139,6 +142,7 @@ func (b *BlockWithExtractedData) EncodeSSZ() (*RawBlockWithExtractedData, error)
 		Errors:          b.Errors,
 		ChildBlocks:     b.ChildBlocks,
 		DbTimestamp:     b.DbTimestamp,
+		Config:          b.Config,
 	}, nil
 }
 

--- a/nil/services/rpc/rawapi/local_block.go
+++ b/nil/services/rpc/rawapi/local_block.go
@@ -81,7 +81,7 @@ func (api *LocalShardApi) getBlockHashByReference(tx db.RoTx, blockReference raw
 func (api *LocalShardApi) getBlockByHash(tx db.RoTx, hash common.Hash, withTransactions bool) (*types.RawBlockWithExtractedData, error) {
 	accessor := api.accessor.RawAccess(tx, api.ShardId).GetBlock()
 	if withTransactions {
-		accessor = accessor.WithInTransactions().WithOutTransactions().WithReceipts().WithChildBlocks().WithDbTimestamp()
+		accessor = accessor.WithInTransactions().WithOutTransactions().WithReceipts().WithChildBlocks().WithDbTimestamp().WithConfig()
 	}
 
 	data, err := accessor.ByHash(hash)
@@ -112,6 +112,7 @@ func (api *LocalShardApi) getBlockByHash(tx db.RoTx, hash common.Hash, withTrans
 		result.Errors = make(map[common.Hash]string)
 		result.ChildBlocks = data.ChildBlocks()
 		result.DbTimestamp = data.DbTimestamp()
+		result.Config = data.Config()
 
 		// Need to decode transactions to get its hashes because external transaction hash
 		// calculated in a bit different way (not just Hash(SSZ)).

--- a/nil/services/rpc/rawapi/pb/conversion.go
+++ b/nil/services/rpc/rawapi/pb/conversion.go
@@ -280,6 +280,7 @@ func (rb *RawFullBlock) PackProtoMessage(block *types.RawBlockWithExtractedData)
 		Errors:             packErrorMap(block.Errors),
 		ChildBlocks:        PackHashes(block.ChildBlocks),
 		DbTimestamp:        block.DbTimestamp,
+		Config:             block.Config,
 	}
 	return nil
 }
@@ -313,6 +314,7 @@ func (rb *RawFullBlock) UnpackProtoMessage() (*types.RawBlockWithExtractedData, 
 		Errors:          unpackErrorMap(rb.Errors),
 		ChildBlocks:     UnpackHashes(rb.ChildBlocks),
 		DbTimestamp:     rb.DbTimestamp,
+		Config:          rb.Config,
 	}, nil
 }
 

--- a/nil/services/rpc/rawapi/proto/block.proto
+++ b/nil/services/rpc/rawapi/proto/block.proto
@@ -33,6 +33,7 @@ message RawFullBlock {
   map<string, Error> errors = 5;
   repeated Hash childBlocks = 6;
   uint64 dbTimestamp = 7;
+  map<string, bytes> config = 8;
 }
 
 message RawFullBlocks {

--- a/nil/services/synccommittee/prover/tracer/copy_tracer.go
+++ b/nil/services/synccommittee/prover/tracer/copy_tracer.go
@@ -203,7 +203,7 @@ var copyEventExtractors = map[vm.OpCode]copyEventExtractor{
 		if err != nil {
 			return copyEvent{}, err
 		}
-		data := getDataOverflowSafe(code, src, size)
+		data := getFixedSizeDataSafe(code, src, size)
 
 		return newFinalizedCopyEvent(CopyEvent{
 			From: CopyParticipant{
@@ -234,7 +234,7 @@ var copyEventExtractors = map[vm.OpCode]copyEventExtractor{
 		if err != nil {
 			return copyEvent{}, err
 		}
-		data := getDataOverflowSafe(code, src, size)
+		data := getFixedSizeDataSafe(code, src, size)
 
 		return newFinalizedCopyEvent(CopyEvent{
 			From: CopyParticipant{
@@ -256,7 +256,7 @@ var copyEventExtractors = map[vm.OpCode]copyEventExtractor{
 			dst  = tCtx.stack.PopUint64()
 			src  = tCtx.stack.PopUint64()
 			size = tCtx.stack.PopUint64()
-			data = getDataOverflowSafe(tCtx.vmCtx.CallInput(), src, size)
+			data = getFixedSizeDataSafe(tCtx.vmCtx.CallInput(), src, size)
 		)
 
 		return newFinalizedCopyEvent(CopyEvent{
@@ -278,7 +278,7 @@ var copyEventExtractors = map[vm.OpCode]copyEventExtractor{
 		var (
 			src  = tCtx.stack.PopUint64()
 			size = tCtx.stack.PopUint64()
-			data = tCtx.vmCtx.MemoryData()[src : src+size]
+			data = getDataIfRangeValid(tCtx.vmCtx.MemoryData(), src, size)
 		)
 
 		return newFinalizedCopyEvent(CopyEvent{
@@ -327,7 +327,7 @@ var copyEventExtractors = map[vm.OpCode]copyEventExtractor{
 			_    = tCtx.stack.Pop() // value
 			src  = tCtx.stack.PopUint64()
 			size = tCtx.stack.PopUint64()
-			data = tCtx.vmCtx.MemoryData()[src : src+size]
+			data = getDataIfRangeValid(tCtx.vmCtx.MemoryData(), src, size)
 		)
 		return newCopyEventWithFinalizer(CopyEvent{
 			From: CopyParticipant{
@@ -352,7 +352,7 @@ var copyEventExtractors = map[vm.OpCode]copyEventExtractor{
 			_    = tCtx.stack.Pop() // value
 			src  = tCtx.stack.PopUint64()
 			size = tCtx.stack.PopUint64()
-			data = tCtx.vmCtx.MemoryData()[src : src+size]
+			data = getDataIfRangeValid(tCtx.vmCtx.MemoryData(), src, size)
 		)
 
 		return newCopyEventWithFinalizer(CopyEvent{
@@ -382,7 +382,7 @@ var copyEventExtractors = map[vm.OpCode]copyEventExtractor{
 		var (
 			src  = tCtx.stack.PopUint64()
 			size = tCtx.stack.PopUint64()
-			data = tCtx.vmCtx.MemoryData()[src : src+size]
+			data = getDataIfRangeValid(tCtx.vmCtx.MemoryData(), src, size)
 		)
 
 		return newCopyEventWithFinalizer(CopyEvent{
@@ -427,7 +427,7 @@ func newLogCopyEvent(tCtx copyEventTraceContext) (copyEvent, error) {
 		return newEmptyCopyEvent(), nil
 	}
 
-	data := tCtx.vmCtx.MemoryData()[src : src+size]
+	data := getDataIfRangeValid(tCtx.vmCtx.MemoryData(), src, size)
 
 	return newFinalizedCopyEvent(CopyEvent{
 		From: CopyParticipant{

--- a/nil/services/synccommittee/prover/tracer/keccak_tracer.go
+++ b/nil/services/synccommittee/prover/tracer/keccak_tracer.go
@@ -36,7 +36,7 @@ func (kt *KeccakTracer) TraceOp(opCode vm.OpCode, opCtx tracing.OpContext) (bool
 		bufSize   = stack.PopUint64()
 	)
 
-	buf := getDataOverflowSafe(opCtx.MemoryData(), memOffset, bufSize)
+	buf := getFixedSizeDataSafe(opCtx.MemoryData(), memOffset, bufSize)
 	kt.hashes = append(kt.hashes, KeccakBuffer{
 		buf: buf,
 	})

--- a/nil/services/synccommittee/prover/tracer/tracer_mock_client_test.go
+++ b/nil/services/synccommittee/prover/tracer/tracer_mock_client_test.go
@@ -57,8 +57,9 @@ func (s *TracerMockClientTestSuite) addContract(addr types.Address, code []byte)
 func (s *TracerMockClientTestSuite) addCallContractTransaction(addr types.Address) {
 	s.inMsgs = append(s.inMsgs, &types.Transaction{
 		TransactionDigest: types.TransactionDigest{
-			To:        addr,
-			FeeCredit: types.GasToValue(1000000),
+			To:           addr,
+			FeeCredit:    types.GasToValue(1000000),
+			MaxFeePerGas: types.DefaultGasPrice,
 		},
 		From: s.smartAccount,
 	})
@@ -108,6 +109,7 @@ func (s *TracerMockClientTestSuite) makeClient() client.Client {
 		blockWithData := &types.BlockWithExtractedData{
 			Block:          block,
 			InTransactions: s.inMsgs,
+			Config:         make(map[string][]byte),
 		}
 		rawBlock, err := blockWithData.EncodeSSZ()
 		s.Require().NoError(err)

--- a/nil/services/synccommittee/prover/tracer/utils.go
+++ b/nil/services/synccommittee/prover/tracer/utils.go
@@ -2,11 +2,11 @@ package tracer
 
 import "github.com/NilFoundation/nil/nil/common"
 
-// getDataOverflowSafe returns a slice from the data based on the start and size and pads
+// getFixedSizeDataSafe returns a slice from the data based on the start and size and pads
 // up to size with zero's
 // This function is borrowed from EVM impl to process some opcodes
 // (CODECOPY, EXTCODECOPY, CALLDATACOPY) the same way as it does
-func getDataOverflowSafe(data []byte, start uint64, size uint64) []byte {
+func getFixedSizeDataSafe(data []byte, start uint64, size uint64) []byte {
 	length := uint64(len(data))
 	if start > length {
 		start = length
@@ -16,4 +16,17 @@ func getDataOverflowSafe(data []byte, start uint64, size uint64) []byte {
 		end = length
 	}
 	return common.RightPadBytes(data[start:end], int(size))
+}
+
+// getDataIfRangeValid returns a slice from `data` starting at `start` with a length of `size` bytes.
+// It returns nil if `size` is zero or if `start` is out of bounds.
+// Note: It does not check if `start+size` exceeds `data` length.
+func getDataIfRangeValid(data []byte, start uint64, size uint64) []byte {
+	if size == 0 {
+		return nil
+	}
+	if len(data) < int(start+size) {
+		return nil
+	}
+	return data[start : start+size]
 }


### PR DESCRIPTION
To enhance the tracing capabilities for a broader set of contracts, several new methods need to be implemented: `AddToken`, `SubToken`, `SetTokenTransfer`, `AddRefund`, `SubRefund`, and `GetGasPrice`. This pull request enables us to gather traces from every block produced by the `nil_load_generator`. 
Additionally, a bug in the copy tracer has been fixed; previously, there was a discrepancy between the execution EVM and the tracer EVM during the deployment transaction.