### PR TITLE
[syncer] fix prev block hash mismatch error on sync

### DIFF
--- a/nil/internal/collate/proposer_test.go
+++ b/nil/internal/collate/proposer_test.go
@@ -100,7 +100,7 @@ func (s *ProposerTestSuite) TestCollator() {
 	generateBlock := func() *execution.Proposal {
 		proposal := s.generateProposal(p)
 
-		blockGenerator, err := execution.NewBlockGenerator(s.ctx, params.BlockGeneratorParams, s.db, nil)
+		blockGenerator, err := execution.NewBlockGenerator(s.ctx, params.BlockGeneratorParams, s.db, nil, nil)
 		s.Require().NoError(err)
 		defer blockGenerator.Rollback()
 

--- a/nil/internal/collate/replay_scheduler.go
+++ b/nil/internal/collate/replay_scheduler.go
@@ -73,7 +73,8 @@ func (s *ReplayScheduler) doReplay(ctx context.Context, blockId types.BlockNumbe
 		return err
 	}
 
-	gen, err := execution.NewBlockGenerator(ctx, s.params.BlockGeneratorParams, s.txFabric, proposal.GetMainShardHash(s.params.ShardId))
+	gen, err := execution.NewBlockGenerator(ctx, s.params.BlockGeneratorParams, s.txFabric,
+		&proposal.PrevBlockHash, proposal.GetMainShardHash(s.params.ShardId))
 	if err != nil {
 		return err
 	}

--- a/nil/internal/collate/syncer.go
+++ b/nil/internal/collate/syncer.go
@@ -402,7 +402,7 @@ func (s *Syncer) GenerateZerostate(ctx context.Context) error {
 
 	s.logger.Info().Msg("Generating zero-state...")
 
-	gen, err := execution.NewBlockGenerator(ctx, s.config.BlockGeneratorParams, s.db, nil)
+	gen, err := execution.NewBlockGenerator(ctx, s.config.BlockGeneratorParams, s.db, nil, nil)
 	if err != nil {
 		return err
 	}
@@ -438,7 +438,7 @@ func (s *Syncer) replayBlock(ctx context.Context, block *types.BlockWithExtracte
 		mainShardHash = block.Block.PrevBlock
 	}
 
-	gen, err := execution.NewBlockGenerator(ctx, s.config.BlockGeneratorParams, s.db, &mainShardHash)
+	gen, err := execution.NewBlockGenerator(ctx, s.config.BlockGeneratorParams, s.db, &block.Block.PrevBlock, &mainShardHash)
 	if err != nil {
 		return err
 	}

--- a/nil/internal/collate/validator.go
+++ b/nil/internal/collate/validator.go
@@ -31,7 +31,8 @@ func (s *Validator) BuildProposal(ctx context.Context) (*execution.Proposal, err
 }
 
 func (s *Validator) VerifyProposal(ctx context.Context, proposal *execution.Proposal) (*types.Block, error) {
-	gen, err := execution.NewBlockGenerator(ctx, s.params.BlockGeneratorParams, s.txFabric, proposal.GetMainShardHash(s.params.ShardId))
+	gen, err := execution.NewBlockGenerator(ctx, s.params.BlockGeneratorParams, s.txFabric,
+		&proposal.PrevBlockHash, proposal.GetMainShardHash(s.params.ShardId))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create block generator: %w", err)
 	}
@@ -45,7 +46,8 @@ func (s *Validator) VerifyProposal(ctx context.Context, proposal *execution.Prop
 }
 
 func (s *Validator) InsertProposal(ctx context.Context, proposal *execution.Proposal, sig types.Signature) error {
-	gen, err := execution.NewBlockGenerator(ctx, s.params.BlockGeneratorParams, s.txFabric, proposal.GetMainShardHash(s.params.ShardId))
+	gen, err := execution.NewBlockGenerator(ctx, s.params.BlockGeneratorParams, s.txFabric,
+		&proposal.PrevBlockHash, proposal.GetMainShardHash(s.params.ShardId))
 	if err != nil {
 		return fmt.Errorf("failed to create block generator: %w", err)
 	}

--- a/nil/internal/execution/execution_state_test.go
+++ b/nil/internal/execution/execution_state_test.go
@@ -655,7 +655,7 @@ contracts:
 
 	params := NewBlockGeneratorParams(1, 2, types.DefaultGasPrice, 0)
 
-	gen, err := NewBlockGenerator(ctx, params, database, nil)
+	gen, err := NewBlockGenerator(ctx, params, database, nil, nil)
 	require.NoError(b, err)
 	_, err = gen.GenerateZeroState(zerostateCfg, nil)
 	require.NoError(b, err)
@@ -683,7 +683,7 @@ contracts:
 		tx, _ := database.CreateRwTx(ctx)
 		proposal.PrevBlockHash, _ = db.ReadLastBlockHash(tx, 1)
 
-		gen, err = NewBlockGenerator(ctx, params, database, nil)
+		gen, err = NewBlockGenerator(ctx, params, database, nil, nil)
 		require.NoError(b, err)
 		_, err = gen.GenerateBlock(proposal, logger, nil)
 		require.NoError(b, err)

--- a/nil/internal/execution/testaide.go
+++ b/nil/internal/execution/testaide.go
@@ -31,7 +31,7 @@ func GenerateZeroState(t *testing.T, ctx context.Context,
 
 	g, err := NewBlockGenerator(ctx,
 		NewBlockGeneratorParams(shardId, 1, types.DefaultGasPrice, 0),
-		txFabric, nil)
+		txFabric, nil, nil)
 	require.NoError(t, err)
 	defer g.Rollback()
 


### PR DESCRIPTION
As in some previous patches we faced with an issue that made an assumption that we should use last block from some chain. However, it seems not so and we should exactly specify blockHash for processing. To avoid such failures in future let's add panic here but only in debug mode. We had the same panic before but it was pretty easy to trigger it from third-party side.