### PR TITLE
Introduce L1 Block fetcher

### DIFF
--- a/nil/Makefile.inc
+++ b/nil/Makefile.inc
@@ -3,13 +3,15 @@ include nil/services/synccommittee/Makefile.inc
 root_client = nil/client
 root_vm = nil/internal/vm
 root_db = nil/internal/db
+root_rollup = nil/services/rollup
 
 .PHONY: generate_mocks
 generate_mocks: \
 	$(root_client)/client_generated_mock.go \
 	$(root_vm)/state_generated_mock.go \
 	$(root_db)/rwtx_generated_mock.go \
-	$(root_db)/db_generated_mock.go
+	$(root_db)/db_generated_mock.go \
+	$(root_rollup)/l1_fetcher_generated_mock.go
 
 $(root_client)/client_generated_mock.go: $(root_client)/client.go ssz_types
 	cd $(root_client) && go generate
@@ -22,3 +24,6 @@ $(root_db)/rwtx_generated_mock.go: $(root_db)/kv.go ssz_types
 
 $(root_db)/db_generated_mock.go: $(root_db)/kv.go ssz_types
 	cd $(root_db) && go generate -run="db_" kv.go
+
+$(root_rollup)/l1_fetcher_generated_mock.go: $(root_rollup)/l1_fetcher.go
+	cd $(root_rollup) && go generate l1_fetcher.go

--- a/nil/contracts/generate.go
+++ b/nil/contracts/generate.go
@@ -3,6 +3,7 @@ package contracts
 import "embed"
 
 //go:generate bash -c "solc ../../smart-contracts/contracts/*.sol --bin --abi --overwrite -o ./compiled --no-cbor-metadata --metadata-hash none"
+//go:generate bash -c "solc solidity/system/*.sol --bin --abi --overwrite -o ./compiled/system --allow-paths ./solidity/lib --no-cbor-metadata --metadata-hash none"
 //go:generate bash -c "solc solidity/tests/*.sol --allow-paths ../../ --base-path ../../ --bin --abi --overwrite -o ./compiled/tests --no-cbor-metadata --metadata-hash none"
 //go:generate bash -c "ln -nsf ../.. @nilfoundation && solc ../../uniswap/contracts/*.sol --bin --abi --overwrite -o ./compiled/uniswap --allow-paths .,../.. --via-ir && rm @nilfoundation"
 //go:embed compiled/*

--- a/nil/contracts/solidity/system/L1BlockInfo.sol
+++ b/nil/contracts/solidity/system/L1BlockInfo.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import "../lib/Nil.sol";
+
+contract L1BlockInfo {
+    address public constant SELF_ADDRESS = address(0x222222222222222222222222222222222222);
+
+    function setL1BlockInfo(
+        uint64 _number,
+        uint64 _timestamp,
+        uint256 _baseFee,
+        uint256 _blobBaseFee,
+        bytes32 _hash
+    ) external {
+        require(msg.sender == SELF_ADDRESS, "setL1BlockInfo: only L1BlockInfo contract can be caller of this function");
+        Nil.setConfigParam("l1block", abi.encode(Nil.ParamL1BlockInfo(_number, _timestamp, _baseFee, _blobBaseFee, _hash)));
+    }
+}

--- a/nil/internal/collate/scheduler.go
+++ b/nil/internal/collate/scheduler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/NilFoundation/nil/nil/internal/execution"
 	"github.com/NilFoundation/nil/nil/internal/network"
 	"github.com/NilFoundation/nil/nil/internal/types"
+	"github.com/NilFoundation/nil/nil/services/rollup"
 	"github.com/NilFoundation/nil/nil/services/txnpool"
 	"github.com/rs/zerolog"
 )
@@ -38,6 +39,8 @@ type Params struct {
 	ZeroStateConfig *execution.ZeroStateConfig
 
 	Topology ShardTopology
+
+	L1Fetcher rollup.L1BlockFetcher
 }
 
 type Scheduler struct {
@@ -50,6 +53,8 @@ type Scheduler struct {
 	params Params
 
 	logger zerolog.Logger
+
+	l1Fetcher rollup.L1BlockFetcher
 }
 
 func NewScheduler(txFabric db.DB, pool txnpool.Pool, params Params, networkManager *network.Manager) *Scheduler {
@@ -61,6 +66,7 @@ func NewScheduler(txFabric db.DB, pool txnpool.Pool, params Params, networkManag
 		logger: logging.NewLogger("collator").With().
 			Stringer(logging.FieldShardId, params.ShardId).
 			Logger(),
+		l1Fetcher: params.L1Fetcher,
 	}
 }
 

--- a/nil/internal/config/config.go
+++ b/nil/internal/config/config.go
@@ -47,6 +47,7 @@ type configReader struct {
 // IConfigParam is an interface that all config params must implement.
 type IConfigParam interface {
 	ssz.Unmarshaler
+	ssz.Marshaler
 
 	Name() string
 	Accessor() *ParamAccessor

--- a/nil/internal/config/generate.go
+++ b/nil/internal/config/generate.go
@@ -1,3 +1,3 @@
 package config
 
-//go:generate go run github.com/NilFoundation/fastssz/sszgen --path params.go -include ../types/address.go,../types/uint256.go,../types/transaction.go --objs ListValidators,ParamValidators,ValidatorInfo,ParamGasPrice,ParamFees,WorkaroundToImportTypes
+//go:generate go run github.com/NilFoundation/fastssz/sszgen --path params.go -include ../types/address.go,../types/uint256.go,../types/transaction.go,../../common/hash.go,../../common/length.go --objs ListValidators,ParamValidators,ValidatorInfo,ParamGasPrice,ParamFees,ParamL1BlockInfo,WorkaroundToImportTypes

--- a/nil/internal/contracts/contract.go
+++ b/nil/internal/contracts/contract.go
@@ -19,6 +19,7 @@ const (
 	NameNilTokenBase  = "NilTokenBase"
 	NameNilBounceable = "NilBounceable"
 	NameNilConfigAbi  = "NilConfigAbi"
+	NameL1BlockInfo   = "system/L1BlockInfo"
 )
 
 var (

--- a/nil/internal/execution/state.go
+++ b/nil/internal/execution/state.go
@@ -1361,6 +1361,13 @@ func (es *ExecutionState) BuildBlock(blockId types.BlockNumber) (*BlockGeneratio
 		return nil, err
 	}
 
+	l1BlockNumber := uint64(0)
+	if es.ShardId.IsMainShard() {
+		if l1Block, err := config.GetParamL1Block(es.configAccessor); err == nil {
+			l1BlockNumber = l1Block.Number
+		}
+	}
+
 	configRoot := common.EmptyHash
 	if es.ShardId.IsMainShard() {
 		var err error
@@ -1390,6 +1397,7 @@ func (es *ExecutionState) BuildBlock(blockId types.BlockNumber) (*BlockGeneratio
 			MainChainHash:       es.MainChainHash,
 			BaseFee:             es.BaseFee,
 			GasUsed:             es.GasUsed,
+			L1BlockNumber:       l1BlockNumber,
 			// TODO(@klonD90): remove this field after changing explorer
 			Timestamp: 0,
 		},

--- a/nil/internal/execution/transactions.go
+++ b/nil/internal/execution/transactions.go
@@ -38,7 +38,11 @@ type transactionPayer struct {
 	es          *ExecutionState
 }
 
-func NewTransactionPayer(transaction *types.Transaction, es *ExecutionState) transactionPayer {
+func NewTransactionPayer(transaction *types.Transaction, es *ExecutionState) Payer {
+	// We don't charge system transactions
+	if transaction.IsSystem() {
+		return dummyPayer{}
+	}
 	return transactionPayer{
 		transaction: transaction,
 		es:          es,

--- a/nil/internal/execution/zerostate.go
+++ b/nil/internal/execution/zerostate.go
@@ -51,10 +51,15 @@ contracts:
   address: {{ .BtcFaucetAddress }}
   value: 100000000000000
   contract: FaucetToken
+- name: L1BlockInfo
+  address: {{ .L1BlockInfoAddress }}
+  value: 0
+  contract: system/L1BlockInfo
 `
 
 	DefaultZeroStateConfig, err = common.ParseTemplate(zerostate, map[string]interface{}{
 		"MainSmartAccountAddress": types.MainSmartAccountAddress.Hex(),
+		"L1BlockInfoAddress":      types.L1BlockInfoAddress.Hex(),
 		"MainPublicKey":           hexutil.Encode(MainPublicKey),
 		"MainSmartAccountPubKey":  hexutil.Encode(MainPublicKey),
 		"FaucetAddress":           types.FaucetAddress.Hex(),
@@ -185,11 +190,13 @@ func (es *ExecutionState) GenerateZeroState(stateConfig *ZeroStateConfig) error 
 	var err error
 
 	if es.ShardId == types.MainShardId {
-		err = config.SetParamValidators(es.GetConfigAccessor(), &stateConfig.ConfigParams.Validators)
+		cfgAccessor := es.GetConfigAccessor()
+		config.InitParams(cfgAccessor)
+		err = config.SetParamValidators(cfgAccessor, &stateConfig.ConfigParams.Validators)
 		if err != nil {
 			return err
 		}
-		err = config.SetParamGasPrice(es.GetConfigAccessor(), &stateConfig.ConfigParams.GasPrice)
+		err = config.SetParamGasPrice(cfgAccessor, &stateConfig.ConfigParams.GasPrice)
 		if err != nil {
 			return err
 		}

--- a/nil/internal/types/address.go
+++ b/nil/internal/types/address.go
@@ -29,6 +29,7 @@ var (
 	EthFaucetAddress        = ShardAndHexToAddress(BaseShardId, "111111111111111111111111111111111112")
 	UsdtFaucetAddress       = ShardAndHexToAddress(BaseShardId, "111111111111111111111111111111111113")
 	BtcFaucetAddress        = ShardAndHexToAddress(BaseShardId, "111111111111111111111111111111111114")
+	L1BlockInfoAddress      = ShardAndHexToAddress(MainShardId, "222222222222222222222222222222222222")
 )
 
 func GetTokenName(addr TokenId) string {

--- a/nil/internal/types/block.go
+++ b/nil/internal/types/block.go
@@ -49,6 +49,7 @@ type BlockData struct {
 	Timestamp           uint64           `json:"timestamp" ch:"timestamp"`
 	BaseFee             Value            `json:"gasPrice" ch:"gas_price"`
 	GasUsed             Gas              `json:"gasUsed" ch:"gas_used"`
+	L1BlockNumber       uint64           `json:"l1BlockNumber" ch:"l1_block_number"`
 }
 
 type Block struct {

--- a/nil/internal/types/ssz_test.go
+++ b/nil/internal/types/ssz_test.go
@@ -36,7 +36,7 @@ func TestSszBlock(t *testing.T) {
 	h, err := common.PoseidonSSZ(&block2)
 	require.NoError(t, err)
 
-	h2, err := hex.DecodeString("18f5d2ef18c2baeef2b6f477d923d3a1354e9760aacb110dc24fee7582472dcb")
+	h2, err := hex.DecodeString("012819c60900c4c6eeafb6d71e02aff10dd1d9b50dc0f081533d26115e2fa0c7")
 	require.NoError(t, err)
 
 	require.Equal(t, common.BytesToHash(h2), common.BytesToHash(h[:]))

--- a/nil/internal/types/transaction.go
+++ b/nil/internal/types/transaction.go
@@ -333,6 +333,9 @@ func (m *Transaction) VerifyFlags() error {
 	} else if m.IsRefund() || m.IsBounce() || m.IsRequestOrResponse() {
 		return errors.New("external transaction cannot be bounce, refund or async")
 	}
+	if m.To.ShardId().IsMainShard() && !m.From.ShardId().IsMainShard() {
+		return errors.New("transaction to main shard is not allowed from a regular shard")
+	}
 	return nil
 }
 
@@ -370,6 +373,10 @@ func (m *Transaction) IsRequest() bool {
 
 func (m *Transaction) IsRequestOrResponse() bool {
 	return m.RequestId != 0
+}
+
+func (m *Transaction) IsSystem() bool {
+	return m.To.ShardId().IsMainShard()
 }
 
 func (m *Transaction) TransactionGasPrice(baseFeePerGas Value) (Value, error) {

--- a/nil/services/cliservice/block_format_test.go
+++ b/nil/services/cliservice/block_format_test.go
@@ -148,7 +148,7 @@ func TestDebugBlockToText(t *testing.T) {
 		text, err := s.debugBlockToText(types.ShardId(13), block, false, false)
 		require.NoError(t, err)
 
-		expectedText := `Block #100500 [0x000d93541bc8aacce6715e281477aae775857ebc6e622991ef0a8d3f00e022b2] @ 13 shard
+		expectedText := `Block #100500 [0x000d9bb830d574ddf2973a367f2fe9d899c7c523afb809a1a7d2480ab9bcd4cf] @ 13 shard
   PrevBlock: 0x00000000000000000000000000000000000000000000000000000000deadbeef
   ChildBlocksRootHash: 0x00000000000000000000000000000000000000000000000000000000deadbabe
   ChildBlocks:

--- a/nil/services/nilservice/config.go
+++ b/nil/services/nilservice/config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/NilFoundation/nil/nil/internal/telemetry"
 	"github.com/NilFoundation/nil/nil/internal/types"
 	"github.com/NilFoundation/nil/nil/services/cometa"
+	"github.com/NilFoundation/nil/nil/services/rollup"
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
@@ -73,6 +74,8 @@ type Config struct {
 	Replay    *ReplayConfig              `yaml:"replay,omitempty"`
 	Cometa    *cometa.Config             `yaml:"cometa,omitempty"`
 	RpcNode   *RpcNodeConfig             `yaml:"rpcNode,omitempty"`
+
+	L1Fetcher rollup.L1BlockFetcher `yaml:"-"`
 }
 
 const DefaultNShards types.ShardId = 5

--- a/nil/services/rollup/eth.go
+++ b/nil/services/rollup/eth.go
@@ -1,0 +1,17 @@
+package rollup
+
+import (
+	"errors"
+
+	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/holiman/uint256"
+)
+
+func GetBlobGasPrice(header *types.Header) (*uint256.Int, error) {
+	if header.ExcessBlobGas == nil {
+		return nil, errors.New("GetBlobGasPrice: header is missing excessBlobGas")
+	}
+	v := eip4844.CalcBlobFee(*header.ExcessBlobGas)
+	return uint256.MustFromBig(v), nil
+}

--- a/nil/services/rollup/l1_fetcher.go
+++ b/nil/services/rollup/l1_fetcher.go
@@ -1,0 +1,112 @@
+package rollup
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/NilFoundation/nil/nil/common/concurrent"
+	"github.com/NilFoundation/nil/nil/common/logging"
+	l1types "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/rs/zerolog"
+)
+
+//go:generate go run github.com/matryer/moq -out l1_fetcher_generated_mock.go -rm -stub -with-resets . L1BlockFetcher
+
+const pollInterval = 5 * time.Second
+
+type L1BlockFetcher interface {
+	GetLastBlockInfo(ctx context.Context) (*l1types.Header, error)
+}
+
+type L1BlockFetcherRpc struct {
+	client    *rpc.Client
+	header    *l1types.Header
+	logger    zerolog.Logger
+	nodeIndex int
+}
+
+var rpcNodeList = []string{
+	"https://eth.llamarpc.com",
+	"https://eth-mainnet.public.blastapi.io",
+	"https://rpc.ankr.com/eth",
+	"https://eth-mainnet.public.blastapi.io",
+	"https://rpc.flashbots.net",
+	"https://cloudflare-eth.com",
+}
+
+func NewL1BlockFetcherRpc(ctx context.Context) L1BlockFetcher {
+	p := &L1BlockFetcherRpc{
+		logger: logging.NewLogger("l1fetcher"),
+	}
+	go func() {
+		p.Run(ctx)
+	}()
+	return p
+}
+
+func (p *L1BlockFetcherRpc) GetLastBlockInfo(ctx context.Context) (*l1types.Header, error) {
+	if p.header == nil {
+		return nil, errors.New("no blocks have been fetched yet")
+	}
+	return p.header, nil
+}
+
+func (p *L1BlockFetcherRpc) Run(ctx context.Context) {
+	p.fetch()
+	concurrent.RunTickerLoop(ctx, pollInterval, func(ctx context.Context) {
+		p.fetch()
+	})
+}
+
+func (p *L1BlockFetcherRpc) fetch() {
+	if p.client == nil {
+		if err := p.connect(); err != nil {
+			p.logger.Error().Err(err).Msg("failed to connect to L1")
+			return
+		}
+	}
+	err := p.client.Call(&p.header, "eth_getBlockByNumber", "latest", false)
+	if err != nil {
+		p.logger.Warn().
+			Err(err).
+			Str("node", rpcNodeList[p.nodeIndex]).
+			Msg("failed to get L1 last block")
+		if err = p.switchNode(); err != nil {
+			p.logger.Error().Err(err).Msg("failed to switch node")
+		}
+	}
+}
+
+func (p *L1BlockFetcherRpc) connect() error {
+	if p.client != nil {
+		p.client.Close()
+	}
+	var err error
+	if p.client, err = rpc.Dial(rpcNodeList[p.nodeIndex]); err != nil {
+		return fmt.Errorf("failed to connect to L1: %w", err)
+	}
+	return nil
+}
+
+func (p *L1BlockFetcherRpc) switchNode() error {
+	initialIndex := p.nodeIndex
+	for {
+		if p.nodeIndex == len(rpcNodeList)-1 {
+			p.nodeIndex = 0
+		} else {
+			p.nodeIndex++
+		}
+		p.logger.Info().Msgf("Switch to new provider: %s", rpcNodeList[p.nodeIndex])
+		err := p.connect()
+		if err == nil {
+			break
+		}
+		if p.nodeIndex == initialIndex {
+			return fmt.Errorf("all nodes are down, last error: %w", err)
+		}
+	}
+	return nil
+}

--- a/nil/services/rpc/jsonrpc/types.go
+++ b/nil/services/rpc/jsonrpc/types.go
@@ -64,6 +64,7 @@ type RPCInTransaction struct {
 // @componentprop Transactions transactions array true "The transactions included in the block."
 // @componentprop TransactionHashes string array true "The hashes of transactions included in the block."
 // @componentprop Number number integer true "The block number."
+// @componentprop L1Number number integer true "The L1 block number."
 // @componentprop ParentHash parentHash string true "The hash of the parent block."
 // @componentprop ReceiptsRoot receiptsRoot string true "The root of the block receipts."
 // @componentprop ShardId shardId integer true "The ID of the shard where the block was generated."
@@ -81,6 +82,7 @@ type RPCBlock struct {
 	MainChainHash       common.Hash         `json:"mainChainHash"`
 	DbTimestamp         uint64              `json:"dbTimestamp"`
 	BaseFee             types.Value         `json:"baseFee"`
+	L1Number            uint64              `json:"l1Number"`
 	LogsBloom           hexutil.Bytes       `json:"logsBloom,omitempty"`
 }
 
@@ -310,6 +312,7 @@ func NewRPCBlock(shardId types.ShardId, data *BlockWithEntities, fullTx bool) (*
 		DbTimestamp:         dbTimestamp,
 		BaseFee:             block.BaseFee,
 		LogsBloom:           bloom,
+		L1Number:            block.L1BlockNumber,
 	}, nil
 }
 

--- a/nil/services/synccommittee/prover/tracer/state_db.go
+++ b/nil/services/synccommittee/prover/tracer/state_db.go
@@ -215,6 +215,11 @@ func (tsdb *TracerStateDB) HandleInTransaction(transaction *types.Transaction) (
 		Str("flags", transaction.Flags.String()).
 		Msg("tracing in_transaction")
 
+	// Skip L1BlockInfo contract because it changes on-chain config.
+	if transaction.To == types.L1BlockInfoAddress {
+		return nil
+	}
+
 	// handlers below initialize EVM instance with tracer
 	// since tracer is not designed to return an error we just make it panic in case of failure and catch result here
 	// it will help us to analyze logical errors in tracer impl down by the callstack

--- a/nil/tests/common.go
+++ b/nil/tests/common.go
@@ -14,9 +14,11 @@ import (
 	"github.com/NilFoundation/nil/nil/internal/db"
 	"github.com/NilFoundation/nil/nil/internal/execution"
 	"github.com/NilFoundation/nil/nil/internal/types"
+	"github.com/NilFoundation/nil/nil/services/rollup"
 	"github.com/NilFoundation/nil/nil/services/rpc/jsonrpc"
 	"github.com/NilFoundation/nil/nil/services/rpc/transport"
 	"github.com/NilFoundation/nil/nil/tools/solc"
+	l1types "github.com/ethereum/go-ethereum/core/types"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -307,4 +309,14 @@ func GetContract(t *testing.T, ctx context.Context, database db.DB, address type
 	contract, err := contractTree.Fetch(address.Hash())
 	require.NoError(t, err)
 	return contract
+}
+
+var DummyL1Fetcher = rollup.L1BlockFetcherMock{
+	GetLastBlockInfoFunc: func(ctx context.Context) (*l1types.Header, error) {
+		return nil, nil
+	},
+}
+
+func GetDummyL1Fetcher() rollup.L1BlockFetcher {
+	return &DummyL1Fetcher
 }

--- a/nil/tests/l1info/l1info_test.go
+++ b/nil/tests/l1info/l1info_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"context"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/NilFoundation/nil/nil/internal/config"
+	"github.com/NilFoundation/nil/nil/internal/types"
+	"github.com/NilFoundation/nil/nil/services/nilservice"
+	"github.com/NilFoundation/nil/nil/services/rollup"
+	"github.com/NilFoundation/nil/nil/services/rpc"
+	"github.com/NilFoundation/nil/nil/tests"
+	l1types "github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/suite"
+)
+
+const numShards = 4
+
+type SuiteL1Info struct {
+	tests.RpcSuite
+	l1Fetcher *rollup.L1BlockFetcherMock
+}
+
+func (s *SuiteL1Info) SetupSuite() {
+	s.l1Fetcher = &rollup.L1BlockFetcherMock{}
+
+	excessBlobGas := uint64(1_000)
+
+	block := &l1types.Header{
+		Number:        big.NewInt(1),
+		BaseFee:       big.NewInt(1_000_000),
+		ExcessBlobGas: &excessBlobGas,
+	}
+	one := big.NewInt(1)
+	lastBlockTm := time.Now()
+	s.l1Fetcher.GetLastBlockInfoFunc = func(ctx context.Context) (*l1types.Header, error) {
+		if time.Since(lastBlockTm) >= 5*time.Second {
+			lastBlockTm = time.Now()
+			block.Number = block.Number.Add(block.Number, one)
+		}
+		return block, nil
+	}
+}
+
+func (s *SuiteL1Info) SetupTest() {
+	s.Start(&nilservice.Config{
+		NShards:              numShards,
+		HttpUrl:              rpc.GetSockPath(s.T()),
+		CollatorTickPeriodMs: 300,
+		RunMode:              nilservice.CollatorsOnlyRunMode,
+		L1Fetcher:            s.l1Fetcher,
+	})
+}
+
+func (s *SuiteL1Info) TearDownTest() {
+	s.Cancel()
+}
+
+func (s *SuiteL1Info) TestL1BlockUpdated() {
+	baseFee := types.NewUint256(1_000_000)
+	s.Require().Eventually(func() bool {
+		cfg := s.readConfig()
+		return cfg.Number != 0 && *baseFee == cfg.BaseFee
+	}, 2*time.Second, 500*time.Millisecond)
+
+	for i := range numShards {
+		block, err := s.Client.GetBlock(s.Context, types.ShardId(i), "latest", false)
+		s.Require().NoError(err)
+		s.Require().NotEqual(0, block.L1Number)
+	}
+}
+
+func (s *SuiteL1Info) readConfig() *config.ParamL1BlockInfo {
+	s.T().Helper()
+
+	roTx, err := s.Db.CreateRoTx(s.Context)
+	s.Require().NoError(err)
+	defer roTx.Rollback()
+
+	cfgAccessor, err := config.NewConfigReader(roTx, nil)
+	s.Require().NoError(err)
+	cfg, err := config.GetParamL1Block(cfgAccessor)
+	s.Require().NoError(err)
+	return cfg
+}
+
+func TestL1Info(t *testing.T) {
+	t.Parallel()
+
+	suite.Run(t, &SuiteL1Info{})
+}

--- a/nil/tests/rpc_suite.go
+++ b/nil/tests/rpc_suite.go
@@ -74,6 +74,10 @@ func (s *RpcSuite) Start(cfg *nilservice.Config) {
 	}
 	s.Db = s.DbInit()
 
+	if cfg.L1Fetcher == nil {
+		cfg.L1Fetcher = GetDummyL1Fetcher()
+	}
+
 	var serviceInterop chan nilservice.ServiceInterop
 	if cfg.RunMode == nilservice.CollatorsOnlyRunMode {
 		serviceInterop = make(chan nilservice.ServiceInterop, 1)

--- a/nil/tests/sharded_suite.go
+++ b/nil/tests/sharded_suite.go
@@ -167,6 +167,10 @@ func (s *ShardedSuite) start(
 	keysManagers := make(map[InstanceId]*keys.ValidatorKeysManager)
 	s.Instances = make([]Instance, instanceCount)
 
+	if cfg.L1Fetcher == nil {
+		cfg.L1Fetcher = GetDummyL1Fetcher()
+	}
+
 	for index := range InstanceId(instanceCount) {
 		keysPath := s.T().TempDir() + fmt.Sprintf("/validator-keys-%d.yaml", index)
 		km := keys.NewValidatorKeyManager(keysPath)
@@ -187,6 +191,7 @@ func (s *ShardedSuite) start(
 
 	for index := range InstanceId(instanceCount) {
 		shardConfig := shardCfgGen(s, index, cfg, networkConfigs[index], keysManagers)
+		shardConfig.L1Fetcher = cfg.L1Fetcher
 
 		node, err := nilservice.CreateNode(s.Context, fmt.Sprintf("shard-%d", index), shardConfig, s.Instances[index].Db, nil)
 		s.Require().NoError(err)

--- a/smart-contracts/contracts/Nil.sol
+++ b/smart-contracts/contracts/Nil.sol
@@ -408,6 +408,14 @@ library Nil {
         uint256[] shards;
     }
 
+    struct ParamL1BlockInfo {
+        uint64 number;
+        uint64 timestamp;
+        uint256 baseFee;
+        uint256 blobBaseFee;
+        bytes32 hash;
+    }
+
     /**
      * @dev Returns the current validators.
      * @return Struct containing the list of validators.
@@ -505,6 +513,7 @@ contract __Precompile__ {
 contract NilConfigAbi {
     function curr_validators(Nil.ParamValidators memory) public {}
     function gas_price(Nil.ParamGasPrice memory) public {}
+    function l1block(Nil.ParamL1BlockInfo memory) public {}
 }
 
 function tokenIdEqual(TokenId a, TokenId b) pure returns (bool) {


### PR DESCRIPTION
L1 Block fetcher is a service that fetches information about Ethereum blockchain and stores it in the on-chain config.
The workflow is as follows:
1. Poll Ethereum RPC nodes for new blocks at some interval.
2. Once new block is fetched, create new transaction to `L1BlockInfo` contract with L1blockInfo in calldata.
3. `L1BlockInfo` contract writes L1 block info to the config parameter `l1info`.
4. L1 block info is updated and stored in the on-chain config. Go to 1.