### PR TITLE
[execution] use specific main shard hash from block generation

### DIFF
--- a/nil/internal/collate/proposer_test.go
+++ b/nil/internal/collate/proposer_test.go
@@ -96,7 +96,7 @@ func (s *ProposerTestSuite) TestCollator() {
 		s.Require().NoError(err)
 		s.Require().NotNil(proposal)
 
-		blockGenerator, err := execution.NewBlockGenerator(s.ctx, params.BlockGeneratorParams, s.db)
+		blockGenerator, err := execution.NewBlockGenerator(s.ctx, params.BlockGeneratorParams, s.db, nil)
 		s.Require().NoError(err)
 		defer blockGenerator.Rollback()
 

--- a/nil/internal/collate/replay_scheduler.go
+++ b/nil/internal/collate/replay_scheduler.go
@@ -72,7 +72,7 @@ func (s *ReplayScheduler) doReplay(ctx context.Context, blockId types.BlockNumbe
 		return err
 	}
 
-	gen, err := execution.NewBlockGenerator(ctx, s.params.BlockGeneratorParams, s.txFabric)
+	gen, err := execution.NewBlockGenerator(ctx, s.params.BlockGeneratorParams, s.txFabric, proposal.GetMainShardHash(s.params.ShardId))
 	if err != nil {
 		return err
 	}

--- a/nil/internal/collate/syncer.go
+++ b/nil/internal/collate/syncer.go
@@ -403,7 +403,7 @@ func (s *Syncer) generateZerostate(ctx context.Context) error {
 
 	s.logger.Info().Msg("Generating zero-state...")
 
-	gen, err := execution.NewBlockGenerator(ctx, s.config.BlockGeneratorParams, s.db)
+	gen, err := execution.NewBlockGenerator(ctx, s.config.BlockGeneratorParams, s.db, &common.EmptyHash)
 	if err != nil {
 		return err
 	}
@@ -446,7 +446,12 @@ func (s *Syncer) replayBlocks(ctx context.Context, blocks []*types.BlockWithExtr
 }
 
 func (s *Syncer) replayBlock(ctx context.Context, block *types.BlockWithExtractedData) error {
-	gen, err := execution.NewBlockGenerator(ctx, s.config.BlockGeneratorParams, s.db)
+	mainShardHash := block.Block.MainChainHash
+	if s.config.ShardId.IsMainShard() {
+		mainShardHash = block.Block.PrevBlock
+	}
+
+	gen, err := execution.NewBlockGenerator(ctx, s.config.BlockGeneratorParams, s.db, &mainShardHash)
 	if err != nil {
 		return err
 	}

--- a/nil/internal/collate/validator.go
+++ b/nil/internal/collate/validator.go
@@ -31,7 +31,7 @@ func (s *Validator) BuildProposal(ctx context.Context) (*execution.Proposal, err
 }
 
 func (s *Validator) VerifyProposal(ctx context.Context, proposal *execution.Proposal) (*types.Block, error) {
-	gen, err := execution.NewBlockGenerator(ctx, s.params.BlockGeneratorParams, s.txFabric)
+	gen, err := execution.NewBlockGenerator(ctx, s.params.BlockGeneratorParams, s.txFabric, proposal.GetMainShardHash(s.params.ShardId))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create block generator: %w", err)
 	}
@@ -45,7 +45,7 @@ func (s *Validator) VerifyProposal(ctx context.Context, proposal *execution.Prop
 }
 
 func (s *Validator) InsertProposal(ctx context.Context, proposal *execution.Proposal, sig types.Signature) error {
-	gen, err := execution.NewBlockGenerator(ctx, s.params.BlockGeneratorParams, s.txFabric)
+	gen, err := execution.NewBlockGenerator(ctx, s.params.BlockGeneratorParams, s.txFabric, proposal.GetMainShardHash(s.params.ShardId))
 	if err != nil {
 		return fmt.Errorf("failed to create block generator: %w", err)
 	}

--- a/nil/internal/config/config.go
+++ b/nil/internal/config/config.go
@@ -236,7 +236,7 @@ func setParamImpl[T any](c ConfigAccessor, obj *T) error {
 
 func getConfigTrie(tx db.RoTx, mainShardHash *common.Hash) (*mpt.Reader, error) {
 	configTree := mpt.NewDbReader(tx, types.MainShardId, db.ConfigTrieTable)
-	lastBlock := mainShardHash == nil || mainShardHash.Empty()
+	lastBlock := mainShardHash == nil
 
 	var mainChainBlock *types.Block
 	var err error
@@ -247,7 +247,7 @@ func getConfigTrie(tx db.RoTx, mainShardHash *common.Hash) (*mpt.Reader, error) 
 			return nil, err
 		}
 	} else {
-		if mainChainBlock, err = db.ReadBlock(tx, types.MainShardId, *mainShardHash); err != nil {
+		if mainChainBlock, err = db.ReadBlock(tx, types.MainShardId, *mainShardHash); err != nil && !errors.Is(err, db.ErrKeyNotFound) {
 			return nil, err
 		}
 	}

--- a/nil/internal/execution/execution_state_test.go
+++ b/nil/internal/execution/execution_state_test.go
@@ -647,7 +647,7 @@ contracts:
 
 	params := NewBlockGeneratorParams(1, 2, types.DefaultGasPrice, 0)
 
-	gen, err := NewBlockGenerator(ctx, params, database)
+	gen, err := NewBlockGenerator(ctx, params, database, nil)
 	require.NoError(b, err)
 	_, err = gen.GenerateZeroState(zerostateCfg, nil)
 	require.NoError(b, err)
@@ -675,7 +675,7 @@ contracts:
 		tx, _ := database.CreateRwTx(ctx)
 		proposal.PrevBlockHash, _ = db.ReadLastBlockHash(tx, 1)
 
-		gen, err = NewBlockGenerator(ctx, params, database)
+		gen, err = NewBlockGenerator(ctx, params, database, nil)
 		require.NoError(b, err)
 		_, err = gen.GenerateBlock(proposal, logger, nil)
 		require.NoError(b, err)

--- a/nil/internal/execution/testaide.go
+++ b/nil/internal/execution/testaide.go
@@ -31,7 +31,7 @@ func GenerateZeroState(t *testing.T, ctx context.Context,
 
 	g, err := NewBlockGenerator(ctx,
 		NewBlockGeneratorParams(shardId, 1, types.DefaultGasPrice, 0),
-		txFabric)
+		txFabric, nil)
 	require.NoError(t, err)
 	defer g.Rollback()
 	block, err := g.GenerateZeroState(DefaultZeroStateConfig, nil)


### PR DESCRIPTION
It's not correct to rely on the latest block.
Main block can be committed earlier than current one that can lead to the case when we read data from a newer source.
We fixed almost the same issue before for `collectGasPrices` function because it affected consensus. This part can also affect it in some ways.