### PR TITLE
[syncer] Fix syncer

### DIFF
--- a/nil/internal/collate/validator.go
+++ b/nil/internal/collate/validator.go
@@ -42,7 +42,7 @@ func (s *Validator) VerifyProposal(ctx context.Context, proposal *execution.Prop
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate block: %w", err)
 	}
-	return res, nil
+	return res.Block, nil
 }
 
 func (s *Validator) InsertProposal(ctx context.Context, proposal *execution.Proposal, sig types.Signature) error {

--- a/nil/internal/execution/contract_test.go
+++ b/nil/internal/execution/contract_test.go
@@ -69,7 +69,7 @@ func TestOpcodes(t *testing.T) {
 			require.NoError(t, state.newVm(true, address, nil))
 			_, _, _ = state.evm.Call(vm.AccountRef(address), address, nil, 100000, new(uint256.Int))
 		}
-		_, _, err := state.Commit(types.BlockNumber(i), nil)
+		_, err := state.Commit(types.BlockNumber(i), nil)
 		require.NoError(t, err)
 	}
 	for i := range 50 {

--- a/nil/internal/execution/execution_state_test.go
+++ b/nil/internal/execution/execution_state_test.go
@@ -74,16 +74,16 @@ func (s *SuiteExecutionState) TestExecState() {
 		}
 	})
 
-	var blockHash common.Hash
+	var blockRes *BlockGenerationResult
 
 	s.Run("CommitBlock", func() {
-		blockHash, _, err = es.Commit(0, nil)
+		blockRes, err = es.Commit(0, nil)
 		s.Require().NoError(err)
 	})
 
 	s.Run("CheckAccount", func() {
 		es, err := NewExecutionState(tx, shardId, StateParams{
-			BlockHash:      blockHash,
+			BlockHash:      blockRes.BlockHash,
 			ConfigAccessor: config.GetStubAccessor(),
 		})
 		s.Require().NoError(err)
@@ -94,7 +94,7 @@ func (s *SuiteExecutionState) TestExecState() {
 	})
 
 	s.Run("CheckTransactions", func() {
-		data, err := es.shardAccessor.GetBlock().ByHash(blockHash)
+		data, err := es.shardAccessor.GetBlock().ByHash(blockRes.BlockHash)
 		s.Require().NoError(err)
 		s.Require().NotNil(data)
 		s.Require().NotNil(data.Block())
@@ -369,7 +369,7 @@ func TestAccountState(t *testing.T) {
 	code := types.Code([]byte{'c', 'a', 'f', 'e'})
 	acc.SetCode(code.Hash(), code)
 
-	_, _, err = state.Commit(0, nil)
+	_, err = state.Commit(0, nil)
 	require.NoError(t, err)
 
 	// Drop local state account cache

--- a/nil/internal/execution/testaide.go
+++ b/nil/internal/execution/testaide.go
@@ -106,18 +106,18 @@ func generateBlockFromTransactions(t *testing.T, ctx context.Context, execute bo
 
 	es.ChildChainBlocks = childChainBlocks
 
-	blockHash, _, err := es.Commit(blockId, nil)
+	blockRes, err := es.Commit(blockId, nil)
 	require.NoError(t, err)
 
-	block, err := PostprocessBlock(tx, shardId, types.DefaultGasPrice, blockHash)
+	err = PostprocessBlock(tx, shardId, blockRes)
 	require.NoError(t, err)
-	require.NotNil(t, block)
+	require.NotNil(t, blockRes.Block)
 
-	require.NoError(t, db.WriteBlockTimestamp(tx, shardId, blockHash, 0))
+	require.NoError(t, db.WriteBlockTimestamp(tx, shardId, blockRes.BlockHash, 0))
 
 	require.NoError(t, tx.Commit())
 
-	return blockHash
+	return blockRes.BlockHash
 }
 
 func NewDeployTransaction(payload types.DeployPayload,

--- a/nil/services/rpc/filters/filters_test.go
+++ b/nil/services/rpc/filters/filters_test.go
@@ -258,7 +258,6 @@ func (s *SuiteFilters) TestBlocksRange() {
 	s.NotNil(filters)
 	s.filters = filters
 	address := types.HexToAddress("0x1111111111")
-	defaultGasPrice := types.DefaultGasPrice
 
 	receiptsMpt := mpt.NewDbMPT(tx, 0, db.ReceiptTrieTable)
 
@@ -290,7 +289,8 @@ func (s *SuiteFilters) TestBlocksRange() {
 	}
 	blockHash := block.Hash(types.MainShardId)
 	s.Require().NoError(db.WriteBlock(tx, types.MainShardId, blockHash, &block))
-	_, err = execution.PostprocessBlock(tx, types.MainShardId, defaultGasPrice, blockHash)
+	blockResult := &execution.BlockGenerationResult{BlockHash: blockHash, Block: &block}
+	err = execution.PostprocessBlock(tx, types.MainShardId, blockResult)
 	s.Require().NoError(err)
 
 	block = types.Block{
@@ -301,7 +301,8 @@ func (s *SuiteFilters) TestBlocksRange() {
 	}
 	blockHash = block.Hash(types.MainShardId)
 	s.Require().NoError(db.WriteBlock(tx, types.MainShardId, blockHash, &block))
-	_, err = execution.PostprocessBlock(tx, types.MainShardId, defaultGasPrice, blockHash)
+	blockResult = &execution.BlockGenerationResult{BlockHash: blockHash, Block: &block}
+	err = execution.PostprocessBlock(tx, types.MainShardId, blockResult)
 	s.Require().NoError(err)
 
 	block = types.Block{
@@ -312,7 +313,8 @@ func (s *SuiteFilters) TestBlocksRange() {
 	}
 	blockHash = block.Hash(types.MainShardId)
 	s.Require().NoError(db.WriteBlock(tx, types.MainShardId, blockHash, &block))
-	_, err = execution.PostprocessBlock(tx, types.MainShardId, defaultGasPrice, blockHash)
+	blockResult = &execution.BlockGenerationResult{BlockHash: blockHash, Block: &block}
+	err = execution.PostprocessBlock(tx, types.MainShardId, blockResult)
 	s.Require().NoError(err)
 
 	block = types.Block{
@@ -323,7 +325,8 @@ func (s *SuiteFilters) TestBlocksRange() {
 	}
 	blockHash = block.Hash(types.MainShardId)
 	s.Require().NoError(db.WriteBlock(tx, types.MainShardId, blockHash, &block))
-	_, err = execution.PostprocessBlock(tx, types.MainShardId, defaultGasPrice, blockHash)
+	blockResult = &execution.BlockGenerationResult{BlockHash: blockHash, Block: &block}
+	err = execution.PostprocessBlock(tx, types.MainShardId, blockResult)
 	s.Require().NoError(err)
 	s.Require().NoError(tx.Commit())
 
@@ -386,7 +389,8 @@ func (s *SuiteFilters) TestBlocksRange() {
 	}
 	blockHash = block.Hash(types.MainShardId)
 	s.Require().NoError(db.WriteBlock(tx, types.MainShardId, blockHash, &block))
-	_, err = execution.PostprocessBlock(tx, types.MainShardId, defaultGasPrice, blockHash)
+	blockResult = &execution.BlockGenerationResult{BlockHash: blockHash, Block: &block}
+	err = execution.PostprocessBlock(tx, types.MainShardId, blockResult)
 	s.Require().NoError(err)
 	s.Require().NoError(tx.Commit())
 

--- a/nil/services/rpc/jsonrpc/debug_api_test.go
+++ b/nil/services/rpc/jsonrpc/debug_api_test.go
@@ -63,7 +63,8 @@ func TestDebugGetBlock(t *testing.T) {
 		err = db.WriteBlock(tx, types.MainShardId, hash, b)
 		require.NoError(t, err)
 
-		_, err = execution.PostprocessBlock(tx, types.MainShardId, types.DefaultGasPrice, hash)
+		blockResult := &execution.BlockGenerationResult{BlockHash: hash, Block: b}
+		err = execution.PostprocessBlock(tx, types.MainShardId, blockResult)
 		require.NoError(t, err)
 	}
 
@@ -140,12 +141,12 @@ func (suite *SuiteDbgContracts) SetupSuite() {
 	suite.Require().NoError(es.SetBalance(suite.smcAddr, types.NewValueFromUint64(1234)))
 	suite.Require().NoError(es.SetExtSeqno(suite.smcAddr, 567))
 
-	blockHash, _, err := es.Commit(0, nil)
+	blockRes, err := es.Commit(0, nil)
 	suite.Require().NoError(err)
-	suite.blockHash = blockHash
+	suite.blockHash = blockRes.BlockHash
 
-	block, err := execution.PostprocessBlock(tx, shardId, types.DefaultGasPrice, blockHash)
-	suite.Require().NotNil(block)
+	err = execution.PostprocessBlock(tx, shardId, blockRes)
+	suite.Require().NotNil(blockRes.Block)
 	suite.Require().NoError(err)
 
 	err = tx.Commit()

--- a/nil/services/rpc/jsonrpc/eth_accounts_test.go
+++ b/nil/services/rpc/jsonrpc/eth_accounts_test.go
@@ -63,12 +63,12 @@ func (suite *SuiteEthAccounts) SetupSuite() {
 	suite.Require().NoError(es.SetBalance(suite.smcAddr, types.NewValueFromUint64(1234)))
 	suite.Require().NoError(es.SetExtSeqno(suite.smcAddr, 567))
 
-	blockHash, _, err := es.Commit(0, nil)
+	blockRes, err := es.Commit(0, nil)
 	suite.Require().NoError(err)
-	suite.blockHash = blockHash
+	suite.blockHash = blockRes.BlockHash
 
-	block, err := execution.PostprocessBlock(tx, shardId, types.DefaultGasPrice, blockHash)
-	suite.Require().NotNil(block)
+	err = execution.PostprocessBlock(tx, shardId, blockRes)
+	suite.Require().NotNil(blockRes.Block)
 	suite.Require().NoError(err)
 
 	err = tx.Commit()

--- a/nil/services/rpc/jsonrpc/eth_receipt_test.go
+++ b/nil/services/rpc/jsonrpc/eth_receipt_test.go
@@ -41,9 +41,9 @@ func (s *SuiteEthReceipt) SetupSuite() {
 	s.outTransactions = append(s.outTransactions, &types.Transaction{TransactionDigest: types.TransactionDigest{Data: []byte{12}}})
 	s.outTransactions = append(s.outTransactions, &types.Transaction{TransactionDigest: types.TransactionDigest{Data: []byte{34}}})
 
-	blockHash := writeTestBlock(s.T(), tx, types.BaseShardId, types.BlockNumber(0), []*types.Transaction{s.transaction},
+	blockRes := writeTestBlock(s.T(), tx, types.BaseShardId, types.BlockNumber(0), []*types.Transaction{s.transaction},
 		[]*types.Receipt{&s.receipt}, s.outTransactions)
-	_, err = execution.PostprocessBlock(tx, types.BaseShardId, types.DefaultGasPrice, blockHash)
+	err = execution.PostprocessBlock(tx, types.BaseShardId, blockRes)
 	s.Require().NoError(err)
 
 	err = tx.Commit()

--- a/nil/services/rpc/jsonrpc/eth_transaction_test.go
+++ b/nil/services/rpc/jsonrpc/eth_transaction_test.go
@@ -44,10 +44,11 @@ func (s *SuiteEthTransaction) SetupSuite() {
 	s.transaction.To = types.GenerateRandomAddress(types.BaseShardId)
 	receipt := types.Receipt{TxnHash: s.transaction.Hash()}
 
-	s.lastBlockHash = writeTestBlock(
+	blockRes := writeTestBlock(
 		s.T(), tx, types.BaseShardId, types.BlockNumber(0), []*types.Transaction{s.transaction}, []*types.Receipt{&receipt}, []*types.Transaction{})
-	_, err = execution.PostprocessBlock(tx, types.BaseShardId, types.DefaultGasPrice, s.lastBlockHash)
+	err = execution.PostprocessBlock(tx, types.BaseShardId, blockRes)
 	s.Require().NoError(err)
+	s.lastBlockHash = blockRes.BlockHash
 
 	err = tx.Commit()
 	s.Require().NoError(err)

--- a/nil/services/rpc/jsonrpc/send_transaction_test.go
+++ b/nil/services/rpc/jsonrpc/send_transaction_test.go
@@ -52,9 +52,9 @@ func (suite *SuiteSendTransaction) SetupSuite() {
 	suite.Require().NoError(es.SetBalance(suite.smcAddr, types.NewValueFromUint64(1234)))
 	suite.Require().NoError(es.SetSeqno(suite.smcAddr, 567))
 
-	blockHash, _, err := es.Commit(0, nil)
+	blockRes, err := es.Commit(0, nil)
 	suite.Require().NoError(err)
-	suite.blockHash = blockHash
+	suite.blockHash = blockRes.BlockHash
 
 	err = tx.Commit()
 	suite.Require().NoError(err)

--- a/nil/services/rpc/jsonrpc/test_block.go
+++ b/nil/services/rpc/jsonrpc/test_block.go
@@ -14,7 +14,7 @@ import (
 
 func writeTestBlock(t *testing.T, tx db.RwTx, shardId types.ShardId, blockNumber types.BlockNumber,
 	transactions []*types.Transaction, receipts []*types.Receipt, outTransactions []*types.Transaction,
-) common.Hash {
+) *execution.BlockGenerationResult {
 	t.Helper()
 	block := types.Block{
 		BlockData: types.BlockData{
@@ -31,7 +31,7 @@ func writeTestBlock(t *testing.T, tx db.RwTx, shardId types.ShardId, blockNumber
 	}
 	hash := block.Hash(types.BaseShardId)
 	require.NoError(t, db.WriteBlock(tx, types.BaseShardId, hash, &block))
-	return hash
+	return &execution.BlockGenerationResult{BlockHash: hash, Block: &block}
 }
 
 func writeTransactions(t *testing.T, tx db.RwTx, shardId types.ShardId, transactions []*types.Transaction) *execution.TransactionTrie {

--- a/nil/tests/common.go
+++ b/nil/tests/common.go
@@ -186,6 +186,7 @@ func analyzeReceiptRec(t *testing.T, ctx context.Context, client client.Client, 
 	}
 	txn, err := client.GetInTransactionByHash(ctx, receipt.TxnHash)
 	require.NoError(t, err)
+	require.NotNil(t, txn)
 
 	value.ValueUsed = value.ValueUsed.Add(receipt.GasUsed.ToValue(receipt.GasPrice))
 	value.ValueForwarded = value.ValueForwarded.Add(receipt.Forwarded)

--- a/nil/tests/consensus/consensus_test.go
+++ b/nil/tests/consensus/consensus_test.go
@@ -56,6 +56,7 @@ func (s *SuiteConsensus) TestConsensus() {
 		for _, instance := range s.Instances {
 			instanceBlock, err := instance.Client.GetBlock(s.Context, block.ShardId, uint64(block.Number), false)
 			s.Require().NoError(err)
+			s.Require().NotNil(instanceBlock)
 			s.Equal(block.Hash, instanceBlock.Hash)
 		}
 	}


### PR DESCRIPTION
The following is fixed:
- Don't replay block if its MainShardBlock was not porcessed in this node yet. Otherwise, on-chain config will be incorect as it is bound to the main block.
- Commit replayed block(write to database) only after validation succeed. To be able to do that, some refactoring in block building was made.

Also, Syncer's logger name was changed - not it contains synced shard and active shards. It allows to better understand which syncer the log belongs to.