### PR TITLE
[tests] improve async_await test speed

### DIFF
--- a/nil/contracts/solidity/tests/Counter.sol
+++ b/nil/contracts/solidity/tests/Counter.sol
@@ -6,6 +6,10 @@ contract Counter {
 
     event eventValue(int32 value);
 
+    function set(int32 val) public {
+        value = val;
+    }
+
     function add(int32 val) public {
         value += val;
     }

--- a/nil/contracts/solidity/tests/RequestResponseTest.sol
+++ b/nil/contracts/solidity/tests/RequestResponseTest.sol
@@ -19,6 +19,13 @@ contract RequestResponseTest is NilTokenBase {
         return true;
     }
 
+    function reset() public {
+        value = 0;
+        counterValue = 0;
+        intValue = 0;
+        strValue = "";
+    }
+
     /**
      * Test sum of counters via awaitCall.
      */

--- a/nil/tests/async_await/async_await_test.go
+++ b/nil/tests/async_await/async_await_test.go
@@ -86,10 +86,8 @@ contracts:
 		"CounterAddress1":         s.counterAddress1.Hex(),
 	})
 	s.Require().NoError(err)
-}
 
-func (s *SuiteAsyncAwait) SetupTest() {
-	nShards := uint32(4)
+	nShards := uint32(3)
 	port := 10425
 
 	s.Start(&nilservice.Config{
@@ -101,7 +99,19 @@ func (s *SuiteAsyncAwait) SetupTest() {
 	s.DefaultClient, _ = s.StartRPCNode(tests.WithDhtBootstrapByValidators, network.AddrInfoSlice{archiveNodeAddr})
 }
 
-func (s *SuiteAsyncAwait) TearDownTest() {
+func (s *SuiteAsyncAwait) SetupTest() {
+	data := s.AbiPack(s.abiCounter, "set", int32(0))
+	receipt := s.SendExternalTransactionNoCheck(data, s.counterAddress0)
+	s.Require().True(receipt.AllSuccess())
+	receipt = s.SendExternalTransactionNoCheck(data, s.counterAddress1)
+	s.Require().True(receipt.AllSuccess())
+
+	data = s.AbiPack(s.abiTest, "reset")
+	receipt = s.SendExternalTransactionNoCheck(data, s.testAddress0)
+	s.Require().True(receipt.AllSuccess())
+}
+
+func (s *SuiteAsyncAwait) TearDownSuite() {
 	s.Cancel()
 }
 


### PR DESCRIPTION
This patch decrease a time that async_await test consumes from 90s to 25s. Here we reset contract values instead of recreate test server each time.