### PR TITLE
Introduce logs filter

### DIFF
--- a/nil/cmd/nild/main.go
+++ b/nil/cmd/nild/main.go
@@ -27,10 +27,14 @@ const (
 	appTitle = "=;Nil"
 )
 
+var logFilter string
+
 func main() {
 	logger := logging.NewLogger("nild")
 
 	cfg := parseArgs()
+
+	logging.ApplyComponentsFilter(logFilter)
 
 	profiling.Start(profiling.DefaultPort)
 
@@ -142,6 +146,7 @@ func parseArgs() *nildconfig.Config {
 	rootCmd.PersistentFlags().StringVar(&cfg.AdminSocketPath, "admin-socket-path", cfg.AdminSocketPath, "unix socket path to start admin server on (disabled if empty)}")
 	rootCmd.PersistentFlags().StringVar(&cfg.ReadThrough.SourceAddr, "read-through-db-addr", cfg.ReadThrough.SourceAddr, "address of the read-through database server. If provided, the local node will be run in read-through mode.")
 	rootCmd.PersistentFlags().Var(&cfg.ReadThrough.ForkMainAtBlock, "read-through-fork-main-at-block", "all blocks generated later than this MainChain block won't be fetched; latest block by default")
+	rootCmd.PersistentFlags().StringVar(&logFilter, "log-filter", "", "filter logs by component, e.g. 'all:-sync:-rpc' - enable all logs, but disable sync and rpc logs")
 
 	// For backward compatibility
 	rootCmd.PersistentFlags().IntVar(&cfg.RPCPort, "port", cfg.RPCPort, "http port for rpc server")

--- a/nil/common/logging/logger_test.go
+++ b/nil/common/logging/logger_test.go
@@ -1,0 +1,77 @@
+package logging
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogger(t *testing.T) {
+	t.Parallel()
+
+	SetupGlobalLogger("debug")
+
+	log1Buf := new(bytes.Buffer)
+	log2Buf := new(bytes.Buffer)
+	log3Buf := new(bytes.Buffer)
+
+	log1 := NewLoggerWithWriter("log1", log1Buf)
+	log2 := NewLoggerWithWriter("log2", log2Buf)
+	log3 := NewLoggerWithWriter("log3", log3Buf)
+
+	msgIndex := 0
+	emitLogs := func() {
+		log1Buf.Reset()
+		log2Buf.Reset()
+		log3Buf.Reset()
+		msgIndex += 1
+		log1.Warn().Msgf("log1 message %d", msgIndex)
+		log2.Warn().Msgf("log2 message %d", msgIndex)
+		log3.Warn().Msgf("log3 message %d", msgIndex)
+	}
+
+	ApplyComponentsFilter("-all")
+	emitLogs()
+	require.Equal(t, 0, log1Buf.Len())
+	require.Equal(t, 0, log2Buf.Len())
+	require.Equal(t, 0, log3Buf.Len())
+
+	ApplyComponentsFilter("all:-log1")
+	emitLogs()
+	require.Equal(t, 0, log1Buf.Len())
+	require.Contains(t, log2Buf.String(), fmt.Sprintf("log2 message %d", msgIndex))
+	require.Contains(t, log3Buf.String(), fmt.Sprintf("log3 message %d", msgIndex))
+
+	ApplyComponentsFilter("log1:-all")
+	emitLogs()
+	require.Equal(t, 0, log1Buf.Len())
+	require.Equal(t, 0, log2Buf.Len())
+	require.Equal(t, 0, log3Buf.Len())
+
+	ApplyComponentsFilter("-all:-log3:all")
+	emitLogs()
+	require.Contains(t, log1Buf.String(), fmt.Sprintf("log1 message %d", msgIndex))
+	require.Contains(t, log2Buf.String(), fmt.Sprintf("log2 message %d", msgIndex))
+	require.Contains(t, log3Buf.String(), fmt.Sprintf("log3 message %d", msgIndex))
+
+	logBuf := new(bytes.Buffer)
+
+	ApplyComponentsFilter("log4")
+	log4 := NewLoggerWithWriter("log4", logBuf)
+	log4.Warn().Msgf("log4 message %d", msgIndex)
+	require.Contains(t, logBuf.String(), fmt.Sprintf("log4 message %d", msgIndex))
+
+	logBuf.Reset()
+	ApplyComponentsFilter("-log5")
+	log5 := NewLoggerWithWriter("log5", logBuf)
+	log5.Warn().Msgf("log5 message %d", msgIndex)
+	require.Equal(t, 0, logBuf.Len())
+
+	ApplyComponentsFilter("-al:-log:dsf::og9erkjthdk&*%^*#s--flk:jsd:lfk3")
+	emitLogs()
+	require.Contains(t, log1Buf.String(), fmt.Sprintf("log1 message %d", msgIndex))
+	require.Contains(t, log2Buf.String(), fmt.Sprintf("log2 message %d", msgIndex))
+	require.Contains(t, log3Buf.String(), fmt.Sprintf("log3 message %d", msgIndex))
+}


### PR DESCRIPTION
Log filter allows specifying which log components are enabled.
Filter is a string in the following format: `"[-]component1:[-]component2:..."`, where `-` indicates that a component is disabled, `:` is separator.

For example:
- `all:-consensus:-collator` will print all logs except `consensus` and `collator`.
- `-all:execution` will print only `execution` logs.

Now, it is used only in `nlid` via `--log-filter` command line argument.