### PR TITLE
synccomittee(proposer): update to new L1 rollup contract, add blob tx

### DIFF
--- a/nil/services/synccommittee/core/proposer.go
+++ b/nil/services/synccommittee/core/proposer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/big"
 	"time"
 
 	"github.com/NilFoundation/nil/nil/common"
@@ -15,6 +14,7 @@ import (
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/storage"
 	scTypes "github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto/kzg4844"
 	"github.com/rs/zerolog"
 )
 
@@ -46,7 +46,7 @@ func NewDefaultProposerParams() *ProposerParams {
 	return &ProposerParams{
 		Endpoint:          "http://rpc2.sepolia.org",
 		PrivateKey:        "0000000000000000000000000000000000000000000000000000000000000001",
-		ContractAddress:   "0xB8E280a085c87Ed91dd6605480DD2DE9EC3699b4",
+		ContractAddress:   "0x796baf7E572948CD0cbC374f345963bA433b47a2",
 		ProposingInterval: 10 * time.Second,
 		EthClientTimeout:  10 * time.Second,
 	}
@@ -68,7 +68,7 @@ func NewProposer(
 		logger,
 	)
 
-	rollupContract, err := rollupcontract.NewWrapper(ctx, params.ContractAddress, params.PrivateKey, ethClient, params.EthClientTimeout)
+	rollupContract, err := rollupcontract.NewWrapper(ctx, params.ContractAddress, params.PrivateKey, ethClient, params.EthClientTimeout, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -173,7 +173,7 @@ func (p *Proposer) proposeNextBlock(ctx context.Context) error {
 }
 
 func (p *Proposer) getLatestProvedStateRoot(ctx context.Context) (common.Hash, error) {
-	var finalizedBatchIndex *big.Int
+	var finalizedBatchIndex string
 	err := p.retryRunner.Do(ctx, func(context.Context) error {
 		var err error
 		finalizedBatchIndex, err = p.rollupContract.FinalizedBatchIndex(ctx)
@@ -181,11 +181,6 @@ func (p *Proposer) getLatestProvedStateRoot(ctx context.Context) (common.Hash, e
 	})
 	if err != nil {
 		return common.EmptyHash, err
-	}
-
-	finalizedBatchIndex.Sub(finalizedBatchIndex, big.NewInt(1))
-	if finalizedBatchIndex.Cmp(big.NewInt(0)) == -1 {
-		return common.EmptyHash, errors.New("value returned from FinalizedBatchIndex is less than 1")
 	}
 
 	var latestProvedState [32]byte
@@ -198,38 +193,115 @@ func (p *Proposer) getLatestProvedStateRoot(ctx context.Context) (common.Hash, e
 	return latestProvedState, err
 }
 
-func (p *Proposer) sendProof(ctx context.Context, data *scTypes.ProposalData) error {
-	if data.OldProvedStateRoot.Empty() || data.NewProvedStateRoot.Empty() {
-		return errors.New("empty hash for state update transaction")
+func (p *Proposer) commitBatch(ctx context.Context, blobs []kzg4844.Blob, batchIndexInBlobStorage string) (*ethtypes.Transaction, bool, error) {
+	var tx *ethtypes.Transaction
+	batchTxSkipped := false
+	err := p.retryRunner.Do(ctx, func(context.Context) error {
+		var err error
+		tx, err = p.rollupContract.CommitBatch(ctx, blobs, batchIndexInBlobStorage)
+		if errors.Is(err, rollupcontract.ErrBatchAlreadyCommitted) {
+			p.logger.Warn().Msg("batch is already committed, skipping blob tx")
+			batchTxSkipped = true
+			return nil
+		}
+		return err
+	})
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to upload blob: %w", err)
 	}
+
+	if !batchTxSkipped {
+		p.logger.Info().
+			Hex("txHash", tx.Hash().Bytes()).
+			Int("gasLimit", int(tx.Gas())).
+			Int("blobGasLimit", int(tx.BlobGas())).
+			Int("cost", int(tx.Cost().Uint64())).
+			Any("blobHases", tx.BlobHashes()).
+			Msg("blob transaction sent")
+
+		receipt, err := p.rollupContract.WaitForReceipt(ctx, tx.Hash())
+		if err != nil {
+			return nil, false, err
+		}
+		if receipt == nil {
+			return nil, false, errors.New("CommitBatch tx mining timout exceeded")
+		}
+		if receipt.Status != ethtypes.ReceiptStatusSuccessful {
+			return nil, false, errors.New("CommitBatch tx failed")
+		}
+	}
+
+	return tx, batchTxSkipped, nil
+}
+
+func (p *Proposer) updateState(ctx context.Context, tx *ethtypes.Transaction, data *scTypes.ProposalData, batchIndexInBlobStorage string) error {
+	blobTxSidecar := tx.BlobTxSidecar()
+	dataProofs, err := rollupcontract.ComputeDataProofs(blobTxSidecar)
+	if err != nil {
+		return err
+	}
+
+	// TODO: populate with actual data
+	validityProof := []byte{0x0A, 0x0B, 0x0C}
 
 	p.logger.Info().
 		Stringer("blockHash", data.MainShardBlockHash).
 		Int("txCount", len(data.Transactions)).
-		Msg("sending proof to L1")
+		Msg("calling UpdateState L1 method")
 
-	proof := make([]byte, 0)
-	batchIndexInBlobStorage := big.NewInt(0)
-
-	var tx *ethtypes.Transaction
-	err := p.retryRunner.Do(ctx, func(context.Context) error {
+	updateTxSkipped := false
+	err = p.retryRunner.Do(ctx, func(context.Context) error {
 		var err error
-		tx, err = p.rollupContract.ProofBatch(ctx, data.OldProvedStateRoot, data.NewProvedStateRoot, proof, batchIndexInBlobStorage)
+		tx, err = p.rollupContract.UpdateState(
+			ctx,
+			batchIndexInBlobStorage,
+			data.OldProvedStateRoot,
+			data.NewProvedStateRoot,
+			dataProofs,
+			blobTxSidecar.BlobHashes(),
+			validityProof,
+			rollupcontract.INilRollupPublicDataInfo{
+				Placeholder1: []byte{0x07, 0x08, 0x09},
+				Placeholder2: []byte{0x07, 0x08, 0x09},
+			},
+		)
+		if errors.Is(err, rollupcontract.ErrBatchAlreadyFinalized) {
+			p.logger.Warn().Msg("batch is already committed, skipping UpdateState tx")
+			updateTxSkipped = true
+			return nil
+		}
 		return err
 	})
 	if err != nil {
-		return fmt.Errorf("failed to update state (eth_sendRawTransaction): %w", err)
+		return fmt.Errorf("failed to update state: %w", err)
 	}
 
-	p.logger.Info().
-		Hex("txHash", tx.Hash().Bytes()).
-		Int("gasLimit", int(tx.Gas())).
-		Int("blobGasLimit", int(tx.BlobGas())).
-		Int("cost", int(tx.Cost().Uint64())).
-		Msg("rollup transaction sent")
+	if !updateTxSkipped {
+		p.logger.Info().
+			Hex("txHash", tx.Hash().Bytes()).
+			Int("gasLimit", int(tx.Gas())).
+			Int("cost", int(tx.Cost().Uint64())).
+			Msg("UpdateState transaction sent")
 
-	// TODO send bloob with transactions and KZG proof
+		p.metrics.RecordProposerTxSent(ctx, data)
+	}
 
-	p.metrics.RecordProposerTxSent(ctx, data)
+	return nil
+}
+
+func (p *Proposer) sendProof(ctx context.Context, data *scTypes.ProposalData) error {
+	// TODO: populate with actual data
+	blobs := []kzg4844.Blob{{0x01}, {0x02}, {0x03}}
+	batchIndexInBlobStorage := "0x0000000000000000000000000000000000000000000000000000000000000001"
+
+	tx, _, err := p.commitBatch(ctx, blobs, batchIndexInBlobStorage)
+	if err != nil {
+		return err
+	}
+
+	if err := p.updateState(ctx, tx, data, batchIndexInBlobStorage); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/nil/services/synccommittee/core/proposer_test.go
+++ b/nil/services/synccommittee/core/proposer_test.go
@@ -2,6 +2,8 @@ package core
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -12,6 +14,7 @@ import (
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/rollupcontract"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/storage"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/testaide"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
 	ethereum "github.com/ethereum/go-ethereum"
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
@@ -24,12 +27,75 @@ type ProposerTestSuite struct {
 	ctx          context.Context
 	cancellation context.CancelFunc
 
-	params    *ProposerParams
-	db        db.DB
-	timer     common.Timer
-	storage   storage.BlockStorage
-	ethClient *rollupcontract.EthClientMock
-	proposer  *Proposer
+	params           *ProposerParams
+	db               db.DB
+	timer            common.Timer
+	storage          storage.BlockStorage
+	ethClient        *rollupcontract.EthClientMock
+	proposer         *Proposer
+	testData         *types.ProposalData
+	callContractMock *callContractMock
+}
+
+type callContractMock struct {
+	methodsReturnValue map[string][][]interface{}
+}
+
+func newCallContractMock() *callContractMock {
+	callContractMock := callContractMock{}
+	callContractMock.Reset()
+	return &callContractMock
+}
+
+func (c *callContractMock) Reset() {
+	c.methodsReturnValue = make(map[string][][]interface{})
+}
+
+type noValue struct{}
+
+func (c *callContractMock) AddExpectedCall(methodName string, returnValues ...interface{}) {
+	c.methodsReturnValue[methodName] = append(c.methodsReturnValue[methodName], returnValues)
+}
+
+func (c *callContractMock) CallContract(ctx context.Context, call ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+	abi, err := rollupcontract.RollupcontractMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	methodId := call.Data[:4]
+	method, err := abi.MethodById(methodId)
+	if err != nil {
+		return nil, err
+	}
+
+	returnValuesSlice, ok := c.methodsReturnValue[method.Name]
+	if !ok {
+		return nil, errors.New("method not mocked")
+	}
+
+	if len(returnValuesSlice) == 0 {
+		return nil, errors.New("not enough return values for method")
+	}
+	returnValues := returnValuesSlice[0]
+	c.methodsReturnValue[method.Name] = returnValuesSlice[1:]
+
+	if len(returnValues) == 1 {
+		if _, ok := returnValues[0].(noValue); ok {
+			// If it's noValue, call Pack with no arguments
+			return method.Outputs.Pack()
+		}
+	}
+
+	return method.Outputs.Pack(returnValues...)
+}
+
+func (c *callContractMock) EverythingCalled() error {
+	for methodName, returnValues := range c.methodsReturnValue {
+		if len(returnValues) != 0 {
+			return fmt.Errorf("not all calls were executed for %s", methodName)
+		}
+	}
+	return nil
 }
 
 func TestProposerSuite(t *testing.T) {
@@ -50,16 +116,26 @@ func (s *ProposerTestSuite) SetupSuite() {
 	s.timer = testaide.NewTestTimer()
 	s.storage = storage.NewBlockStorage(s.db, s.timer, metricsHandler, logger)
 	s.params = NewDefaultProposerParams()
+	s.testData = testaide.NewProposalData(3, s.timer.NowTime())
+	s.callContractMock = newCallContractMock()
 	s.ethClient = &rollupcontract.EthClientMock{
-		CallContractFunc: func(ctx context.Context, call ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
-			return []byte{123}, nil
-		},
+		CallContractFunc:    s.callContractMock.CallContract,
 		EstimateGasFunc:     func(ctx context.Context, call ethereum.CallMsg) (uint64, error) { return 123, nil },
 		SuggestGasPriceFunc: func(ctx context.Context) (*big.Int, error) { return big.NewInt(123), nil },
-		HeaderByNumberFunc:  func(ctx context.Context, number *big.Int) (*ethtypes.Header, error) { return &ethtypes.Header{}, nil },
-		PendingCodeAtFunc:   func(ctx context.Context, account ethcommon.Address) ([]byte, error) { return []byte{123}, nil },
-		PendingNonceAtFunc:  func(ctx context.Context, account ethcommon.Address) (uint64, error) { return 123, nil },
-		ChainIDFunc:         func(ctx context.Context) (*big.Int, error) { return big.NewInt(0), nil },
+		HeaderByNumberFunc: func(ctx context.Context, number *big.Int) (*ethtypes.Header, error) {
+			excessBlobGas := uint64(123)
+			return &ethtypes.Header{BaseFee: big.NewInt(123), ExcessBlobGas: &excessBlobGas}, nil
+		},
+		PendingCodeAtFunc:    func(ctx context.Context, account ethcommon.Address) ([]byte, error) { return []byte{123}, nil },
+		PendingNonceAtFunc:   func(ctx context.Context, account ethcommon.Address) (uint64, error) { return 123, nil },
+		ChainIDFunc:          func(ctx context.Context) (*big.Int, error) { return big.NewInt(0), nil },
+		SuggestGasTipCapFunc: func(ctx context.Context) (*big.Int, error) { return big.NewInt(123), nil },
+		CodeAtFunc: func(ctx context.Context, contract ethcommon.Address, blockNumber *big.Int) ([]byte, error) {
+			return []byte{123}, nil
+		},
+		TransactionReceiptFunc: func(ctx context.Context, txHash ethcommon.Hash) (*ethtypes.Receipt, error) {
+			return &ethtypes.Receipt{Status: ethtypes.ReceiptStatusSuccessful}, nil
+		},
 	}
 	s.proposer, err = NewProposer(s.ctx, s.params, s.storage, s.ethClient, metricsHandler, logger)
 	s.Require().NoError(err)
@@ -69,6 +145,7 @@ func (s *ProposerTestSuite) SetupTest() {
 	err := s.db.DropAll()
 	s.Require().NoError(err, "failed to clear database in SetUpTest")
 	s.ethClient.ResetCalls()
+	s.callContractMock.Reset()
 }
 
 func (s *ProposerTestSuite) TearDownSuite() {
@@ -76,10 +153,55 @@ func (s *ProposerTestSuite) TearDownSuite() {
 }
 
 func (s *ProposerTestSuite) TestSendProof() {
-	data := testaide.NewProposalData(3, s.timer.NowTime())
+	// Calls inside CommitBatch
+	s.callContractMock.AddExpectedCall("isBatchCommitted", false)
+	// Calls inside UpdateState
+	s.callContractMock.AddExpectedCall("verifyDataProof", noValue{})
+	s.callContractMock.AddExpectedCall("verifyDataProof", noValue{})
+	s.callContractMock.AddExpectedCall("verifyDataProof", noValue{})
+	s.callContractMock.AddExpectedCall("isBatchFinalized", false)
+	s.callContractMock.AddExpectedCall("isBatchCommitted", true)
+	s.callContractMock.AddExpectedCall("lastFinalizedBatchIndex", "testingFinalizedBatchIndex")
+	s.callContractMock.AddExpectedCall("finalizedStateRoots", s.testData.OldProvedStateRoot)
 
-	err := s.proposer.sendProof(s.ctx, data)
+	err := s.proposer.sendProof(s.ctx, s.testData)
+	s.Require().NoError(err, "failed to send proof")
+
+	s.Require().NoError(s.callContractMock.EverythingCalled())
+	s.Require().Len(s.ethClient.SendTransactionCalls(), 2, "wrong number of calls to rpc client")
+}
+
+// Only UpdateState tx should be created
+func (s *ProposerTestSuite) TestSendProofCommitedBatch() {
+	// Calls inside CommitBatch
+	s.callContractMock.AddExpectedCall("isBatchCommitted", true)
+	// Calls inside UpdateState
+	s.callContractMock.AddExpectedCall("verifyDataProof", noValue{})
+	s.callContractMock.AddExpectedCall("verifyDataProof", noValue{})
+	s.callContractMock.AddExpectedCall("verifyDataProof", noValue{})
+	s.callContractMock.AddExpectedCall("isBatchFinalized", false)
+	s.callContractMock.AddExpectedCall("isBatchCommitted", true)
+	s.callContractMock.AddExpectedCall("lastFinalizedBatchIndex", "testingFinalizedBatchIndex")
+	s.callContractMock.AddExpectedCall("finalizedStateRoots", s.testData.OldProvedStateRoot)
+
+	err := s.proposer.sendProof(s.ctx, s.testData)
 	s.Require().NoError(err, "failed to send proof")
 
 	s.Require().Len(s.ethClient.SendTransactionCalls(), 1, "wrong number of calls to rpc client")
+}
+
+// No tx should be created
+func (s *ProposerTestSuite) TestSendProofFinalizedBatch() {
+	// Calls inside CommitBatch
+	s.callContractMock.AddExpectedCall("isBatchCommitted", true)
+	// Calls inside UpdateState
+	s.callContractMock.AddExpectedCall("verifyDataProof", noValue{})
+	s.callContractMock.AddExpectedCall("verifyDataProof", noValue{})
+	s.callContractMock.AddExpectedCall("verifyDataProof", noValue{})
+	s.callContractMock.AddExpectedCall("isBatchFinalized", true)
+
+	err := s.proposer.sendProof(s.ctx, s.testData)
+	s.Require().NoError(err, "failed to send proof")
+
+	s.Require().Empty(s.ethClient.SendTransactionCalls(), "no tx should be created")
 }

--- a/nil/services/synccommittee/internal/rollupcontract/abi.json
+++ b/nil/services/synccommittee/internal/rollupcontract/abi.json
@@ -1,47 +1,1515 @@
-[{
-    "type": "function",
-    "name": "proofBatch",
-    "inputs": [{
-        "name": "_prevStateRoot",
-        "type": "bytes32"
-      },
-      {
-        "name": "_newStateRoot",
-        "type": "bytes32"
-      },
-      {
-        "name": "_blobProof",
-        "type": "bytes"
-      },
-      {
-        "name": "_batchIndexInBlobStorage",
-        "type": "uint256"
-      }
-    ]
+[
+  {
+    "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
   },
   {
     "inputs": [],
-    "name": "finalizedBatchIndex",
-    "outputs": [{
-      "internalType": "uint256",
-      "name": "",
-      "type": "uint256"
-    }],
+    "name": "AccessControlBadConfirmation",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "neededRole",
+        "type": "bytes32"
+      }
+    ],
+    "name": "AccessControlUnauthorizedAccount",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "EnforcedPause",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "batchIndex",
+        "type": "string"
+      }
+    ],
+    "name": "ErrorBatchAlreadyCommitted",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "batchIndex",
+        "type": "string"
+      }
+    ],
+    "name": "ErrorBatchAlreadyFinalized",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "batchIndex",
+        "type": "string"
+      }
+    ],
+    "name": "ErrorBatchNotCommitted",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ErrorCallEvaluationPrecompileFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ErrorCallPointEvaluationPrecompileFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ErrorCallerIsNotAdmin",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ErrorCallerIsNotProposer",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "dataProofCount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "committedBlobCount",
+        "type": "uint256"
+      }
+    ],
+    "name": "ErrorDataProofsAndBlobCountMismatch",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ErrorEmptyDataProofs",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ErrorEvaluationPrecompileOutputWrong",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ErrorIncorrectDataProofSize",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ErrorInvalidBatchIndex",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ErrorInvalidChainID",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "proofIndex",
+        "type": "uint256"
+      }
+    ],
+    "name": "ErrorInvalidDataProofItem",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ErrorInvalidDefaultAdmin",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ErrorInvalidNewStateRoot",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ErrorInvalidNilVerifier",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ErrorInvalidOldStateRoot",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ErrorInvalidOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ErrorInvalidPublicInputForProof",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ErrorInvalidValidityProof",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "batchIndex",
+        "type": "string"
+      },
+      {
+        "internalType": "uint256",
+        "name": "blobIndex",
+        "type": "uint256"
+      }
+    ],
+    "name": "ErrorInvalidVersionedHash",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "batchIndex",
+        "type": "string"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "newStateRoot",
+        "type": "bytes32"
+      }
+    ],
+    "name": "ErrorNewStateRootAlreadyFinalized",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ErrorNilVerifierAddressNotChanged",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ErrorOldStateRootMismatch",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ErrorUnexpectedPointEvaluationPrecompileOutput",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ExpectedPause",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidInitialization",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotInitializing",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnableInvalidOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "OwnableUnauthorizedAccount",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      }
+    ],
+    "name": "Unauthorized",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "string",
+        "name": "batchIndex",
+        "type": "string"
+      }
+    ],
+    "name": "BatchCommitted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "version",
+        "type": "uint64"
+      }
+    ],
+    "name": "Initialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferStarted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Paused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "previousAdminRole",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "newAdminRole",
+        "type": "bytes32"
+      }
+    ],
+    "name": "RoleAdminChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleGranted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleRevoked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "string",
+        "name": "batchIndex",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "oldStateRoot",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "newStateRoot",
+        "type": "bytes32"
+      }
+    ],
+    "name": "StateRootUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Unpaused",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "DEFAULT_ADMIN_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
-    "inputs": [{
-      "internalType": "uint256",
-      "name": "",
-      "type": "uint256"
-    }],
-    "name": "stateRoots",
-    "outputs": [{
-      "internalType": "bytes32",
-      "name": "",
-      "type": "bytes32"
-    }],
+    "inputs": [],
+    "name": "GENESIS_BATCH_INDEX",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "OWNER_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "POINT_EVALUATION_PRECOMPILE_ADDR",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "PROPOSER_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "PROPOSER_ROLE_ADMIN",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "acceptOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "acceptOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "addAdmin",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "stateRoot",
+        "type": "bytes32"
+      }
+    ],
+    "name": "batchIndexOfRoot",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "name": "batchInfoRecords",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "batchIndex",
+        "type": "string"
+      },
+      {
+        "internalType": "bool",
+        "name": "isCommitted",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "isFinalized",
+        "type": "bool"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "oldStateRoot",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "newStateRoot",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "validityProof",
+        "type": "bytes"
+      },
+      {
+        "components": [
+          {
+            "internalType": "bytes",
+            "name": "placeholder1",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "placeholder2",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct INilRollup.PublicDataInfo",
+        "name": "publicDataInputs",
+        "type": "tuple"
+      },
+      {
+        "internalType": "uint256",
+        "name": "blobCount",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "batchIndex",
+        "type": "string"
+      },
+      {
+        "internalType": "uint256",
+        "name": "blobCount",
+        "type": "uint256"
+      }
+    ],
+    "name": "commitBatch",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "adminRole",
+        "type": "bytes32"
+      }
+    ],
+    "name": "createNewRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "batchIndex",
+        "type": "string"
+      }
+    ],
+    "name": "finalizedStateRoots",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "batchIndex",
+        "type": "string"
+      },
+      {
+        "components": [
+          {
+            "internalType": "bytes",
+            "name": "placeholder1",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "placeholder2",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct INilRollup.PublicDataInfo",
+        "name": "publicDataInfo",
+        "type": "tuple"
+      }
+    ],
+    "name": "generatePublicInputForValidityProofVerification",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAllAdmins",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAllProposers",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "getBlobHash",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "batchIndex",
+        "type": "string"
+      }
+    ],
+    "name": "getBlobVersionedHashes",
+    "outputs": [
+      {
+        "internalType": "bytes32[]",
+        "name": "",
+        "type": "bytes32[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getLastCommittedBatchIndex",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getLastFinalizedBatchIndex",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getOwner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getRoleAdmin",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "getRoleMember",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getRoleMemberCount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getRoleMembers",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "grantAccess",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "grantProposerAccess",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "grantProposerAdminRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "grantRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "hasRole",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "_l2ChainId",
+        "type": "uint64"
+      },
+      {
+        "internalType": "address",
+        "name": "_owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_defaultAdmin",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_nilVerifierAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_proposer",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_genesisStateRoot",
+        "type": "bytes32"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "proposerArg",
+        "type": "address"
+      }
+    ],
+    "name": "isAProposer",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "adminArg",
+        "type": "address"
+      }
+    ],
+    "name": "isAnAdmin",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "ownerArg",
+        "type": "address"
+      }
+    ],
+    "name": "isAnOwner",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "batchIndex",
+        "type": "string"
+      }
+    ],
+    "name": "isBatchCommitted",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "batchIndex",
+        "type": "string"
+      }
+    ],
+    "name": "isBatchFinalized",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_stateRoot",
+        "type": "bytes32"
+      }
+    ],
+    "name": "isRootFinalized",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "l2ChainId",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lastCommittedBatchIndex",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lastFinalizedBatchIndex",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "nilVerifierAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "paused",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pendingOwner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "removeAdmin",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      }
+    ],
+    "name": "renounceAccess",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "callerConfirmation",
+        "type": "address"
+      }
+    ],
+    "name": "renounceRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "revokeAccess",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "revokeProposerAccess",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "revokeProposerAdminRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "revokeRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "_status",
+        "type": "bool"
+      }
+    ],
+    "name": "setPause",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_nilVerifierAddress",
+        "type": "address"
+      }
+    ],
+    "name": "setVerifierAddress",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "stateRootIndex",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes4",
+        "name": "interfaceId",
+        "type": "bytes4"
+      }
+    ],
+    "name": "supportsInterface",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "batchIndex",
+        "type": "string"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "oldStateRoot",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "newStateRoot",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes[]",
+        "name": "dataProofs",
+        "type": "bytes[]"
+      },
+      {
+        "internalType": "bytes",
+        "name": "validityProof",
+        "type": "bytes"
+      },
+      {
+        "components": [
+          {
+            "internalType": "bytes",
+            "name": "placeholder1",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "placeholder2",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct INilRollup.PublicDataInfo",
+        "name": "publicDataInfo",
+        "type": "tuple"
+      }
+    ],
+    "name": "updateState",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "blobVersionedHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "dataProof",
+        "type": "bytes"
+      }
+    ],
+    "name": "verifyDataProof",
+    "outputs": [],
     "stateMutability": "view",
     "type": "function"
   }

--- a/nil/services/synccommittee/internal/rollupcontract/commit_batch.go
+++ b/nil/services/synccommittee/internal/rollupcontract/commit_batch.go
@@ -1,0 +1,191 @@
+package rollupcontract
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"errors"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/crypto/kzg4844"
+	ethparams "github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
+)
+
+// CommitBatch creates blob transaction for `CommitBatch` contract method and sends it on chain. If such `batchIndex` is already
+// submitted, returns `signedTx, ErrBatchAlreadyCommitted`, so `signedTx` could be used later for accessing prepared blobs fields.
+func (r *Wrapper) CommitBatch(
+	ctx context.Context,
+	blobs []kzg4844.Blob,
+	batchIndex string,
+) (*ethtypes.Transaction, error) {
+	callOpts, cancel := r.getEthCallOpts(ctx)
+	defer cancel()
+	isCommited, err := r.rollupContract.IsBatchCommitted(callOpts, batchIndex)
+	if err != nil {
+		return nil, err
+	}
+
+	publicKeyECDSA, ok := r.privateKey.Public().(*ecdsa.PublicKey)
+	if !ok {
+		return nil, errors.New("error casting public key to ECDSA")
+	}
+
+	address := crypto.PubkeyToAddress(*publicKeyECDSA)
+
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, r.requestTimeout)
+	defer cancel()
+
+	blobTx, err := r.createBlobTx(ctxWithTimeout, blobs, address, batchIndex)
+	if err != nil {
+		return nil, err
+	}
+
+	keyedTransactor, err := bind.NewKeyedTransactorWithChainID(r.privateKey, r.chainID)
+	if err != nil {
+		return nil, fmt.Errorf("creating keyed transactor with chain ID: %w", err)
+	}
+
+	signedTx, err := keyedTransactor.Signer(address, blobTx)
+	if err != nil {
+		return nil, err
+	}
+
+	if isCommited {
+		return signedTx, ErrBatchAlreadyCommitted
+	}
+
+	err = r.ethClient.SendTransaction(ctxWithTimeout, signedTx)
+	if err != nil {
+		return nil, err
+	}
+
+	return signedTx, nil
+}
+
+// computeSidecar handles all KZG commitment related computations
+func computeSidecar(blobs []kzg4844.Blob) (*ethtypes.BlobTxSidecar, error) {
+	commitments := make([]kzg4844.Commitment, 0, len(blobs))
+	proofs := make([]kzg4844.Proof, 0, len(blobs))
+
+	for _, blob := range blobs {
+		commitment, err := kzg4844.BlobToCommitment(&blob)
+		if err != nil {
+			return nil, fmt.Errorf("computing commitment: %w", err)
+		}
+
+		proof, err := kzg4844.ComputeBlobProof(&blob, commitment)
+		if err != nil {
+			return nil, fmt.Errorf("computing proof: %w", err)
+		}
+
+		commitments = append(commitments, commitment)
+		proofs = append(proofs, proof)
+	}
+
+	return &ethtypes.BlobTxSidecar{
+		Blobs:       blobs,
+		Commitments: commitments,
+		Proofs:      proofs,
+	}, nil
+}
+
+// txParams holds all the Ethereum transaction related parameters
+type txParams struct {
+	Nonce      uint64
+	GasTipCap  *big.Int
+	GasFeeCap  *big.Int
+	BlobFeeCap *big.Int
+	Gas        uint64
+}
+
+// computeTxParams fetches and computes all necessary transaction parameters
+func (r *Wrapper) computeTxParams(ctx context.Context, from ethcommon.Address, blobCount int) (*txParams, error) {
+	nonce, err := r.ethClient.PendingNonceAt(ctx, from)
+	if err != nil {
+		return nil, fmt.Errorf("getting nonce: %w", err)
+	}
+
+	gasTipCap, err := r.ethClient.SuggestGasTipCap(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("suggesting gas tip cap: %w", err)
+	}
+
+	head, err := r.ethClient.HeaderByNumber(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("getting header: %w", err)
+	}
+
+	const basefeeWiggleMultiplier = 2
+	gasFeeCap := new(big.Int).Add(
+		gasTipCap,
+		new(big.Int).Mul(head.BaseFee, big.NewInt(basefeeWiggleMultiplier)),
+	)
+
+	if gasFeeCap.Cmp(gasTipCap) < 0 {
+		return nil, fmt.Errorf("maxFeePerGas (%v) < maxPriorityFeePerGas (%v)", gasFeeCap, gasTipCap)
+	}
+
+	blobFee := eip4844.CalcBlobFee(*head.ExcessBlobGas)
+	gas := ethparams.BlobTxBlobGasPerBlob * uint64(blobCount)
+
+	return &txParams{
+		Nonce:      nonce,
+		GasTipCap:  gasTipCap,
+		GasFeeCap:  gasFeeCap,
+		BlobFeeCap: blobFee,
+		Gas:        gas,
+	}, nil
+}
+
+// createBlobTx creates a new blob transaction using the computed blob data and transaction parameters
+func (r *Wrapper) createBlobTx(ctx context.Context, blobs []kzg4844.Blob, from ethcommon.Address, batchIndex string) (*ethtypes.Transaction, error) {
+	startTime := time.Now()
+	sidecar, err := computeSidecar(blobs)
+	if err != nil {
+		return nil, fmt.Errorf("computing blob data: %w", err)
+	}
+	r.logger.Info().Dur("elapsedTime", time.Since(startTime)).Int("blobsLen", len(blobs)).Msg("blob proof computed")
+
+	txParams, err := r.computeTxParams(ctx, from, len(blobs))
+	if err != nil {
+		return nil, fmt.Errorf("computing tx params: %w", err)
+	}
+
+	abi, err := RollupcontractMetaData.GetAbi()
+	if err != nil {
+		return nil, fmt.Errorf("getting ABI: %w", err)
+	}
+
+	data, err := abi.Pack("commitBatch", batchIndex, big.NewInt(int64(len(blobs))))
+	if err != nil {
+		return nil, fmt.Errorf("packing ABI data: %w", err)
+	}
+
+	b := &ethtypes.BlobTx{
+		ChainID:    uint256.MustFromBig(r.chainID),
+		Nonce:      txParams.Nonce,
+		GasTipCap:  uint256.MustFromBig(txParams.GasTipCap),
+		GasFeeCap:  uint256.MustFromBig(txParams.GasFeeCap),
+		Gas:        txParams.Gas,
+		To:         r.contractAddress,
+		Value:      uint256.NewInt(0),
+		Data:       data,
+		AccessList: nil,
+		BlobFeeCap: uint256.MustFromBig(txParams.BlobFeeCap),
+		BlobHashes: sidecar.BlobHashes(),
+		Sidecar: &ethtypes.BlobTxSidecar{
+			Blobs:       sidecar.Blobs,
+			Commitments: sidecar.Commitments,
+			Proofs:      sidecar.Proofs,
+		},
+	}
+
+	return ethtypes.NewTx(b), nil
+}

--- a/nil/services/synccommittee/internal/rollupcontract/errors.go
+++ b/nil/services/synccommittee/internal/rollupcontract/errors.go
@@ -1,0 +1,8 @@
+package rollupcontract
+
+import "errors"
+
+var (
+	ErrBatchAlreadyFinalized = errors.New("batch already finalized")
+	ErrBatchAlreadyCommitted = errors.New("batch already committed")
+)

--- a/nil/services/synccommittee/internal/rollupcontract/eth_client.go
+++ b/nil/services/synccommittee/internal/rollupcontract/eth_client.go
@@ -5,9 +5,12 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 )
 
 type EthClient interface {
 	bind.ContractBackend
 	ChainID(ctx context.Context) (*big.Int, error)
+	TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
 }

--- a/nil/services/synccommittee/internal/rollupcontract/utils.go
+++ b/nil/services/synccommittee/internal/rollupcontract/utils.go
@@ -1,0 +1,49 @@
+package rollupcontract
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/NilFoundation/nil/nil/common"
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto/kzg4844"
+)
+
+func ComputeDataProofs(sidecar *ethtypes.BlobTxSidecar) ([][]byte, error) {
+	blobHashes := sidecar.BlobHashes()
+	dataProofs := make([][]byte, len(blobHashes))
+	for i, blobHash := range blobHashes {
+		point := generatePointFromVersionedHash(blobHash)
+		proof, claim, err := kzg4844.ComputeProof(&sidecar.Blobs[i], point)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate KZG proof from the blob and point: %w", err)
+		}
+		dataProofs[i] = encodeDataProof(point, claim, sidecar.Commitments[i], proof)
+	}
+	return dataProofs, nil
+}
+
+func generatePointFromVersionedHash(versionedHash ethcommon.Hash) kzg4844.Point {
+	blsModulo, _ := new(big.Int).SetString("52435875175126190479447740508185965837690552500527637822603658699938581184513", 10)
+	pointHash := common.Keccak256Hash(versionedHash[:])
+
+	pointBigInt := new(big.Int).SetBytes(pointHash.Bytes())
+	pointBytes := new(big.Int).Mod(pointBigInt, blsModulo).Bytes()
+	start := 32 - len(pointBytes)
+	var point kzg4844.Point
+	copy(point[start:], pointBytes)
+
+	return point
+}
+
+func encodeDataProof(point kzg4844.Point, claim kzg4844.Claim, commitment kzg4844.Commitment, proof kzg4844.Proof) []byte {
+	result := make([]byte, 32+32+48+48)
+
+	copy(result[0:32], point[:])
+	copy(result[32:64], claim[:])
+	copy(result[64:112], commitment[:])
+	copy(result[112:160], proof[:])
+
+	return result
+}

--- a/nil/services/synccommittee/internal/rollupcontract/wrapper.go
+++ b/nil/services/synccommittee/internal/rollupcontract/wrapper.go
@@ -1,33 +1,42 @@
 package rollupcontract
 
 import (
+	"bytes"
 	"context"
 	"crypto/ecdsa"
+	"errors"
 	"fmt"
 	"math/big"
 	"time"
 
 	"github.com/NilFoundation/nil/nil/common"
+	"github.com/NilFoundation/nil/nil/common/concurrent"
+	ethereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/rs/zerolog"
 )
 
 type Wrapper struct {
-	rollupContract *Rollupcontract
-	requestTimeout time.Duration
-	privateKey     *ecdsa.PrivateKey
-	chainID        *big.Int
+	rollupContract  *Rollupcontract
+	contractAddress ethcommon.Address
+	requestTimeout  time.Duration
+	privateKey      *ecdsa.PrivateKey
+	chainID         *big.Int
+	ethClient       EthClient
+	logger          zerolog.Logger
 }
 
-func NewWrapper(ctx context.Context, contractAddress string, privateKey string, ethClient EthClient, requestTimeout time.Duration) (*Wrapper, error) {
-	rollupContract, err := NewRollupcontract(ethcommon.HexToAddress(contractAddress), ethClient)
+func NewWrapper(ctx context.Context, contractAddressHex, privateKeyHex string, ethClient EthClient, requestTimeout time.Duration, logger zerolog.Logger) (*Wrapper, error) {
+	contactAddress := ethcommon.HexToAddress(contractAddressHex)
+	rollupContract, err := NewRollupcontract(contactAddress, ethClient)
 	if err != nil {
 		return nil, fmt.Errorf("can't create rollup contract instance: %w", err)
 	}
 
-	privateKeyECDSA, err := crypto.HexToECDSA(privateKey)
+	privateKeyECDSA, err := crypto.HexToECDSA(privateKeyHex)
 	if err != nil {
 		return nil, fmt.Errorf("converting private key hex to ECDSA: %w", err)
 	}
@@ -40,37 +49,120 @@ func NewWrapper(ctx context.Context, contractAddress string, privateKey string, 
 	}
 
 	return &Wrapper{
-		rollupContract: rollupContract,
-		requestTimeout: requestTimeout,
-		privateKey:     privateKeyECDSA,
-		chainID:        chainID,
+		rollupContract:  rollupContract,
+		contractAddress: contactAddress,
+		requestTimeout:  requestTimeout,
+		privateKey:      privateKeyECDSA,
+		chainID:         chainID,
+		ethClient:       ethClient,
+		logger:          logger,
 	}, nil
 }
 
-func (r *Wrapper) ProofBatch(ctx context.Context, prevStateRoot common.Hash, newStateRoot common.Hash, proof []byte, batchIndexInBlobStorage *big.Int) (*ethtypes.Transaction, error) {
+// UpdateState attempts to update the state of a rollup contract using the provided proofs and state roots.
+// It checks for non-empty state roots, validates the batch, verifies data proofs, and finally submits the update.
+// Returns a transaction pointer on success or an error on validation failure or submission issues.
+func (r *Wrapper) UpdateState(
+	ctx context.Context,
+	batchIndex string,
+	oldStateRoot, newStateRoot common.Hash,
+	dataProofs [][]byte,
+	blobHashes []ethcommon.Hash, // used for verification
+	validityProof []byte,
+	publicDataInputs INilRollupPublicDataInfo,
+) (*ethtypes.Transaction, error) {
+	if oldStateRoot.Empty() {
+		return nil, errors.New("old state root is empty")
+	}
+	if newStateRoot.Empty() {
+		return nil, errors.New("new state root is empty")
+	}
+
+	_, err := r.validateBatch(ctx, batchIndex, oldStateRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	// to make sure proofs are correct before submission, not necessary
+	if err := r.verifyDataProofs(ctx, blobHashes, dataProofs); err != nil {
+		return nil, err
+	}
+
 	transactOpts, cancel, err := r.getEthTransactOpts(ctx)
 	if err != nil {
 		return nil, err
 	}
 	defer cancel()
-	return r.rollupContract.ProofBatch(transactOpts, prevStateRoot, newStateRoot, proof, batchIndexInBlobStorage)
+
+	return r.rollupContract.UpdateState(
+		transactOpts,
+		batchIndex,
+		oldStateRoot,
+		newStateRoot,
+		dataProofs,
+		validityProof,
+		publicDataInputs,
+	)
 }
 
-func (r *Wrapper) StateRoots(ctx context.Context, finalizedBatchIndex *big.Int) ([32]byte, error) {
+func (r *Wrapper) StateRoots(ctx context.Context, finalizedBatchIndex string) ([32]byte, error) {
 	callOpts, cancel := r.getEthCallOpts(ctx)
 	defer cancel()
-	return r.rollupContract.StateRoots(callOpts, finalizedBatchIndex)
+	return r.rollupContract.FinalizedStateRoots(callOpts, finalizedBatchIndex)
 }
 
-func (r *Wrapper) FinalizedBatchIndex(ctx context.Context) (*big.Int, error) {
+func (r *Wrapper) FinalizedBatchIndex(ctx context.Context) (string, error) {
 	callOpts, cancel := r.getEthCallOpts(ctx)
 	defer cancel()
-	return r.rollupContract.FinalizedBatchIndex(callOpts)
+	return r.rollupContract.GetLastFinalizedBatchIndex(callOpts)
+}
+
+// WaitForReceipt repeatedly tries to get tx receipt, retrying on `NotFound` error (tx not mined yet).
+// In case `ReceiptWaitFor` timeout is reached, returns `(nil, nil)`.
+func (r *Wrapper) WaitForReceipt(ctx context.Context, txnHash ethcommon.Hash) (*ethtypes.Receipt, error) {
+	const (
+		ReceiptWaitFor  = 30 * time.Second
+		ReceiptWaitTick = 500 * time.Millisecond
+	)
+	return concurrent.WaitFor(ctx, ReceiptWaitFor, ReceiptWaitTick, func(ctx context.Context) (*ethtypes.Receipt, error) {
+		receipt, err := r.ethClient.TransactionReceipt(ctx, txnHash)
+		if errors.Is(err, ethereum.NotFound) {
+			// retry
+			return nil, nil
+		}
+		return receipt, err
+	})
+}
+
+func (r *Wrapper) verifyDataProofs(
+	ctx context.Context,
+	hashes []ethcommon.Hash,
+	dataProofs [][]byte,
+) error {
+	opts, cancel := r.getEthCallOpts(ctx)
+	defer cancel()
+	for i, blobHash := range hashes {
+		if err := r.rollupContract.VerifyDataProof(opts, blobHash, dataProofs[i]); err != nil {
+			// TODO: make verification return a value. Currently, no way to distinguish network error from verification one
+			return fmt.Errorf("proof verification failed for versioned hash %s (%w)", blobHash.Hex(), err)
+		}
+	}
+	return nil
 }
 
 func (r *Wrapper) getEthCallOpts(ctx context.Context) (*bind.CallOpts, context.CancelFunc) {
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, r.requestTimeout)
 	return &bind.CallOpts{Context: ctxWithTimeout}, cancel
+}
+
+type contractCall func(opts *bind.CallOpts) error
+
+// callWithTimeout executes a contract call with the specified timeout
+func (r *Wrapper) callWithTimeout(ctx context.Context, call contractCall) error {
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, r.requestTimeout)
+	defer cancel()
+
+	return call(&bind.CallOpts{Context: ctxWithTimeout})
 }
 
 func (r *Wrapper) getEthTransactOpts(ctx context.Context) (*bind.TransactOpts, context.CancelFunc, error) {
@@ -82,4 +174,67 @@ func (r *Wrapper) getEthTransactOpts(ctx context.Context) (*bind.TransactOpts, c
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, r.requestTimeout)
 	keyedTransactor.Context = ctxWithTimeout
 	return keyedTransactor, cancel, nil
+}
+
+// BatchValidation contains validation results for a batch
+type BatchValidation struct {
+	IsFinalized             bool
+	IsCommitted             bool
+	LastFinalizedBatchIndex string
+	LastFinalizedStateRoot  common.Hash
+}
+
+func (r *Wrapper) validateBatch(ctx context.Context, batchIndex string, oldStateRoot common.Hash) (*BatchValidation, error) {
+	validation := &BatchValidation{}
+
+	// Check if batch is finalized
+	if err := r.callWithTimeout(ctx, func(opts *bind.CallOpts) error {
+		isFinalized, err := r.rollupContract.IsBatchFinalized(opts, batchIndex)
+		validation.IsFinalized = isFinalized
+		return err
+	}); err != nil {
+		return nil, err
+	}
+
+	if validation.IsFinalized {
+		return nil, ErrBatchAlreadyFinalized
+	}
+
+	// Check if batch is committed
+	if err := r.callWithTimeout(ctx, func(opts *bind.CallOpts) error {
+		isCommitted, err := r.rollupContract.IsBatchCommitted(opts, batchIndex)
+		validation.IsCommitted = isCommitted
+		return err
+	}); err != nil {
+		return nil, err
+	}
+
+	if !validation.IsCommitted {
+		return nil, fmt.Errorf("can't call UpdateState with uncommitted batch %s", batchIndex)
+	}
+
+	// Get last finalized batch index
+	if err := r.callWithTimeout(ctx, func(opts *bind.CallOpts) error {
+		index, err := r.rollupContract.LastFinalizedBatchIndex(opts)
+		validation.LastFinalizedBatchIndex = index
+		return err
+	}); err != nil {
+		return nil, err
+	}
+
+	// Get last finalized state root
+	if err := r.callWithTimeout(ctx, func(opts *bind.CallOpts) error {
+		stateRoot, err := r.rollupContract.FinalizedStateRoots(opts, validation.LastFinalizedBatchIndex)
+		validation.LastFinalizedStateRoot = stateRoot
+		return err
+	}); err != nil {
+		return nil, err
+	}
+
+	if !bytes.Equal(validation.LastFinalizedStateRoot[:], oldStateRoot.Bytes()) {
+		return nil, fmt.Errorf("last finalized state root (%s) and oldStateRoot (%s) differ",
+			validation.LastFinalizedStateRoot, oldStateRoot)
+	}
+
+	return validation, nil
 }


### PR DESCRIPTION
- Update L1 rollup contract abi, adjusted proposer code to use updated version (including batch tx creation). 
- Add offchain checks for `UpdateState` input data to avoid `execution reverted` errors. 

There are two kind of errors that are ignored while submitting blob and state updating. If the batch is already commited, we skip `commitBatch` call, if it is already finalized, we skip `updateState` as well.