### PR TITLE
[collate] drop unused config options

### DIFF
--- a/nil/internal/collate/scheduler.go
+++ b/nil/internal/collate/scheduler.go
@@ -35,9 +35,6 @@ type Params struct {
 	CollatorTickPeriod time.Duration
 	Timeout            time.Duration
 
-	ZeroState       string
-	ZeroStateConfig *execution.ZeroStateConfig
-
 	Topology ShardTopology
 
 	L1Fetcher rollup.L1BlockFetcher

--- a/nil/services/nilservice/config.go
+++ b/nil/services/nilservice/config.go
@@ -198,9 +198,10 @@ func (c *Config) LoadValidatorPrivateKey() (key *ecdsa.PrivateKey, err error) {
 
 func (c *Config) BlockGeneratorParams(shardId types.ShardId) execution.BlockGeneratorParams {
 	return execution.BlockGeneratorParams{
-		ShardId:  shardId,
-		NShards:  c.NShards,
-		TraceEVM: c.TraceEVM,
-		Timer:    common.NewTimer(),
+		ShardId:         shardId,
+		NShards:         c.NShards,
+		TraceEVM:        c.TraceEVM,
+		Timer:           common.NewTimer(),
+		MainKeysOutPath: c.MainKeysOutPath,
 	}
 }

--- a/nil/services/nilservice/service.go
+++ b/nil/services/nilservice/service.go
@@ -602,22 +602,15 @@ func createShards(
 func createActiveCollator(shard types.ShardId, cfg *Config, collatorTickPeriod time.Duration, database db.DB, networkManager *network.Manager, txnPool txnpool.Pool) *collate.Scheduler {
 	collatorCfg := collate.Params{
 		BlockGeneratorParams: execution.BlockGeneratorParams{
-			ShardId:         shard,
-			NShards:         cfg.NShards,
-			TraceEVM:        cfg.TraceEVM,
-			Timer:           common.NewTimer(),
-			MainKeysOutPath: cfg.MainKeysOutPath,
+			ShardId:  shard,
+			NShards:  cfg.NShards,
+			TraceEVM: cfg.TraceEVM,
+			Timer:    common.NewTimer(),
 		},
 		CollatorTickPeriod: collatorTickPeriod,
 		Timeout:            collatorTickPeriod,
-		ZeroState:          execution.DefaultZeroStateConfig,
-		ZeroStateConfig:    cfg.ZeroState,
 		Topology:           collate.GetShardTopologyById(cfg.Topology),
 		L1Fetcher:          cfg.L1Fetcher,
 	}
-	if len(cfg.ZeroStateYaml) != 0 {
-		collatorCfg.ZeroState = cfg.ZeroStateYaml
-	}
-
 	return collate.NewScheduler(database, txnPool, collatorCfg, networkManager)
 }


### PR DESCRIPTION
Right now syncer is responsible for zerostate generation.