### PR TITLE
Added support to interact with a mapping via playground

### DIFF
--- a/explorer_frontend/src/features/contracts/init.ts
+++ b/explorer_frontend/src/features/contracts/init.ts
@@ -341,8 +341,14 @@ sample({
           if (typeof input.name !== "string") {
             continue;
           }
-          const name = input.name;
-          args.push(callParams[name] || "");
+          if (input.name === "") {
+            for (const key in callParams) {
+              args.push(callParams[key] || "");
+            }
+          } else {
+            const name = input.name;
+            args.push(callParams[name] || "");
+          }
         }
       }
     }


### PR DESCRIPTION
This PR solves this [issue](https://github.com/NilFoundation/nil/issues/296) where you would get an error or a wrong default result when you query a mapping. This PR would enable this functionality as initially the `input.name` from the `abi` was checked but mapping usually have no name and hence this would not take any args. This PR will add a check to see if the `input.name` is empty string and if so it would take into consideration that it is a mapping and hence extract the arguments in a different manner. 