### PR TITLE
[docs] fixed CLI refs generation

### DIFF
--- a/docs/nil/prerequisites.mdx
+++ b/docs/nil/prerequisites.mdx
@@ -87,7 +87,7 @@ The =nil; CLI is an easy-to-use tool for interacting with the cluster from any s
 
 [**Get started with the =nil; CLI**](nilcli/getting-started.mdx).
 
-[**The 'Reference' section**](reference/cli-reference/abi/index.mdx) contains a full list of commands that can be used via the =nil; CLI.
+The 'Reference' section contains a full list of commands that can be used via the =nil; CLI.
 
 :::info
 

--- a/docs/nil/scripts/cliRefGenerator.ts
+++ b/docs/nil/scripts/cliRefGenerator.ts
@@ -5,7 +5,8 @@ import path from "path";
 import util from "node:util";
 import { exec as execCallback } from "node:child_process";
 import { fileURLToPath } from "url";
-import { NIL_GLOBAL } from "../../tests/globals";
+
+const NIL_CLI = process.env.NIL_CLI;
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -33,13 +34,13 @@ async function prettifyCommandNames(key: string, commandNamesArray: string[]): P
     const formattedName = name.replace(".go", "");
     switch (formattedName) {
       case "command":
-        result.push(`${NIL_GLOBAL} ${key} -h`);
+        result.push(`${NIL_CLI} ${key} -h`);
         break;
       case `${key}`:
-        result.push(`${NIL_GLOBAL} ${key} -h`);
+        result.push(`${NIL_CLI} ${key} -h`);
         break;
       default:
-        result.push(`${NIL_GLOBAL} ${key} ${formattedName} -h`);
+        result.push(`${NIL_CLI} ${key} ${formattedName} -h`);
         break;
     }
   }
@@ -132,7 +133,7 @@ async function generateCommandSpec(commandName: string): Promise<CommandSpec | n
     const globalFlags = parseFlags(globalFlagsSection);
 
     return {
-      name: commandName.replace("-h", "").trim(),
+      name: commandName.replace("-h", "").replace(`${NIL_CLI}`, "nil").trim(),
       description: commandDescription,
       usage: usage,
       regularFlags: regularFlags,

--- a/nix/nildocs.nix
+++ b/nix/nildocs.nix
@@ -67,8 +67,10 @@ stdenv.mkDerivation rec {
     export NILJS_SRC=${../niljs}
     export OPENRPC_JSON=${nil}/share/doc/nil/openrpc.json
     export CMD_NIL=${../nil/cmd/nil/internal}
+    export NIL_CLI=${nil}/bin/nil
     export COMETA_CONFIG=${../docs/tests/cometa.yaml}
     export NODE_JS=${nodejs}/bin/node
+    export NIL=${nil}
     cd docs
     npm run build
   '';
@@ -88,6 +90,7 @@ stdenv.mkDerivation rec {
 
   shellHook = ''
     export NILJS_SRC=${../niljs}
+    export NIL_CLI=${nil}/bin/nil
     export OPENRPC_JSON=${nil}/share/doc/nil/openrpc.json
     export CMD_NIL=${../nil/cmd/nil/internal}
     export COMETA_CONFIG=${../docs/tests/cometa.yaml}


### PR DESCRIPTION
This diff fixes two bugs in docs:

* CLI references generation. Right now, no refs are generated as part of CI because the Nix env cannot find the `nil` binary. The `nildocs` derivation is adjusted to have a path to the correct binary, and the binary is used in the ref generator.
* The remnants of the broken links introduced by the renaming of terms are also fixed.