### PR TITLE
[syncer] use stream instead of request-response

### DIFF
--- a/nil/internal/collate/scheduler.go
+++ b/nil/internal/collate/scheduler.go
@@ -85,7 +85,7 @@ func (s *Scheduler) Run(ctx context.Context, syncer *Syncer, consensus Consensus
 	SetBootstrapHandler(ctx, s.networkManager, s.params.ShardId, s.txFabric)
 
 	// Enable handler for blocks relaying
-	SetRequestHandler(ctx, s.networkManager, s.params.ShardId, s.txFabric)
+	SetRequestHandler(ctx, s.networkManager, s.params.ShardId, s.txFabric, s.logger)
 
 	ticker := time.NewTicker(s.params.CollatorTickPeriod)
 	defer ticker.Stop()

--- a/nil/services/rpc/rawapi/proto/block.proto
+++ b/nil/services/rpc/rawapi/proto/block.proto
@@ -11,7 +11,6 @@ message BlockRequest {
 
 message BlocksRangeRequest {
   int64 id = 1;
-  uint32 count = 2;
 }
 
 message RawBlock {


### PR DESCRIPTION
Such approach should be more network-friendly than request blocks by batches. Here we send blocks one by one in a following way: [header (message size)] [message].