### PR TITLE
Add npm dedupe to clean install command to optimize lockfile after initial install

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build": "npm run build --workspaces --if-present",
     "lint": "npm run lint --workspaces --if-present",
     "lint:fix": "npm run lint:fix --workspaces --if-present",
-    "install:clean": "rm -rf package-lock.json && rm -rf node_modules && rm -rf */node_modules && rm -rf */package-lock.json && npm i",
+    "install:clean": "rm -rf package-lock.json && rm -rf node_modules && rm -rf */node_modules && rm -rf */package-lock.json && npm i && npm dedupe",
     "pub": "npm run pub --workspaces --if-present"
   },
   "author": "",


### PR DESCRIPTION
This diff adds `npm dedupe` to clean install script to optimize lockfile and `node_modules` as a result.

If a dependency is only required by a devDependency, it gets marked as "dev": true" in package-lock.json. In a monorepo setup, some transitive dependencies (dependencies of dependencies) might be installed only for development, so they get `"dev": true`.

On initial `npm install` lockfile is not optimized and dependencies are not deduped (moved to a higher level and duplicates removed). It's like internal npm mechanics. Deduplication happens only after second `npm install`.

So, before the patch lockfile was not optimized after clear install. And on any new installations lockfile was modified.
Though, this diff slightly increases `install:clean` execution time.