### PR TITLE
[log] fix spammy message level

### DIFF
--- a/nil/internal/collate/proposer.go
+++ b/nil/internal/collate/proposer.go
@@ -200,7 +200,7 @@ func (p *proposer) handleTransactionsFromPool() error {
 		if res := execution.ValidateExternalTransaction(p.executionState, txn); res.FatalError != nil {
 			return false, res.FatalError
 		} else if res.Failed() {
-			p.logger.Warn().Stringer(logging.FieldTransactionHash, hash).
+			p.logger.Info().Stringer(logging.FieldTransactionHash, hash).
 				Err(res.Error).Msg("External txn validation failed. Saved failure receipt. Dropping...")
 
 			execution.AddFailureReceipt(hash, txn.To, res)

--- a/nil/internal/network/pubsub.go
+++ b/nil/internal/network/pubsub.go
@@ -205,7 +205,7 @@ func (s *Subscription) Start(ctx context.Context, skipSelfMessages bool) <-chan 
 			}
 
 			if skipSelfMessages && msg.ReceivedFrom == s.self {
-				s.logger.Error().Msg("Skip message from self")
+				s.logger.Trace().Msg("Skip message from self")
 				s.counters.SkippedMessages.Add(1)
 				continue
 			}


### PR DESCRIPTION
Changed log level for two non-errors:
- message to self (trace)
- saved temporary fail receipt (info)