### PR TITLE
[syncer] Replicate data from all shards.

### DIFF
--- a/nil/internal/execution/block_generator.go
+++ b/nil/internal/execution/block_generator.go
@@ -16,10 +16,10 @@ import (
 )
 
 type BlockGeneratorParams struct {
-	ShardId         types.ShardId
-	NShards         uint32
-	TraceEVM        bool
-	MainKeysOutPath string
+	ShardId      types.ShardId
+	NShards      uint32
+	TraceEVM     bool
+	MainKeysPath string
 }
 
 func NewBlockGeneratorParams(shardId types.ShardId, nShards uint32) BlockGeneratorParams {

--- a/nil/services/nilservice/config.go
+++ b/nil/services/nilservice/config.go
@@ -48,7 +48,7 @@ type Config struct {
 	AdminSocketPath string `yaml:"adminSocket,omitempty"`
 
 	// Keys
-	MainKeysOutPath      string                     `yaml:"mainKeysPath,omitempty"`
+	MainKeysPath         string                     `yaml:"mainKeysPath,omitempty"`
 	NetworkKeysPath      string                     `yaml:"networkKeysPath,omitempty"`
 	ValidatorKeysPath    string                     `yaml:"validatorKeysPath,omitempty"`
 	ValidatorKeysManager *keys.ValidatorKeysManager `yaml:"-"`
@@ -84,7 +84,7 @@ func NewDefaultConfig() *Config {
 		RunMode: NormalRunMode,
 
 		NShards:           uint32(DefaultNShards),
-		MainKeysOutPath:   "keys.yaml",
+		MainKeysPath:      "keys.yaml",
 		NetworkKeysPath:   "network-keys.yaml",
 		ValidatorKeysPath: "validator-keys.yaml",
 
@@ -197,9 +197,9 @@ func (c *Config) LoadValidatorPrivateKey() (key *ecdsa.PrivateKey, err error) {
 
 func (c *Config) BlockGeneratorParams(shardId types.ShardId) execution.BlockGeneratorParams {
 	return execution.BlockGeneratorParams{
-		ShardId:         shardId,
-		NShards:         c.NShards,
-		TraceEVM:        c.TraceEVM,
-		MainKeysOutPath: c.MainKeysOutPath,
+		ShardId:      shardId,
+		NShards:      c.NShards,
+		TraceEVM:     c.TraceEVM,
+		MainKeysPath: c.MainKeysPath,
 	}
 }

--- a/nil/services/rpc/jsonrpc/types.go
+++ b/nil/services/rpc/jsonrpc/types.go
@@ -252,6 +252,7 @@ func NewRPCInTransaction(
 		BounceTo:             transaction.BounceTo,
 		Index:                hexutil.Uint64(index),
 		Value:                transaction.Value,
+		Token:                transaction.Token,
 		ChainID:              transaction.ChainId,
 		Signature:            transaction.Signature,
 	}


### PR DESCRIPTION
In this PR, we aim to replicate data across all shards for the validator, even if the validator is not actively validating a specific shard (#54). To ensure this, it’s crucial that the zeroStateConfig is consistent across all validators. To achieve this, we will share the publicMainKey with them.