### PR TITLE
[docs] add LICENCE file and fix 404 links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -74,4 +74,4 @@ npm run test:useNilD path/to/test
 
 ## License
 
-[MIT](./LICENSE)
+[MIT](./LICENCE)

--- a/smart-contracts/LICENCE
+++ b/smart-contracts/LICENCE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Sean James Han
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/smart-contracts/README.md
+++ b/smart-contracts/README.md
@@ -52,6 +52,6 @@ import "@nilfoundation/smart-contracts/contracts/SmartAccount.sol";
 
 ## License
 
-[MIT](./LICENSE)
+[MIT](./LICENCE)
 
 


### PR DESCRIPTION
Hi!
Added missing `LICENCE` file in `smart-contracts` with MIT License.
Fixed broken links in `README.md` files (updated `LICENSE` → `LICENCE`).