### PR TITLE
[GH-65] Path to executable fixed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,9 +69,9 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
-          name: nil-darwin-${{ matrix.platform.arch }}
+          name: clijs-darwin-${{ matrix.platform.arch }}
           path: |
-            build/bin/nil
+            result/clijs
 
   ensure_cluster_builds_macos:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Corrected an [inattention](https://github.com/NilFoundation/nil/pull/158#discussion_r1949294829) from a previous PR