### PR TITLE
Throw error if in playground import nonexistent smart contract

### DIFF
--- a/explorer_frontend/src/features/contracts/components/Deploy/DeployContractModal.tsx
+++ b/explorer_frontend/src/features/contracts/components/Deploy/DeployContractModal.tsx
@@ -9,9 +9,9 @@ import {
 } from "@nilfoundation/ui-kit";
 import {} from "@nilfoundation/ui-kit";
 import type { TabsOverrides } from "baseui/tabs";
-import { useStore } from "effector-react";
+import { useUnit } from "effector-react";
 import type { FC } from "react";
-import {} from "../../models/base";
+import { deploySmartContractFx, importSmartContractFx } from "../../models/base";
 import { $activeComponent, setActiveComponent } from "../../models/base";
 import { ActiveComponent } from "./ActiveComponent";
 import { DeployTab } from "./DeployTab";
@@ -24,7 +24,12 @@ type DeployContractModalProps = {
 };
 
 export const DeployContractModal: FC<DeployContractModalProps> = ({ onClose, isOpen, name }) => {
-  const activeComponent = useStore($activeComponent) || ActiveComponent.Deploy;
+  const [activeComponent, deployPending, importExistingPending] = useUnit([
+    $activeComponent,
+    deploySmartContractFx.pending,
+    importSmartContractFx.pending,
+  ]);
+  const tabsDisabled = deployPending || importExistingPending;
 
   return (
     <Modal
@@ -58,6 +63,7 @@ export const DeployContractModal: FC<DeployContractModalProps> = ({ onClose, isO
             activeKey={activeComponent}
             overrides={tabsOverrides}
             onChange={({ activeKey }) => setActiveComponent(activeKey as ActiveComponent)}
+            disabled={tabsDisabled}
           >
             <Tab
               title="Deploy"

--- a/explorer_frontend/src/features/contracts/components/Deploy/ImportContractTab.tsx
+++ b/explorer_frontend/src/features/contracts/components/Deploy/ImportContractTab.tsx
@@ -8,19 +8,19 @@ import { useStyletron } from "styletron-react";
 import { $smartAccount } from "../../../account-connector/model";
 import {
   $activeAppWithState,
-  $assignedSmartContractAddress,
   $deployedContracts,
-  assignSmartContract,
-  assignSmartContractFx,
-  setAssignedSmartContractAddress,
+  $importedSmartContractAddress,
+  importSmartContract,
+  importSmartContractFx,
+  setImportedSmartContractAddress,
 } from "../../models/base";
 
 export const ImportContractTab = () => {
-  const [smartAccount, pending, deployedContracts, assignedAddress, activeApp] = useUnit([
+  const [smartAccount, pending, deployedContracts, importedAddress, activeApp] = useUnit([
     $smartAccount,
-    assignSmartContractFx.pending,
+    importSmartContractFx.pending,
     $deployedContracts,
-    $assignedSmartContractAddress,
+    $importedSmartContractAddress,
     $activeAppWithState,
   ]);
 
@@ -33,8 +33,10 @@ export const ImportContractTab = () => {
         setError(null);
         return;
       }
+
       const existingAddresses = Object.values(deployedContracts).flat();
-      if (existingAddresses.includes(address)) {
+
+      if (existingAddresses.includes(address as Hex)) {
         setError(`Contract with address ${address} already exists.`);
       } else {
         setError(null);
@@ -44,11 +46,11 @@ export const ImportContractTab = () => {
   );
 
   useEffect(() => {
-    validateAddress(assignedAddress);
-  }, [assignedAddress, validateAddress]);
+    validateAddress(importedAddress);
+  }, [importedAddress, validateAddress]);
 
   useEffect(() => {
-    setAssignedSmartContractAddress("0x" as Hex);
+    setImportedSmartContractAddress("0x" as Hex);
     setError(null);
   }, []);
 
@@ -67,9 +69,9 @@ export const ImportContractTab = () => {
             overrides={inputOverrides}
             onChange={(e) => {
               const value = e.target.value as Hex;
-              setAssignedSmartContractAddress(value);
+              setImportedSmartContractAddress(value);
             }}
-            value={assignedAddress && assignedAddress !== "0x" ? assignedAddress : ""}
+            value={importedAddress && importedAddress !== "0x" ? importedAddress : ""}
           />
         </FormControl>
         {error && (
@@ -94,7 +96,7 @@ export const ImportContractTab = () => {
       <div>
         <Button
           onClick={() => {
-            if (!error) assignSmartContract();
+            if (!error) importSmartContract();
           }}
           isLoading={pending}
           disabled={pending || !smartAccount || !!error}

--- a/explorer_frontend/src/features/contracts/init.ts
+++ b/explorer_frontend/src/features/contracts/init.ts
@@ -24,6 +24,8 @@ import {
   $errors,
   $importedAddress,
   $importedSmartContractAddress,
+  $importedSmartContractAddressError,
+  $importedSmartContractAddressIsValid,
   $loading,
   $shardId,
   $shardIdIsValid,
@@ -50,11 +52,14 @@ import {
   setAssignAddress,
   setDeploymentArg,
   setImportedSmartContractAddress,
+  setImportedSmartContractAddressError,
+  setImportedSmartContractAddressIsValid,
   setParams,
   setShardId,
   setValueInput,
   toggleActiveKey,
   unlinkApp,
+  validateSmartContractAddressFx,
 } from "./models/base";
 import { exportApp, exportAppFx } from "./models/exportApp";
 
@@ -195,6 +200,20 @@ sample({
 });
 
 $importedSmartContractAddress.on(setImportedSmartContractAddress, (_, address) => address);
+$importedSmartContractAddress.reset($activeApp);
+
+$importedSmartContractAddressIsValid.reset($activeApp);
+$importedSmartContractAddressIsValid.reset(setImportedSmartContractAddress);
+$importedSmartContractAddressIsValid.on(
+  setImportedSmartContractAddressIsValid,
+  (_, isValid) => isValid,
+);
+
+$importedSmartContractAddressError.reset($activeApp);
+$importedSmartContractAddressError.reset(setImportedSmartContractAddress);
+$importedSmartContractAddressError.on(setImportedSmartContractAddressError, (_, err) => {
+  return err;
+});
 
 sample({
   source: combine(
@@ -224,8 +243,17 @@ sample({
       importedSmartContractAddress: importedSmartContractAddress as Hex,
     };
   },
-  clock: importSmartContract,
+  clock: validateSmartContractAddressFx.doneData,
   target: importSmartContractFx,
+});
+
+sample({
+  clock: importSmartContract,
+  source: combine({
+    address: $importedSmartContractAddress,
+    deployedContracts: $deployedContracts,
+  }),
+  target: validateSmartContractAddressFx,
 });
 
 sample({

--- a/explorer_frontend/src/features/logs/init.tsx
+++ b/explorer_frontend/src/features/logs/init.tsx
@@ -3,9 +3,9 @@ import { MonoParagraphMedium } from "baseui/typography";
 import { nanoid } from "nanoid";
 import { compileCodeFx } from "../code/model";
 import {
-  assignSmartContractFx,
   callFx,
   deploySmartContractFx,
+  importSmartContractFx,
   registerContractInCometaFx,
   sendMethodFx,
 } from "../contracts/models/base";
@@ -40,7 +40,7 @@ $logs.on(deploySmartContractFx.doneData, (logs, { address, name, deployedFrom, t
   ];
 });
 
-$logs.on(assignSmartContractFx.doneData, (logs, { assignedSmartContractAddress }) => {
+$logs.on(importSmartContractFx.doneData, (logs, { importedSmartContractAddress }) => {
   return [
     ...logs,
     {
@@ -49,10 +49,10 @@ $logs.on(assignSmartContractFx.doneData, (logs, { assignedSmartContractAddress }
       type: LogType.Success,
       shortDescription: (
         <MonoParagraphMedium color={COLORS.green200}>
-          Contract assigned successfully
+          Contract imported successfully
         </MonoParagraphMedium>
       ),
-      payload: <ContractDeployedLog address={assignedSmartContractAddress} />,
+      payload: <ContractDeployedLog address={importedSmartContractAddress} />,
       timestamp: Date.now(),
     },
   ];
@@ -74,7 +74,7 @@ $logs.on(deploySmartContractFx.failData, (logs, error) => {
   ];
 });
 
-$logs.on(assignSmartContractFx.failData, (logs, error) => {
+$logs.on(importSmartContractFx.failData, (logs, error) => {
   return [
     ...logs,
     {


### PR DESCRIPTION
Currently we have a severe issue with importing existing contract feature in playground. User can set any address to input, even the address of nonexistent contract (any valid Hex string) and import will not fail. Moreover the fake contract will appear in the project and can cause a lot of misunderstanding.

This is fixed just by checking the code of the contract before importing it. It `getCode()` returns `0x` it means nothing is deploy at address.

Additionally this diff fixes remnants in the code of "assign smart contract" naming.