### PR TITLE
added transaction routing to overview

### DIFF
--- a/explorer_frontend/src/features/transaction/components/Transaction.tsx
+++ b/explorer_frontend/src/features/transaction/components/Transaction.tsx
@@ -31,6 +31,11 @@ export const Transaction = () => {
     $transactionChilds,
     fetchTransactionChildsFx.pending,
   ]);
+
+  useEffect(() => {
+    if (transaction) setActiveKey("0");
+  }, [transaction]);
+
   const [activeKey, setActiveKey] = useState<Key>("0");
   const onChangeHandler: OnChangeHandler = (currentKey) => {
     setActiveKey(currentKey.activeKey);


### PR DESCRIPTION
This PR solves [this](https://github.com/NilFoundation/nil/issues/117) issue. Transaction routing to overview is fixed. Initially, when you click on a tx hash in the outgoing or incoming message tab, it would route to outgoing or incoming message tab respectively, instead of the overview of the tx hash. But upon this PR it would redirect you to the overview.