### PR TITLE
[execution] validate shardId for outgoing messages

### DIFF
--- a/nil/internal/collate/proposer_test.go
+++ b/nil/internal/collate/proposer_test.go
@@ -50,6 +50,7 @@ func newTestProposer(params Params, pool TxnPool) *proposer {
 
 func (s *ProposerTestSuite) TestBlockGas() {
 	s.Run("GenerateZeroState", func() {
+		execution.GenerateZeroState(s.T(), s.ctx, types.MainShardId, s.db)
 		execution.GenerateZeroState(s.T(), s.ctx, s.shardId, s.db)
 	})
 
@@ -107,6 +108,7 @@ func (s *ProposerTestSuite) TestCollator() {
 	}
 
 	s.Run("GenerateZeroState", func() {
+		execution.GenerateZeroState(s.T(), s.ctx, types.MainShardId, s.db)
 		execution.GenerateZeroState(s.T(), s.ctx, shardId, s.db)
 	})
 

--- a/nil/internal/config/params.go
+++ b/nil/internal/config/params.go
@@ -103,3 +103,11 @@ func GetParamGasPrice(c ConfigAccessor) (*ParamGasPrice, error) {
 func SetParamGasPrice(c ConfigAccessor, params *ParamGasPrice) error {
 	return setParamImpl(c, params)
 }
+
+func GetParamNShards(c ConfigAccessor) (uint32, error) {
+	param, err := getParamImpl[ParamGasPrice](c)
+	if err != nil {
+		return 0, err
+	}
+	return uint32(len(param.Shards)), nil
+}

--- a/nil/internal/execution/testaide.go
+++ b/nil/internal/execution/testaide.go
@@ -34,7 +34,17 @@ func GenerateZeroState(t *testing.T, ctx context.Context,
 		txFabric, nil)
 	require.NoError(t, err)
 	defer g.Rollback()
-	block, err := g.GenerateZeroState(DefaultZeroStateConfig, nil)
+
+	zerostateCfg, err := ParseZeroStateConfig(DefaultZeroStateConfig)
+	require.NoError(t, err)
+	zerostateCfg.ConfigParams = ConfigParams{
+		GasPrice: config.ParamGasPrice{
+			GasPriceScale: *types.NewUint256(10),
+			Shards:        []types.Uint256{*types.NewUint256(10), *types.NewUint256(10), *types.NewUint256(10)},
+		},
+	}
+
+	block, err := g.GenerateZeroState("", zerostateCfg)
 	require.NoError(t, err)
 	require.NotNil(t, block)
 	return block.Hash(shardId)

--- a/nil/internal/execution/zerostate.go
+++ b/nil/internal/execution/zerostate.go
@@ -80,7 +80,6 @@ type MainKeys struct {
 }
 
 type ConfigParams struct {
-	GasPrices  []int                  `yaml:"gasPrices"`
 	Validators config.ParamValidators `yaml:"validators,omitempty"`
 	GasPrice   config.ParamGasPrice   `yaml:"gasPrice"`
 }
@@ -171,9 +170,9 @@ func (es *ExecutionState) GenerateZeroState(stateConfig *ZeroStateConfig) error 
 		}
 	}
 
-	if stateConfig.ConfigParams.GasPrices != nil {
-		check.PanicIfNot(len(stateConfig.ConfigParams.GasPrices) > int(es.ShardId))
-		es.GasPrice = types.NewValueFromUint64(uint64(stateConfig.ConfigParams.GasPrices[es.ShardId]))
+	if len(stateConfig.ConfigParams.GasPrice.Shards) != 0 {
+		check.PanicIfNot(len(stateConfig.ConfigParams.GasPrice.Shards) > int(es.ShardId))
+		es.GasPrice = types.Value{Uint256: &stateConfig.ConfigParams.GasPrice.Shards[es.ShardId]}
 	} else {
 		es.GasPrice = types.DefaultGasPrice
 	}

--- a/nil/internal/execution/zerostate_test.go
+++ b/nil/internal/execution/zerostate_test.go
@@ -114,7 +114,8 @@ func TestZerostateFromConfig(t *testing.T) {
 	// Test config params
 	configYaml = `
 config:
-  gasPrices: [1, 2, 3]
+  gasPrice:
+    shards: ["1", "2", "3"]
 `
 	configAccessor, err := config.NewConfigAccessor(context.Background(), database, nil)
 	require.NoError(t, err)

--- a/nil/internal/vm/errors.go
+++ b/nil/internal/vm/errors.go
@@ -41,6 +41,7 @@ var (
 	ErrCrossShardTransaction    = types.NewVmError(types.ErrorCrossShardTransaction)
 	ErrUnexpectedPrecompileType = types.NewVmError(types.ErrorUnexpectedPrecompileType)
 	ErrTransactionToMainShard   = types.NewVmError(types.ErrorMessageToMainShard)
+	ErrShardIdIsTooBig          = types.NewVmError(types.ErrorShardIdIsTooBig)
 
 	// errStopToken is an internal token indicating interpreter loop termination,
 	// never returned to outside callers.

--- a/nil/services/synccommittee/prover/tracer/state_db.go
+++ b/nil/services/synccommittee/prover/tracer/state_db.go
@@ -7,6 +7,7 @@ import (
 	"runtime/debug"
 
 	"github.com/NilFoundation/nil/nil/common"
+	"github.com/NilFoundation/nil/nil/common/check"
 	"github.com/NilFoundation/nil/nil/internal/config"
 	"github.com/NilFoundation/nil/nil/internal/db"
 	"github.com/NilFoundation/nil/nil/internal/execution"
@@ -698,7 +699,20 @@ func (tsdb *TracerStateDB) SaveVmState(state *types.EvmState, continuationGasCre
 }
 
 func (tsdb *TracerStateDB) GetConfigAccessor() config.ConfigAccessor {
-	panic("not implemented")
+	// TODO: implement (right now it's a stub to make tests pass)
+	accessor, err := config.NewConfigAccessorTx(context.Background(), tsdb.mptTracer.GetRwTx(), nil)
+	check.PanicIfErr(err)
+	check.PanicIfErr(config.SetParamGasPrice(accessor, &config.ParamGasPrice{
+		GasPriceScale: *types.NewUint256(10),
+		Shards: []types.Uint256{
+			*types.NewUint256(10),
+			*types.NewUint256(10),
+			*types.NewUint256(10),
+			*types.NewUint256(10),
+			*types.NewUint256(10),
+		},
+	}))
+	return accessor
 }
 
 func (tsdb *TracerStateDB) FinalizeTraces() error {

--- a/nil/tests/basic/basic_test.go
+++ b/nil/tests/basic/basic_test.go
@@ -318,6 +318,14 @@ func (s *SuiteRpc) TestRpcContractSendTransaction() {
 	s.Run("ToSameShard", func() {
 		checkForShard(types.BaseShardId)
 	})
+
+	s.Run("SendToNonExistingShard", func() {
+		shardId := types.ShardId(1050)
+		receipt := s.SendTransactionViaSmartAccountNoCheck(types.MainSmartAccountAddress, types.GenerateRandomAddress(shardId),
+			execution.MainPrivateKey, nil, types.NewFeePackFromGas(100_000), types.NewValueFromUint64(100_000), nil)
+		s.Require().False(receipt.Success)
+		s.Equal("ShardIdIsTooBig", receipt.Status)
+	})
 }
 
 func (s *SuiteRpc) TestRpcCallWithTransactionSend() { //nolint:maintidx

--- a/nil/tests/config/config_test.go
+++ b/nil/tests/config/config_test.go
@@ -175,8 +175,8 @@ func (s *SuiteConfigParams) TestConfigReadWriteGasPrice() {
 
 	// Manually set gas price for all shards. It is necessary because the initial prices are set only during the first
 	// block generation. But we will likely read config before that.
-	cfg.ConfigParams.GasPrice.Shards = make([]types.Uint256, s.ShardsNum-1)
-	for i := range s.ShardsNum - 1 {
+	cfg.ConfigParams.GasPrice.Shards = make([]types.Uint256, s.ShardsNum)
+	for i := range s.ShardsNum {
 		cfg.ConfigParams.GasPrice.Shards[i] = *types.DefaultGasPrice.Uint256
 	}
 


### PR DESCRIPTION
Before this patch it was valid to send messages to non-exising shards. That caused different errors during getting receipts for messages that contained such messages.

This patch adds some validation for that. Fix is pretty straightforward since we don't have "nShards" as a separate option we get an array of gas prices because amount of elements is exactly shard count.

Closes #85