### PR TITLE
Add `started` channel to `StartRpcServer` for synchronization

### DIFF
--- a/nil/services/cometa/service.go
+++ b/nil/services/cometa/service.go
@@ -355,5 +355,5 @@ func (s *Service) startRpcServer(ctx context.Context, endpoint string) error {
 
 	apiList := []transport.API{s.GetRpcApi()}
 
-	return rpc.StartRpcServer(ctx, httpConfig, apiList, logger)
+	return rpc.StartRpcServer(ctx, httpConfig, apiList, logger, nil)
 }

--- a/nil/services/faucet/service.go
+++ b/nil/services/faucet/service.go
@@ -47,5 +47,5 @@ func (s *Service) startRpcServer(ctx context.Context, endpoint string) error {
 		s.GetRpcApi(),
 	}
 
-	return rpc.StartRpcServer(ctx, httpConfig, apiList, logger)
+	return rpc.StartRpcServer(ctx, httpConfig, apiList, logger, nil)
 }

--- a/nil/services/nil_load_generator/service.go
+++ b/nil/services/nil_load_generator/service.go
@@ -137,7 +137,7 @@ func startRpcServer(ctx context.Context, endpoint string) error {
 		},
 	}
 
-	return rpc.StartRpcServer(ctx, httpConfig, apiList, logger)
+	return rpc.StartRpcServer(ctx, httpConfig, apiList, logger, nil)
 }
 
 func Run(ctx context.Context, cfg Config, logger zerolog.Logger) error {

--- a/nil/services/nilservice/service.go
+++ b/nil/services/nilservice/service.go
@@ -114,7 +114,7 @@ func startRpcServer(ctx context.Context, cfg *Config, rawApi rawapi.NodeApi, db 
 		})
 	}
 
-	return rpc.StartRpcServer(ctx, httpConfig, apiList, logger)
+	return rpc.StartRpcServer(ctx, httpConfig, apiList, logger, nil)
 }
 
 func startAdminServer(ctx context.Context, cfg *Config) error {

--- a/nil/services/rpc/server.go
+++ b/nil/services/rpc/server.go
@@ -15,7 +15,13 @@ import (
 	"github.com/rs/zerolog"
 )
 
-func StartRpcServer(ctx context.Context, cfg *httpcfg.HttpCfg, rpcAPI []transport.API, logger zerolog.Logger) error {
+func StartRpcServer(
+	ctx context.Context,
+	cfg *httpcfg.HttpCfg,
+	rpcAPI []transport.API,
+	logger zerolog.Logger,
+	started chan<- struct{},
+) error {
 	// register apis and create handler stack
 	srv := transport.NewServer(cfg.TraceRequests, cfg.DebugSingleRequest, logger, cfg.RPCSlowLogThreshold)
 
@@ -61,6 +67,10 @@ func StartRpcServer(ctx context.Context, cfg *httpcfg.HttpCfg, rpcAPI []transpor
 	}()
 
 	logger.Info().Stringer(logging.FieldUrl, httpAddr).Msg("JsonRPC endpoint opened.")
+
+	if started != nil {
+		close(started)
+	}
 
 	<-ctx.Done()
 	return nil

--- a/nil/services/synccommittee/internal/rpc/task_listener.go
+++ b/nil/services/synccommittee/internal/rpc/task_listener.go
@@ -58,5 +58,6 @@ func (l *TaskListener) Run(context context.Context) error {
 	}
 
 	l.logger.Info().Msgf("Open task listener endpoint %v", l.config.HttpEndpoint)
-	return rpc.StartRpcServer(context, httpConfig, apiList, l.logger)
+	// TODO: pass `started` channel in https://github.com/NilFoundation/nil/pull/114
+	return rpc.StartRpcServer(context, httpConfig, apiList, l.logger, nil)
 }


### PR DESCRIPTION
### Add `started` channel to `StartRpcServer` for synchronization

The `StartRpcServer` function now accepts an optional `started` channel to signal when the server is ready.
This allows tests or dependent services to wait for the server to start before proceeding.

Used in #114 [here](https://github.com/NilFoundation/nil/pull/114/files#diff-542761f02f1af7ddd793620cd7937512d98bd4c03272d5105be85d0418857b7fR68).

Also helped to get rid of tcp polling in SyncCommittee's tests [here](https://github.com/NilFoundation/nil/pull/114/files#diff-65c07945e59b0f995aecbbc1b34838a373453561b392bd9282c4145e6ebb653bL34) and [here](https://github.com/NilFoundation/nil/pull/114/files#diff-62d417a55fb50077c21a27d5093d9e94fa49308906eef45359c4e5672ef05e6dL101)