### PR TITLE
Add shardid validation to deploy modal

### DIFF
--- a/explorer_frontend/src/features/account-connector/init.ts
+++ b/explorer_frontend/src/features/account-connector/init.ts
@@ -13,7 +13,7 @@ import {
 import { combine, forward, sample } from "effector";
 import { persist as persistLocalStorage } from "effector-storage/local";
 import { persist as persistSessionStorage } from "effector-storage/session";
-import { loadedPage } from "../code/model";
+import { loadedPlaygroundPage } from "../code/model";
 import { sendMethodFx } from "../contracts/models/base";
 import { playgroundRoute, playgroundWithHashRoute } from "../routing";
 import { getRuntimeConfigOrThrow } from "../runtime-config";
@@ -319,7 +319,7 @@ sample({
 });
 
 sample({
-  clock: loadedPage,
+  clock: loadedPlaygroundPage,
   source: combine(playgroundRoute.$query, playgroundWithHashRoute.$query, (query1, query2) => {
     const user = query1.user ?? query2.user;
     const token = query1.token ?? query2.token;

--- a/explorer_frontend/src/features/code/init.ts
+++ b/explorer_frontend/src/features/code/init.ts
@@ -19,7 +19,7 @@ import {
   compileCodeFx,
   fetchCodeSnippetEvent,
   fetchCodeSnippetFx,
-  loadedPage,
+  loadedPlaygroundPage,
   setCodeSnippetEvent,
   setCodeSnippetFx,
   updateRecentProjects,
@@ -157,7 +157,7 @@ sample({
 });
 
 sample({
-  clock: loadedPage,
+  clock: loadedPlaygroundPage,
   filter: $code.map((code) => !(code.trim().length === 0)),
   target: compile,
 });

--- a/explorer_frontend/src/features/code/model.ts
+++ b/explorer_frontend/src/features/code/model.ts
@@ -48,7 +48,7 @@ fetchCodeSnippetFx.use((hash) => {
   return fetchCodeSnippet(hash);
 });
 
-export const loadedPage = codeDomain.createEvent();
+export const loadedPlaygroundPage = codeDomain.createEvent();
 
 export const $recentProjects = codeDomain.createStore<Record<string, string>>({});
 

--- a/explorer_frontend/src/features/contracts/components/Deploy/DeployTab.tsx
+++ b/explorer_frontend/src/features/contracts/components/Deploy/DeployTab.tsx
@@ -5,7 +5,6 @@ import {
   FormControl,
   HeadingMedium,
   Input,
-  ParagraphSmall,
   SPACE,
 } from "@nilfoundation/ui-kit";
 import { useUnit } from "effector-react";
@@ -15,6 +14,7 @@ import { $constructor } from "../../init";
 import {
   $deploymentArgs,
   $shardId,
+  $shardIdIsValid,
   deploySmartContract,
   deploySmartContractFx,
   setDeploymentArg,
@@ -23,12 +23,13 @@ import {
 import { ShardIdInput } from "./ShardIdInput";
 
 export const DeployTab = () => {
-  const [smartAccount, args, constuctorAbi, pending, shardId] = useUnit([
+  const [smartAccount, args, constuctorAbi, pending, shardId, shardIdIsValid] = useUnit([
     $smartAccount,
     $deploymentArgs,
     $constructor,
     deploySmartContractFx.pending,
     $shardId,
+    $shardIdIsValid,
   ]);
   const [css] = useStyletron();
 
@@ -122,16 +123,14 @@ export const DeployTab = () => {
             })}
           </div>
         ) : (
-          <ParagraphSmall marginBottom="24px" color={COLORS.gray400}>
-            No deployment arguments
-          </ParagraphSmall>
+          <></>
         )}
         <Button
           onClick={() => {
             deploySmartContract();
           }}
           isLoading={pending}
-          disabled={pending || !smartAccount || shardId === null}
+          disabled={pending || !smartAccount || shardId === null || !shardIdIsValid}
         >
           Deploy
         </Button>

--- a/explorer_frontend/src/features/contracts/components/Deploy/ShardIdInput.tsx
+++ b/explorer_frontend/src/features/contracts/components/Deploy/ShardIdInput.tsx
@@ -8,9 +8,11 @@ import {
   ParagraphXSmall,
   PlusIcon,
 } from "@nilfoundation/ui-kit";
+import { useUnit } from "effector-react";
 import type { FC } from "react";
 import { useStyletron } from "styletron-react";
-import { decrementShardId, incrementShardId } from "../../models/base";
+import { $shardsAmount } from "../../../shards/models/model";
+import { $shardIdIsValid, decrementShardId, incrementShardId } from "../../models/base";
 
 type ShardIdInputProps = {
   shardId: number | null;
@@ -30,6 +32,7 @@ const btnOverrides = {
 
 export const ShardIdInput: FC<ShardIdInputProps> = ({ shardId, setShardId, disabled }) => {
   const [css] = useStyletron();
+  const [shardsAmount, shardIdIsValid] = useUnit([$shardsAmount, $shardIdIsValid]);
 
   return (
     <div
@@ -48,7 +51,7 @@ export const ShardIdInput: FC<ShardIdInputProps> = ({ shardId, setShardId, disab
         })}
       >
         <div>
-          <FormControl label="Shard ID">
+          <FormControl label={`Shard ID (1 to ${shardsAmount})`} error={!shardIdIsValid}>
             <Input
               value={shardId?.toString() ?? ""}
               onChange={(e) => {
@@ -105,7 +108,12 @@ export const ShardIdInput: FC<ShardIdInputProps> = ({ shardId, setShardId, disab
           disabled={disabled}
         />
       </div>
-      <ParagraphXSmall color={COLORS.gray400} marginTop="-16px">
+      {shardIdIsValid ? null : (
+        <ParagraphXSmall color={COLORS.red400} marginTop="-8px">
+          {`That Shard ID doesn't exist. Please select from 1 to ${shardsAmount}.`}
+        </ParagraphXSmall>
+      )}
+      <ParagraphXSmall color={COLORS.gray400}>
         <div>Choosing a shard can help reduce transaction gas fees.</div>
         <div>
           Learn how to select or check shards in the{" "}

--- a/explorer_frontend/src/features/contracts/models/base.ts
+++ b/explorer_frontend/src/features/contracts/models/base.ts
@@ -344,3 +344,5 @@ export const removeValueInput = createEvent<number>();
 
 export const $activeComponent = createStore<ActiveComponent | null>(ActiveComponent.Deploy);
 export const setActiveComponent = createEvent<ActiveComponent>();
+
+export const $shardIdIsValid = createStore<boolean>(true);

--- a/explorer_frontend/src/features/shards/init.ts
+++ b/explorer_frontend/src/features/shards/init.ts
@@ -1,12 +1,12 @@
-import { sample } from "effector";
+import { merge, sample } from "effector";
 import { interval } from "patronum";
+import { loadedPlaygroundPage } from "../code/model";
 import { explorerRoute } from "../routing/routes/explorerRoute";
 import { $shards, fetchShardsFx } from "./models/model";
 
 const { tick } = interval({
   timeout: 1000 * 6,
-  start: explorerRoute.navigated,
-  stop: explorerRoute.closed,
+  start: merge([explorerRoute.navigated, loadedPlaygroundPage]),
   leading: true,
 });
 
@@ -14,7 +14,5 @@ sample({
   clock: tick,
   target: fetchShardsFx,
 });
-
-$shards.reset(explorerRoute.navigated);
 
 $shards.on(fetchShardsFx.doneData, (_, data) => data);

--- a/explorer_frontend/src/features/shards/models/model.ts
+++ b/explorer_frontend/src/features/shards/models/model.ts
@@ -9,6 +9,7 @@ const createStore = explorerShardsList.createStore.bind(explorerShardsList);
 const createEffect = explorerShardsList.createEffect.bind(explorerShardsList);
 
 export const $shards = createStore<Shards>([]);
+export const $shardsAmount = $shards.map((shards) => shards.length - 1);
 
 export const fetchShardsFx = createEffect<void, Shards, Error>();
 

--- a/explorer_frontend/src/pages/playground/PlaygroundPage.tsx
+++ b/explorer_frontend/src/pages/playground/PlaygroundPage.tsx
@@ -6,7 +6,7 @@ import { useEffect } from "react";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { AccountPane } from "../../features/account-connector";
 import { Code } from "../../features/code/Code";
-import { loadedPage } from "../../features/code/model";
+import { loadedPlaygroundPage } from "../../features/code/model";
 import { ContractsContainer, closeApp } from "../../features/contracts";
 import { Logs } from "../../features/logs/components/Logs";
 import { useMobile } from "../../features/shared";
@@ -21,7 +21,7 @@ export const PlaygroundPage = () => {
   const [isMobile] = useMobile();
 
   useEffect(() => {
-    loadedPage();
+    loadedPlaygroundPage();
 
     return () => {
       closeApp();


### PR DESCRIPTION
This diff adds shard id validation to deploy contract modal. The motivation is to improve UX, especially for newcomers who need to see concrete errors while trying to deploy on a nonexistent shard.


https://github.com/user-attachments/assets/6201e7a9-86eb-4de0-bad9-98778c1e0683



