### PR TITLE
[mpt] Refactoring to introduce SSZ for sparse tries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ test: generated
 
 $(COMMANDS): %: generated %.cmd
 
+include nil/common/sszx/Makefile.inc
 include nil/internal/db/Makefile.inc
 include nil/internal/mpt/Makefile.inc
 include nil/internal/types/Makefile.inc
@@ -41,7 +42,7 @@ include nil/go-ibft/messages/proto/Makefile.inc
 include nil/Makefile.inc
 
 .PHONY: ssz
-ssz: ssz_db ssz_mpt ssz_types ssz_config ssz_execution
+ssz: ssz_sszx ssz_db ssz_mpt ssz_types ssz_config ssz_execution
 
 .PHONY: pb
 pb: pb_rawapi pb_ibft pb_synccommittee

--- a/nil/cmd/exporter/internal/clickhouse/clickhouse.go
+++ b/nil/cmd/exporter/internal/clickhouse/clickhouse.go
@@ -10,7 +10,7 @@ import (
 	"github.com/NilFoundation/nil/nil/cmd/exporter/internal"
 	"github.com/NilFoundation/nil/nil/common"
 	"github.com/NilFoundation/nil/nil/common/check"
-	"github.com/NilFoundation/nil/nil/common/ssz"
+	"github.com/NilFoundation/nil/nil/common/sszx"
 	"github.com/NilFoundation/nil/nil/internal/types"
 )
 
@@ -56,9 +56,9 @@ type TransactionWithBinary struct {
 
 func NewTransactionWithBinary(
 	transaction *types.Transaction,
-	transactionBinary ssz.SSZEncodedData,
+	transactionBinary sszx.SSZEncodedData,
 	receipt *types.Receipt,
-	receiptBinary ssz.SSZEncodedData,
+	receiptBinary sszx.SSZEncodedData,
 	block *types.BlockWithExtractedData,
 	idx types.TransactionIndex,
 	shardId types.ShardId,
@@ -312,7 +312,7 @@ type blockWithSSZ struct {
 
 type receiptWithSSZ struct {
 	decoded    *types.Receipt
-	sszEncoded ssz.SSZEncodedData
+	sszEncoded sszx.SSZEncodedData
 }
 
 func (d *ClickhouseDriver) ExportBlocks(ctx context.Context, blocksToExport []*internal.BlockWithShardId) error {

--- a/nil/common/sszx/Makefile.inc
+++ b/nil/common/sszx/Makefile.inc
@@ -1,0 +1,6 @@
+.PHONY: ssz_sszx
+ssz_sszx: nil/common/sszx/map_encoding.go
+
+nil/common/sszx/map_encoding.go: nil/common/sszx/map.go
+	cd nil/common/sszx && go run github.com/NilFoundation/fastssz/sszgen --path map.go \
+		--objs KeyValue,MapHolder

--- a/nil/common/sszx/map.go
+++ b/nil/common/sszx/map.go
@@ -1,0 +1,36 @@
+package sszx
+
+import (
+	"bytes"
+	"slices"
+)
+
+type KeyValue struct {
+	Key   []byte `ssz-max:"1024"`
+	Value []byte `ssz-max:"4096"`
+}
+
+// MapHolder is a wrapper around a map[string][]byte that can be serialized to SSZ
+type MapHolder struct {
+	// data is a sorted list of key-value pairs
+	data []KeyValue `ssz-max:"4096"`
+}
+
+func NewMapHolder(m map[string][]byte) *MapHolder {
+	keyValues := make([]KeyValue, 0, len(m))
+	for key, value := range m {
+		keyValues = append(keyValues, KeyValue{[]byte(key), value})
+	}
+	slices.SortFunc(keyValues, func(a, b KeyValue) int {
+		return bytes.Compare(a.Key, b.Key)
+	})
+	return &MapHolder{data: keyValues}
+}
+
+func (m *MapHolder) ToMap() map[string][]byte {
+	result := make(map[string][]byte, len(m.data))
+	for _, kv := range m.data {
+		result[string(kv.Key)] = kv.Value
+	}
+	return result
+}

--- a/nil/common/sszx/ssz.go
+++ b/nil/common/sszx/ssz.go
@@ -1,4 +1,4 @@
-package ssz
+package sszx
 
 import (
 	ssz "github.com/NilFoundation/fastssz"

--- a/nil/internal/execution/state_accessor.go
+++ b/nil/internal/execution/state_accessor.go
@@ -8,7 +8,7 @@ import (
 	"github.com/NilFoundation/nil/nil/common"
 	"github.com/NilFoundation/nil/nil/common/assert"
 	"github.com/NilFoundation/nil/nil/common/check"
-	nilssz "github.com/NilFoundation/nil/nil/common/ssz"
+	nilssz "github.com/NilFoundation/nil/nil/common/sszx"
 	"github.com/NilFoundation/nil/nil/internal/db"
 	"github.com/NilFoundation/nil/nil/internal/mpt"
 	"github.com/NilFoundation/nil/nil/internal/types"

--- a/nil/internal/mpt/accessors.go
+++ b/nil/internal/mpt/accessors.go
@@ -41,27 +41,25 @@ func (s *DbSetter) Set(key, value []byte) error {
 	return s.tx.PutToShard(s.shardId, s.tableName, key, value)
 }
 
-type MapGetter struct {
-	m map[string][]byte
+type InMemHolder map[string][]byte
+
+func NewInMemHolder() InMemHolder {
+	return make(map[string][]byte)
 }
 
-func NewMapGetter(m map[string][]byte) *MapGetter {
-	return &MapGetter{m}
+func NewMPTFromMap(m InMemHolder) *MerklePatriciaTrie {
+	return NewMPT(&m, NewReader(m))
 }
 
-func (g *MapGetter) Get(key []byte) ([]byte, error) {
-	return g.m[string(key)], nil
+func NewInMemMPT() *MerklePatriciaTrie {
+	return NewMPTFromMap(NewInMemHolder())
 }
 
-type MapSetter struct {
-	m map[string][]byte
+func (s InMemHolder) Get(key []byte) ([]byte, error) {
+	return s[string(key)], nil
 }
 
-func NewMapSetter(m map[string][]byte) *MapSetter {
-	return &MapSetter{m}
-}
-
-func (s *MapSetter) Set(key, value []byte) error {
-	s.m[string(key)] = value
+func (s *InMemHolder) Set(key, value []byte) error {
+	(*s)[string(key)] = value
 	return nil
 }

--- a/nil/internal/mpt/mpt_test.go
+++ b/nil/internal/mpt/mpt_test.go
@@ -47,17 +47,10 @@ func getValue(t *testing.T, trie *MerklePatriciaTrie, key []byte) []byte {
 	return value
 }
 
-func CreateMerklePatriciaTrie(t *testing.T) *MerklePatriciaTrie {
-	t.Helper()
-
-	holder := make(map[string][]byte)
-	return NewMPT(NewMapSetter(holder), NewReader(NewMapGetter(holder)))
-}
-
 func TestInsertGetOneShort(t *testing.T) {
 	t.Parallel()
 
-	trie := CreateMerklePatriciaTrie(t)
+	trie := NewInMemMPT()
 	key := []byte("key")
 	value := []byte("value")
 
@@ -72,7 +65,7 @@ func TestInsertGetOneShort(t *testing.T) {
 func TestInsertGetOneLong(t *testing.T) {
 	t.Parallel()
 
-	trie := CreateMerklePatriciaTrie(t)
+	trie := NewInMemMPT()
 
 	key := []byte("key_0000000000000000000000000000000000000000000000000000000000000000")
 	value := []byte("value_0000000000000000000000000000000000000000000000000000000000000000")
@@ -83,7 +76,7 @@ func TestInsertGetOneLong(t *testing.T) {
 func TestInsertGetMany(t *testing.T) {
 	t.Parallel()
 
-	trie := CreateMerklePatriciaTrie(t)
+	trie := NewInMemMPT()
 
 	cases := []struct {
 		k string
@@ -107,7 +100,7 @@ func TestInsertGetMany(t *testing.T) {
 func TestIterate(t *testing.T) {
 	t.Parallel()
 
-	trie := CreateMerklePatriciaTrie(t)
+	trie := NewInMemMPT()
 	// Check iteration on the empty trie
 	for range trie.Iterate() {
 	}
@@ -131,7 +124,7 @@ func TestIterate(t *testing.T) {
 func TestInsertGetLots(t *testing.T) {
 	t.Parallel()
 
-	trie := CreateMerklePatriciaTrie(t)
+	trie := NewInMemMPT()
 	const size uint32 = 100
 
 	var keys [size][]byte
@@ -154,7 +147,7 @@ func TestInsertGetLots(t *testing.T) {
 func TestDeleteOne(t *testing.T) {
 	t.Parallel()
 
-	trie := CreateMerklePatriciaTrie(t)
+	trie := NewInMemMPT()
 
 	require.NoError(t, trie.Set([]byte("key"), []byte("value")))
 	require.NoError(t, trie.Delete([]byte("key")))
@@ -167,7 +160,7 @@ func TestDeleteOne(t *testing.T) {
 func TestDeleteMany(t *testing.T) {
 	t.Parallel()
 
-	trie := CreateMerklePatriciaTrie(t)
+	trie := NewInMemMPT()
 
 	require.NoError(t, trie.Set([]byte("do"), []byte("verb")))
 	require.NoError(t, trie.Set([]byte("dog"), []byte("puppy")))
@@ -196,7 +189,7 @@ func TestDeleteMany(t *testing.T) {
 func TestDeleteLots(t *testing.T) {
 	t.Parallel()
 
-	trie := CreateMerklePatriciaTrie(t)
+	trie := NewInMemMPT()
 	const size uint32 = 100
 
 	require.Equal(t, trie.RootHash(), common.EmptyHash)
@@ -224,7 +217,7 @@ func TestDeleteLots(t *testing.T) {
 func TestTrieFromOldRoot(t *testing.T) {
 	t.Parallel()
 
-	trie := CreateMerklePatriciaTrie(t)
+	trie := NewInMemMPT()
 
 	require.NoError(t, trie.Set([]byte("do"), []byte("verb")))
 	require.NoError(t, trie.Set([]byte("dog"), []byte("puppy")))
@@ -249,16 +242,16 @@ func TestTrieFromOldRoot(t *testing.T) {
 func TestSmallRootHash(t *testing.T) {
 	t.Parallel()
 
-	holder := make(map[string][]byte)
+	holder := NewInMemHolder()
 
-	trie := NewMPT(NewMapSetter(holder), NewReader(NewMapGetter(holder)))
+	trie := NewMPTFromMap(holder)
 	key := []byte("key")
 	value := []byte("value")
 
 	require.NoError(t, trie.Set(key, value))
 	assert.Equal(t, value, getValue(t, trie, key))
 
-	trie2 := NewMPT(NewMapSetter(holder), NewReader(NewMapGetter(holder)))
+	trie2 := NewMPTFromMap(holder)
 	trie2.SetRootHash(trie.RootHash())
 
 	assert.Equal(t, value, getValue(t, trie2, key))
@@ -271,8 +264,8 @@ func TestInsertBatch(t *testing.T) {
 	// pick short alphabet and short keys to increase key collisions count
 	treeOps := generateTestCase(gen, 1000, 1, 8, "abcdefgh")
 
-	trie := CreateMerklePatriciaTrie(t)
-	trieBatch := CreateMerklePatriciaTrie(t)
+	trie := NewInMemMPT()
+	trieBatch := NewInMemMPT()
 
 	checkTreesEqual := func(t *testing.T) {
 		t.Helper()
@@ -329,8 +322,7 @@ func TestInsertBatch(t *testing.T) {
 
 func BenchmarkTreeInsertions(b *testing.B) {
 	b.Run("simple insert", func(b *testing.B) {
-		holder := make(map[string][]byte)
-		trie := NewMPT(NewMapSetter(holder), NewReader(NewMapGetter(holder)))
+		trie := NewInMemMPT()
 		gen := newRandGen()
 
 		// long keys and alphabet to increase key uniqueness
@@ -353,8 +345,7 @@ func BenchmarkTreeInsertions(b *testing.B) {
 	})
 
 	b.Run("batch insert", func(b *testing.B) {
-		holder := make(map[string][]byte)
-		trie := NewMPT(NewMapSetter(holder), NewReader(NewMapGetter(holder)))
+		trie := NewInMemMPT()
 		gen := newRandGen()
 
 		// long keys and alphabet to increase key uniqueness

--- a/nil/internal/mpt/proof.go
+++ b/nil/internal/mpt/proof.go
@@ -148,11 +148,8 @@ func (p *Proof) VerifySet(key []byte, value []byte, rootHash, newRootHash common
 
 // unwrapSparseMpt creates sparse MPT trie from proof
 func unwrapSparseMpt(p *Proof) (*MerklePatriciaTrie, error) {
-	holder := make(map[string][]byte)
-	mpt := NewMPT(NewMapSetter(holder), NewReader(NewMapGetter(holder)))
-
-	err := PopulateMptWithProof(mpt, p)
-	if err != nil {
+	mpt := NewInMemMPT()
+	if err := PopulateMptWithProof(mpt, p); err != nil {
 		return nil, err
 	}
 	return mpt, nil

--- a/nil/internal/types/block.go
+++ b/nil/internal/types/block.go
@@ -8,7 +8,7 @@ import (
 
 	fastssz "github.com/NilFoundation/fastssz"
 	"github.com/NilFoundation/nil/nil/common"
-	"github.com/NilFoundation/nil/nil/common/ssz"
+	"github.com/NilFoundation/nil/nil/common/sszx"
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
@@ -58,10 +58,10 @@ type Block struct {
 }
 
 type RawBlockWithExtractedData struct {
-	Block           ssz.SSZEncodedData
-	InTransactions  []ssz.SSZEncodedData
-	OutTransactions []ssz.SSZEncodedData
-	Receipts        []ssz.SSZEncodedData
+	Block           sszx.SSZEncodedData
+	InTransactions  []sszx.SSZEncodedData
+	OutTransactions []sszx.SSZEncodedData
+	Receipts        []sszx.SSZEncodedData
 	Errors          map[common.Hash]string
 	ChildBlocks     []common.Hash
 	DbTimestamp     uint64
@@ -92,15 +92,15 @@ func (b *RawBlockWithExtractedData) DecodeSSZ() (*BlockWithExtractedData, error)
 	if err := block.UnmarshalSSZ(b.Block); err != nil {
 		return nil, err
 	}
-	inTransactions, err := ssz.DecodeContainer[*Transaction](b.InTransactions)
+	inTransactions, err := sszx.DecodeContainer[*Transaction](b.InTransactions)
 	if err != nil {
 		return nil, err
 	}
-	outTransactions, err := ssz.DecodeContainer[*Transaction](b.OutTransactions)
+	outTransactions, err := sszx.DecodeContainer[*Transaction](b.OutTransactions)
 	if err != nil {
 		return nil, err
 	}
-	receipts, err := ssz.DecodeContainer[*Receipt](b.Receipts)
+	receipts, err := sszx.DecodeContainer[*Receipt](b.Receipts)
 	if err != nil {
 		return nil, err
 	}
@@ -120,15 +120,15 @@ func (b *BlockWithExtractedData) EncodeSSZ() (*RawBlockWithExtractedData, error)
 	if err != nil {
 		return nil, err
 	}
-	inTransactions, err := ssz.EncodeContainer(b.InTransactions)
+	inTransactions, err := sszx.EncodeContainer(b.InTransactions)
 	if err != nil {
 		return nil, err
 	}
-	outTransactions, err := ssz.EncodeContainer(b.OutTransactions)
+	outTransactions, err := sszx.EncodeContainer(b.OutTransactions)
 	if err != nil {
 		return nil, err
 	}
-	receipts, err := ssz.EncodeContainer(b.Receipts)
+	receipts, err := sszx.EncodeContainer(b.Receipts)
 	if err != nil {
 		return nil, err
 	}

--- a/nil/services/rpc/rawapi/api.go
+++ b/nil/services/rpc/rawapi/api.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/NilFoundation/nil/nil/common"
-	"github.com/NilFoundation/nil/nil/common/ssz"
+	"github.com/NilFoundation/nil/nil/common/sszx"
 	"github.com/NilFoundation/nil/nil/internal/network"
 	"github.com/NilFoundation/nil/nil/internal/types"
 	rawapitypes "github.com/NilFoundation/nil/nil/services/rpc/rawapi/types"
@@ -14,7 +14,7 @@ import (
 )
 
 type NodeApiRo interface {
-	GetBlockHeader(ctx context.Context, shardId types.ShardId, blockReference rawapitypes.BlockReference) (ssz.SSZEncodedData, error)
+	GetBlockHeader(ctx context.Context, shardId types.ShardId, blockReference rawapitypes.BlockReference) (sszx.SSZEncodedData, error)
 	GetFullBlockData(ctx context.Context, shardId types.ShardId, blockReference rawapitypes.BlockReference) (*types.RawBlockWithExtractedData, error)
 	GetBlockTransactionCount(ctx context.Context, shardId types.ShardId, blockReference rawapitypes.BlockReference) (uint64, error)
 
@@ -41,7 +41,7 @@ type NodeApi interface {
 }
 
 type ShardApiRo interface {
-	GetBlockHeader(ctx context.Context, blockReference rawapitypes.BlockReference) (ssz.SSZEncodedData, error)
+	GetBlockHeader(ctx context.Context, blockReference rawapitypes.BlockReference) (sszx.SSZEncodedData, error)
 	GetFullBlockData(ctx context.Context, blockReference rawapitypes.BlockReference) (*types.RawBlockWithExtractedData, error)
 	GetBlockTransactionCount(ctx context.Context, blockReference rawapitypes.BlockReference) (uint64, error)
 

--- a/nil/services/rpc/rawapi/client.go
+++ b/nil/services/rpc/rawapi/client.go
@@ -10,7 +10,7 @@ import (
 	"github.com/NilFoundation/nil/nil/common"
 	"github.com/NilFoundation/nil/nil/common/assert"
 	"github.com/NilFoundation/nil/nil/common/check"
-	"github.com/NilFoundation/nil/nil/common/ssz"
+	"github.com/NilFoundation/nil/nil/common/sszx"
 	"github.com/NilFoundation/nil/nil/internal/network"
 	"github.com/NilFoundation/nil/nil/internal/types"
 	rawapitypes "github.com/NilFoundation/nil/nil/services/rpc/rawapi/types"
@@ -117,8 +117,8 @@ func makeDoLocalRawApiRequestFunction(rawapi ShardApi) doApiRequestFunction {
 	}
 }
 
-func (api *ShardApiAccessor) GetBlockHeader(ctx context.Context, blockReference rawapitypes.BlockReference) (ssz.SSZEncodedData, error) {
-	return sendRequestAndGetResponseWithCallerMethodName[ssz.SSZEncodedData](ctx, api, "GetBlockHeader", blockReference)
+func (api *ShardApiAccessor) GetBlockHeader(ctx context.Context, blockReference rawapitypes.BlockReference) (sszx.SSZEncodedData, error) {
+	return sendRequestAndGetResponseWithCallerMethodName[sszx.SSZEncodedData](ctx, api, "GetBlockHeader", blockReference)
 }
 
 func (api *ShardApiAccessor) GetFullBlockData(ctx context.Context, blockReference rawapitypes.BlockReference) (*types.RawBlockWithExtractedData, error) {

--- a/nil/services/rpc/rawapi/client_test.go
+++ b/nil/services/rpc/rawapi/client_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/NilFoundation/nil/nil/common/ssz"
+	"github.com/NilFoundation/nil/nil/common/sszx"
 	"github.com/NilFoundation/nil/nil/internal/network"
 	"github.com/NilFoundation/nil/nil/internal/types"
 	"github.com/NilFoundation/nil/nil/services/rpc/rawapi/pb"
@@ -16,7 +16,7 @@ import (
 )
 
 type generatedApiClientIface interface {
-	TestMethod(ctx context.Context, blockReference rawapitypes.BlockReference) (ssz.SSZEncodedData, error)
+	TestMethod(ctx context.Context, blockReference rawapitypes.BlockReference) (sszx.SSZEncodedData, error)
 }
 
 type generatedApiClient struct {
@@ -45,8 +45,8 @@ func newGeneratedApiClient(networkManager *network.Manager, serverPeerId network
 	}, nil
 }
 
-func (api *generatedApiClient) TestMethod(ctx context.Context, blockReference rawapitypes.BlockReference) (ssz.SSZEncodedData, error) {
-	return sendRequestAndGetResponse[ssz.SSZEncodedData](api.doApiRequest, api.apiCodec, "TestMethod", ctx, blockReference)
+func (api *generatedApiClient) TestMethod(ctx context.Context, blockReference rawapitypes.BlockReference) (sszx.SSZEncodedData, error) {
+	return sendRequestAndGetResponse[sszx.SSZEncodedData](api.doApiRequest, api.apiCodec, "TestMethod", ctx, blockReference)
 }
 
 func (s *ApiClientTestSuite) SetupSuite() {
@@ -61,7 +61,7 @@ func (s *ApiClientTestSuite) SetupTest() {
 	s.Require().NoError(err)
 }
 
-func (s *ApiClientTestSuite) doRequest() (ssz.SSZEncodedData, error) {
+func (s *ApiClientTestSuite) doRequest() (sszx.SSZEncodedData, error) {
 	return s.apiClient.TestMethod(s.ctx, rawapitypes.NamedBlockIdentifierAsBlockReference(rawapitypes.LatestBlock))
 }
 

--- a/nil/services/rpc/rawapi/codec_test.go
+++ b/nil/services/rpc/rawapi/codec_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/NilFoundation/nil/nil/common/ssz"
+	"github.com/NilFoundation/nil/nil/common/sszx"
 	"github.com/NilFoundation/nil/nil/services/rpc/rawapi/pb"
 	rawapitypes "github.com/NilFoundation/nil/nil/services/rpc/rawapi/types"
 	"github.com/stretchr/testify/require"
@@ -16,19 +16,19 @@ type compatibleNetworkTransportProtocol interface {
 }
 
 type compatibleApi interface {
-	TestMethod(ctx context.Context, blockReference rawapitypes.BlockReference) (ssz.SSZEncodedData, error)
+	TestMethod(ctx context.Context, blockReference rawapitypes.BlockReference) (sszx.SSZEncodedData, error)
 }
 
 type apiWithOtherMethod interface {
-	OtherMethod(ctx context.Context, blockReference rawapitypes.BlockReference) (ssz.SSZEncodedData, error)
+	OtherMethod(ctx context.Context, blockReference rawapitypes.BlockReference) (sszx.SSZEncodedData, error)
 }
 
 type apiWithWrongMethodArguments interface {
-	TestMethod(ctx context.Context, blockReference rawapitypes.BlockReference, extraArg int) (ssz.SSZEncodedData, error)
+	TestMethod(ctx context.Context, blockReference rawapitypes.BlockReference, extraArg int) (sszx.SSZEncodedData, error)
 }
 
 type apiWithWrongContextMethodArgument interface {
-	TestMethod(notContextArgument int, blockReference rawapitypes.BlockReference) (ssz.SSZEncodedData, error)
+	TestMethod(notContextArgument int, blockReference rawapitypes.BlockReference) (sszx.SSZEncodedData, error)
 }
 
 type apiWithWrongMethodReturn interface {
@@ -36,11 +36,11 @@ type apiWithWrongMethodReturn interface {
 }
 
 type apiWithPointerInsteadOfValueMethodReturn interface {
-	TestMethod(ctx context.Context, blockReference rawapitypes.BlockReference) (*ssz.SSZEncodedData, error)
+	TestMethod(ctx context.Context, blockReference rawapitypes.BlockReference) (*sszx.SSZEncodedData, error)
 }
 
 type apiWithWrongErrorTypeReturn interface {
-	TestMethod(ctx context.Context, blockReference rawapitypes.BlockReference) (ssz.SSZEncodedData, int)
+	TestMethod(ctx context.Context, blockReference rawapitypes.BlockReference) (sszx.SSZEncodedData, int)
 }
 
 func TestApisCompatibility(t *testing.T) {
@@ -81,11 +81,11 @@ type noArgsNetworkTransportProtocol interface {
 }
 
 type noArgsApi interface {
-	TestMethod(ctx context.Context) (ssz.SSZEncodedData, error)
+	TestMethod(ctx context.Context) (sszx.SSZEncodedData, error)
 }
 
 type noArgsApiWithoutCtx interface {
-	TestMethod() (ssz.SSZEncodedData, error)
+	TestMethod() (sszx.SSZEncodedData, error)
 }
 
 func TestApisNoArgs(t *testing.T) {

--- a/nil/services/rpc/rawapi/local_block.go
+++ b/nil/services/rpc/rawapi/local_block.go
@@ -7,13 +7,13 @@ import (
 	"github.com/NilFoundation/nil/nil/common"
 	"github.com/NilFoundation/nil/nil/common/assert"
 	"github.com/NilFoundation/nil/nil/common/check"
-	"github.com/NilFoundation/nil/nil/common/ssz"
+	"github.com/NilFoundation/nil/nil/common/sszx"
 	"github.com/NilFoundation/nil/nil/internal/db"
 	"github.com/NilFoundation/nil/nil/internal/types"
 	rawapitypes "github.com/NilFoundation/nil/nil/services/rpc/rawapi/types"
 )
 
-func (api *LocalShardApi) GetBlockHeader(ctx context.Context, blockReference rawapitypes.BlockReference) (ssz.SSZEncodedData, error) {
+func (api *LocalShardApi) GetBlockHeader(ctx context.Context, blockReference rawapitypes.BlockReference) (sszx.SSZEncodedData, error) {
 	tx, err := api.db.CreateRoTx(ctx)
 	if err != nil {
 		return nil, err
@@ -115,7 +115,7 @@ func (api *LocalShardApi) getBlockByHash(tx db.RoTx, hash common.Hash, withTrans
 
 		// Need to decode transactions to get its hashes because external transaction hash
 		// calculated in a bit different way (not just Hash(SSZ)).
-		transactions, err := ssz.DecodeContainer[*types.Transaction](result.InTransactions)
+		transactions, err := sszx.DecodeContainer[*types.Transaction](result.InTransactions)
 		if err != nil {
 			return nil, err
 		}

--- a/nil/services/rpc/rawapi/node.go
+++ b/nil/services/rpc/rawapi/node.go
@@ -8,7 +8,7 @@ import (
 	"github.com/NilFoundation/nil/nil/common"
 	"github.com/NilFoundation/nil/nil/common/assert"
 	"github.com/NilFoundation/nil/nil/common/check"
-	"github.com/NilFoundation/nil/nil/common/ssz"
+	"github.com/NilFoundation/nil/nil/common/sszx"
 	"github.com/NilFoundation/nil/nil/internal/types"
 	rawapitypes "github.com/NilFoundation/nil/nil/services/rpc/rawapi/types"
 	rpctypes "github.com/NilFoundation/nil/nil/services/rpc/types"
@@ -55,7 +55,7 @@ func makeCallError(methodName string, shardId types.ShardId, err error) error {
 	return fmt.Errorf("failed to call method %s on shard %d: %w", methodName, shardId, err)
 }
 
-func (api *NodeApiOverShardApis) GetBlockHeader(ctx context.Context, shardId types.ShardId, blockReference rawapitypes.BlockReference) (ssz.SSZEncodedData, error) {
+func (api *NodeApiOverShardApis) GetBlockHeader(ctx context.Context, shardId types.ShardId, blockReference rawapitypes.BlockReference) (sszx.SSZEncodedData, error) {
 	methodName := methodNameChecked("GetBlockHeader")
 	shardApi, ok := api.Apis[shardId]
 	if !ok {

--- a/nil/services/rpc/rawapi/pb/conversion.go
+++ b/nil/services/rpc/rawapi/pb/conversion.go
@@ -7,7 +7,7 @@ import (
 	"github.com/NilFoundation/nil/nil/common"
 	"github.com/NilFoundation/nil/nil/common/check"
 	"github.com/NilFoundation/nil/nil/common/hexutil"
-	"github.com/NilFoundation/nil/nil/common/ssz"
+	"github.com/NilFoundation/nil/nil/common/sszx"
 	"github.com/NilFoundation/nil/nil/internal/db"
 	"github.com/NilFoundation/nil/nil/internal/types"
 	rawapitypes "github.com/NilFoundation/nil/nil/services/rpc/rawapi/types"
@@ -214,7 +214,7 @@ func unpackErrorMap(pbErrors map[string]*Error) map[common.Hash]string {
 
 // RawBlock converters
 
-func (rb *RawBlock) PackProtoMessage(block ssz.SSZEncodedData) error {
+func (rb *RawBlock) PackProtoMessage(block sszx.SSZEncodedData) error {
 	if block == nil {
 		return errors.New("block should not be nil")
 	}
@@ -224,13 +224,13 @@ func (rb *RawBlock) PackProtoMessage(block ssz.SSZEncodedData) error {
 	return nil
 }
 
-func (rb *RawBlock) UnpackProtoMessage() (ssz.SSZEncodedData, error) {
+func (rb *RawBlock) UnpackProtoMessage() (sszx.SSZEncodedData, error) {
 	return rb.BlockSSZ, nil
 }
 
 // RawBlockResponse converters
 
-func (br *RawBlockResponse) PackProtoMessage(block ssz.SSZEncodedData, err error) error {
+func (br *RawBlockResponse) PackProtoMessage(block sszx.SSZEncodedData, err error) error {
 	if err != nil {
 		br.fromError(err)
 	} else {
@@ -243,7 +243,7 @@ func (br *RawBlockResponse) fromError(err error) {
 	br.Result = &RawBlockResponse_Error{Error: new(Error).PackProtoMessage(err)}
 }
 
-func (br *RawBlockResponse) fromData(data ssz.SSZEncodedData) {
+func (br *RawBlockResponse) fromData(data sszx.SSZEncodedData) {
 	var rawBlock RawBlock
 	if err := rawBlock.PackProtoMessage(data); err != nil {
 		br.fromError(err)
@@ -252,7 +252,7 @@ func (br *RawBlockResponse) fromData(data ssz.SSZEncodedData) {
 	}
 }
 
-func (br *RawBlockResponse) UnpackProtoMessage() (ssz.SSZEncodedData, error) {
+func (br *RawBlockResponse) UnpackProtoMessage() (sszx.SSZEncodedData, error) {
 	switch br.Result.(type) {
 	case *RawBlockResponse_Error:
 		return nil, br.GetError().UnpackProtoMessage()

--- a/nil/services/rpc/rawapi/server_test.go
+++ b/nil/services/rpc/rawapi/server_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/NilFoundation/nil/nil/common/logging"
-	"github.com/NilFoundation/nil/nil/common/ssz"
+	"github.com/NilFoundation/nil/nil/common/sszx"
 	"github.com/NilFoundation/nil/nil/internal/network"
 	"github.com/NilFoundation/nil/nil/internal/types"
 	"github.com/NilFoundation/nil/nil/services/rpc/rawapi/pb"
@@ -43,14 +43,14 @@ func (s *RawApiTestSuite) SetupTest() {
 }
 
 type testApiIface interface {
-	TestMethod(ctx context.Context, blockReference rawapitypes.BlockReference) (ssz.SSZEncodedData, error)
+	TestMethod(ctx context.Context, blockReference rawapitypes.BlockReference) (sszx.SSZEncodedData, error)
 }
 
 type testApi struct {
-	handler func() (ssz.SSZEncodedData, error)
+	handler func() (sszx.SSZEncodedData, error)
 }
 
-func (t *testApi) TestMethod(ctx context.Context, blockReference rawapitypes.BlockReference) (ssz.SSZEncodedData, error) {
+func (t *testApi) TestMethod(ctx context.Context, blockReference rawapitypes.BlockReference) (sszx.SSZEncodedData, error) {
 	return t.handler()
 }
 
@@ -106,7 +106,7 @@ func (s *ApiServerTestSuite) makeInvalidBlockRequest() []byte {
 
 func (s *ApiServerTestSuite) TestValidResponse() {
 	var index types.TransactionIndex
-	s.api.handler = func() (ssz.SSZEncodedData, error) {
+	s.api.handler = func() (sszx.SSZEncodedData, error) {
 		index += 1
 		return index.Bytes(), nil
 	}
@@ -123,7 +123,7 @@ func (s *ApiServerTestSuite) TestValidResponse() {
 }
 
 func (s *ApiServerTestSuite) TestNilResponse() {
-	s.api.handler = func() (ssz.SSZEncodedData, error) {
+	s.api.handler = func() (sszx.SSZEncodedData, error) {
 		return nil, nil
 	}
 
@@ -139,8 +139,8 @@ func (s *ApiServerTestSuite) TestNilResponse() {
 }
 
 func (s *ApiServerTestSuite) TestInvalidSchemaRequest() {
-	s.api.handler = func() (ssz.SSZEncodedData, error) {
-		return ssz.SSZEncodedData{}, nil
+	s.api.handler = func() (sszx.SSZEncodedData, error) {
+		return sszx.SSZEncodedData{}, nil
 	}
 
 	response, err := s.clientNetworkManager.SendRequestAndGetResponse(s.ctx, s.serverPeerId, "/shard/1/testapi/TestMethod", []byte("invalid request"))
@@ -154,8 +154,8 @@ func (s *ApiServerTestSuite) TestInvalidSchemaRequest() {
 }
 
 func (s *ApiServerTestSuite) TestInvalidDataRequest() {
-	s.api.handler = func() (ssz.SSZEncodedData, error) {
-		return ssz.SSZEncodedData{}, nil
+	s.api.handler = func() (sszx.SSZEncodedData, error) {
+		return sszx.SSZEncodedData{}, nil
 	}
 
 	request := s.makeInvalidBlockRequest()
@@ -170,7 +170,7 @@ func (s *ApiServerTestSuite) TestInvalidDataRequest() {
 }
 
 func (s *ApiServerTestSuite) TestHandlerPanic() {
-	s.api.handler = func() (ssz.SSZEncodedData, error) {
+	s.api.handler = func() (sszx.SSZEncodedData, error) {
 		panic("test panic")
 	}
 

--- a/nil/services/synccommittee/prover/tracer/tracer_mock_client_test.go
+++ b/nil/services/synccommittee/prover/tracer/tracer_mock_client_test.go
@@ -82,10 +82,8 @@ func (s *TracerMockClientTestSuite) makeClient() client.Client {
 		s.Require().NoError(err)
 
 		// Build empty proof
-		holder := make(map[string][]byte)
-		tree := mpt.NewMPT(mpt.NewMapSetter(holder), mpt.NewReader(mpt.NewMapGetter(holder)))
 		key := []byte{0x1}
-		proof, err := mpt.BuildProof(tree.Reader, key, mpt.ReadMPTOperation)
+		proof, err := mpt.BuildProof(mpt.NewInMemMPT().Reader, key, mpt.ReadMPTOperation)
 		s.Require().NoError(err)
 		encodedProof, err := proof.Encode()
 		s.Require().NoError(err)


### PR DESCRIPTION
We need proofs for internal transactions in the proposal.
Since they come in batches in consecutive order, storing their proofs is possible via sparse mpts (containing only the desired paths).
An mpt can be stored as a key-value map. Since serialization requires order which is not provided by the standard map, a wrapper is introduced.

The rest of the PR is a light refactoring of mpt and proposal.

1. Map wrapper in `ssz` package.
2. Simplified mpt ctors.
3. Renamed ssz package to sszx, because it conflicts with fastssz in generated code (in my future code, not here).