### PR TITLE
Show warning in playground if sa is not connected

### DIFF
--- a/explorer_frontend/src/features/contracts/assets/arrow-circle-up.svg
+++ b/explorer_frontend/src/features/contracts/assets/arrow-circle-up.svg
@@ -1,0 +1,5 @@
+<svg width="56" height="56" viewBox="0 0 56 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M27.9998 51.3333C40.8865 51.3333 51.3332 40.8867 51.3332 28C51.3332 15.1134 40.8865 4.66667 27.9998 4.66667C15.1132 4.66667 4.6665 15.1134 4.6665 28C4.6665 40.8867 15.1132 51.3333 27.9998 51.3333Z" stroke="#F1F1F1" stroke-linejoin="round"/>
+<path d="M28 39.0833V18.0833" stroke="#F1F1F1" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M38.5 28.5833L28 18.0833L17.5 28.5833" stroke="#F1F1F1" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/explorer_frontend/src/features/contracts/components/Contracts/Contract.tsx
+++ b/explorer_frontend/src/features/contracts/components/Contracts/Contract.tsx
@@ -17,9 +17,10 @@ import { RemoveAppButton } from "../RemoveAppButton";
 type ContractProps = {
   contract: App;
   deployedApps: Array<App & { address?: Hex }>;
+  disabled?: boolean;
 };
 
-export const Contract: FC<ContractProps> = ({ contract, deployedApps }) => {
+export const Contract: FC<ContractProps> = ({ contract, deployedApps, disabled }) => {
   const [css] = useStyletron();
 
   return (
@@ -44,6 +45,7 @@ export const Contract: FC<ContractProps> = ({ contract, deployedApps }) => {
         })}
       >
         <HeadingMedium
+          color={disabled ? COLORS.gray400 : COLORS.gray50}
           className={css({
             wordBreak: "break-word",
             paddingRight: SPACE[8],
@@ -58,6 +60,7 @@ export const Contract: FC<ContractProps> = ({ contract, deployedApps }) => {
             });
           }}
           kind={BUTTON_KIND.primary}
+          disabled={disabled}
         >
           Deploy
         </Button>

--- a/explorer_frontend/src/features/contracts/components/Contracts/Contracts.tsx
+++ b/explorer_frontend/src/features/contracts/components/Contracts/Contracts.tsx
@@ -11,20 +11,27 @@ import {
   SPACE,
   Spinner,
 } from "@nilfoundation/ui-kit";
+import { memo } from "react";
 import { useStyletron } from "styletron-react";
 import { LayoutComponent, setActiveComponent } from "../../../../pages/playground/model";
+import { $smartAccount } from "../../../account-connector/model";
 import { compileCodeFx } from "../../../code/model";
 import { useMobile } from "../../../shared";
 import { Contract } from "./Contract";
+import { SmartAccountNotConnectedWarning } from "./SmartAccountNotConnectedWarning";
+
+const MemoizedWarning = memo(SmartAccountNotConnectedWarning);
 
 export const Contracts = () => {
-  const [deployedApps, contracts, compilingContracts] = useUnit([
+  const [deployedApps, contracts, compilingContracts, smartAccount] = useUnit([
     $contractWithState,
     $contracts,
     compileCodeFx.pending,
+    $smartAccount,
   ]);
   const [css] = useStyletron();
   const [isMobile] = useMobile();
+  const smartAccountExists = smartAccount !== null;
 
   return (
     <div
@@ -75,6 +82,7 @@ export const Contracts = () => {
           height: "100%",
         })}
       >
+        {!smartAccountExists && <MemoizedWarning />}
         {contracts.length === 0 && (
           <div
             className={css({
@@ -97,11 +105,15 @@ export const Contracts = () => {
           </div>
         )}
         {contracts.map((contract, i) => {
+          const appsToShow = smartAccountExists
+            ? deployedApps.filter((app) => app.bytecode === contract.bytecode)
+            : [];
           return (
             <Contract
               key={`${contract.bytecode}-${i}`}
               contract={contract}
-              deployedApps={deployedApps.filter((app) => app.bytecode === contract.bytecode)}
+              deployedApps={appsToShow}
+              disabled={!smartAccountExists}
             />
           );
         })}

--- a/explorer_frontend/src/features/contracts/components/Contracts/SmartAccountNotConnectedWarning.tsx
+++ b/explorer_frontend/src/features/contracts/components/Contracts/SmartAccountNotConnectedWarning.tsx
@@ -1,0 +1,42 @@
+import { COLORS } from "@nilfoundation/ui-kit";
+import { ParagraphSmall } from "baseui/typography";
+import type { FC } from "react";
+import { useStyletron } from "styletron-react";
+import arrowCircleUp from "../../assets/arrow-circle-up.svg";
+
+export const SmartAccountNotConnectedWarning: FC = () => {
+  const [css] = useStyletron();
+
+  return (
+    <div
+      className={css({
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "center",
+        alignItems: "center",
+        paddingLeft: "40px",
+        paddingRight: "40px",
+        paddingTop: "24px",
+        paddingBottom: "24px",
+        gap: "24px",
+      })}
+    >
+      <img
+        src={arrowCircleUp}
+        alt="Arrow pointing up to the account connector panel"
+        className={css({
+          width: "56px",
+          height: "56px",
+        })}
+      />
+      <ParagraphSmall
+        className={css({
+          textAlign: "center",
+        })}
+        color={COLORS.gray200}
+      >
+        Connect a Smart Account above to deploy contracts
+      </ParagraphSmall>
+    </div>
+  );
+};


### PR DESCRIPTION
We have a problem in explorer that when user does not have a connected/deployed smart account we don't disable contract management panel and allow to deploy/import/call smart contracts (which evidently fails).

To make it easier to understand for a user what their first action should be, we need to disable contract management panel and show a warning instead, saying that smart account should be connected first.