### PR TITLE
[rpc] log client RPC events

### DIFF
--- a/nil/client/direct_client.go
+++ b/nil/client/direct_client.go
@@ -38,7 +38,7 @@ func NewEthClient(ctx context.Context, db db.ReadOnlyDB, nShards types.ShardId, 
 	}
 	localApi := rawapi.NewNodeApiOverShardApis(localShardApis)
 
-	ethApi := jsonrpc.NewEthAPI(ctx, localApi, db, true)
+	ethApi := jsonrpc.NewEthAPI(ctx, localApi, db, true, false)
 	debugApi := jsonrpc.NewDebugAPI(localApi, logger)
 	dbApi := jsonrpc.NewDbAPI(db, logger)
 

--- a/nil/common/logging/ch_logger.go
+++ b/nil/common/logging/ch_logger.go
@@ -1,0 +1,28 @@
+package logging
+
+import "github.com/rs/zerolog"
+
+type CHLogger struct {
+	l zerolog.Logger
+}
+
+func NewCHLogger(component, table string) CHLogger {
+	return CHLogger{
+		NewLogger(component).With().
+			Bool("store_to_clickhouse", true).
+			Str("database", "metrics").
+			Str("table", table).
+			Logger(),
+	}
+}
+
+func (l CHLogger) Disable() CHLogger {
+	l.l = zerolog.Nop()
+	return l
+}
+
+func (l CHLogger) Log() *zerolog.Event {
+	// cheap trick to ensure these logs are always written
+	// despite of zerolog global log level
+	return l.l.WithLevel(zerolog.PanicLevel) //nolint:zerologlint
+}

--- a/nil/common/logging/fields.go
+++ b/nil/common/logging/fields.go
@@ -51,4 +51,8 @@ const (
 	FieldHeight    = "height"
 	FieldRound     = "round"
 	FieldType      = "type"
+
+	FieldClientType    = "clientType"
+	FieldClientVersion = "clientVersion"
+	FieldUid           = "uid"
 )

--- a/nil/internal/collate/proposer_test.go
+++ b/nil/internal/collate/proposer_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/NilFoundation/nil/nil/internal/execution"
 	"github.com/NilFoundation/nil/nil/internal/types"
 	"github.com/NilFoundation/nil/nil/services/txnpool"
-	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -103,7 +102,7 @@ func (s *ProposerTestSuite) TestCollator() {
 		s.Require().NoError(err)
 		defer blockGenerator.Rollback()
 
-		_, err = blockGenerator.GenerateBlock(proposal, zerolog.Nop(), nil)
+		_, err = blockGenerator.GenerateBlock(proposal, nil)
 		s.Require().NoError(err)
 
 		return proposal

--- a/nil/internal/collate/replay_scheduler.go
+++ b/nil/internal/collate/replay_scheduler.go
@@ -80,7 +80,7 @@ func (s *ReplayScheduler) doReplay(ctx context.Context, blockId types.BlockNumbe
 	}
 	defer gen.Rollback()
 
-	if _, err := gen.GenerateBlock(proposal, s.logger, nil); err != nil {
+	if _, err := gen.GenerateBlock(proposal, nil); err != nil {
 		return err
 	}
 

--- a/nil/internal/collate/syncer.go
+++ b/nil/internal/collate/syncer.go
@@ -423,7 +423,7 @@ func (s *Syncer) replayBlock(ctx context.Context, block *types.BlockWithExtracte
 
 	// First we build block without writing it into the database, because we need to check that the resulted block is
 	// the same as the proposed one.
-	resBlock, err := gen.BuildBlock(proposal, s.logger)
+	resBlock, err := gen.BuildBlock(proposal)
 	if err != nil {
 		return fmt.Errorf("failed to build block: %w", err)
 	}

--- a/nil/internal/collate/validator.go
+++ b/nil/internal/collate/validator.go
@@ -38,7 +38,7 @@ func (s *Validator) VerifyProposal(ctx context.Context, proposal *execution.Prop
 	}
 	defer gen.Rollback()
 
-	res, err := gen.BuildBlock(proposal, s.logger)
+	res, err := gen.BuildBlock(proposal)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate block: %w", err)
 	}
@@ -53,7 +53,7 @@ func (s *Validator) InsertProposal(ctx context.Context, proposal *execution.Prop
 	}
 	defer gen.Rollback()
 
-	res, err := gen.GenerateBlock(proposal, s.logger, sig)
+	res, err := gen.GenerateBlock(proposal, sig)
 	if err != nil {
 		return fmt.Errorf("failed to generate block: %w", err)
 	}

--- a/nil/internal/execution/execution_state_test.go
+++ b/nil/internal/execution/execution_state_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/NilFoundation/nil/nil/internal/db"
 	"github.com/NilFoundation/nil/nil/internal/types"
 	"github.com/NilFoundation/nil/nil/internal/vm"
-	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -639,7 +638,6 @@ func BenchmarkBlockGeneration(b *testing.B) {
 	database, err := db.NewBadgerDbInMemory()
 	require.NoError(b, err)
 	logging.SetupGlobalLogger("error")
-	logger := zerolog.Nop()
 
 	address, err := contracts.CalculateAddress(contracts.NameCounter, 1, nil)
 	require.NoError(b, err)
@@ -684,7 +682,7 @@ contracts:
 
 		gen, err = NewBlockGenerator(ctx, params, database, nil, nil)
 		require.NoError(b, err)
-		_, err = gen.GenerateBlock(proposal, logger, nil)
+		_, err = gen.GenerateBlock(proposal, nil)
 		require.NoError(b, err)
 
 		tx.Rollback()

--- a/nil/services/nilservice/config.go
+++ b/nil/services/nilservice/config.go
@@ -46,6 +46,9 @@ type Config struct {
 	// Admin
 	AdminSocketPath string `yaml:"adminSocket,omitempty"`
 
+	// RPC events log
+	LogClientRpcEvents bool `yaml:"logClientRpcEvents,omitempty"`
+
 	// Keys
 	MainKeysPath         string                     `yaml:"mainKeysPath,omitempty"`
 	NetworkKeysPath      string                     `yaml:"networkKeysPath,omitempty"`

--- a/nil/services/nilservice/service.go
+++ b/nil/services/nilservice/service.go
@@ -54,6 +54,7 @@ func startRpcServer(ctx context.Context, cfg *Config, rawApi rawapi.NodeApi, db 
 		TraceRequests:   true,
 		HTTPTimeouts:    httpcfg.DefaultHTTPTimeouts,
 		HttpCORSDomain:  []string{"*"},
+		KeepHeaders:     []string{"Client-Version", "Client-Type", "X-UID"},
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -61,11 +62,11 @@ func startRpcServer(ctx context.Context, cfg *Config, rawApi rawapi.NodeApi, db 
 
 	var ethApiService any
 	if cfg.RunMode == NormalRunMode || cfg.RunMode == RpcRunMode {
-		ethImpl := jsonrpc.NewEthAPI(ctx, rawApi, db, pollBlocksForLogs)
+		ethImpl := jsonrpc.NewEthAPI(ctx, rawApi, db, pollBlocksForLogs, cfg.LogClientRpcEvents)
 		defer ethImpl.Shutdown()
 		ethApiService = ethImpl
 	} else {
-		ethImpl := jsonrpc.NewEthAPIRo(ctx, rawApi, db, pollBlocksForLogs)
+		ethImpl := jsonrpc.NewEthAPIRo(ctx, rawApi, db, pollBlocksForLogs, cfg.LogClientRpcEvents)
 		defer ethImpl.Shutdown()
 		ethApiService = ethImpl
 	}

--- a/nil/services/rpc/httpcfg/http_cfg.go
+++ b/nil/services/rpc/httpcfg/http_cfg.go
@@ -46,4 +46,6 @@ type HttpCfg struct {
 	HTTPTimeouts       HTTPTimeouts
 
 	RPCSlowLogThreshold time.Duration
+
+	KeepHeaders []string // List of headers to pass to the request handler
 }

--- a/nil/services/rpc/jsonrpc/eth_api_test.go
+++ b/nil/services/rpc/jsonrpc/eth_api_test.go
@@ -37,7 +37,7 @@ func NewTestEthAPI(t *testing.T, ctx context.Context, db db.DB, nShards int) *AP
 		require.NoError(t, err)
 	}
 	rawApi := rawapi.NewNodeApiOverShardApis(shardApis)
-	return NewEthAPI(ctx, rawApi, db, true)
+	return NewEthAPI(ctx, rawApi, db, true, false)
 }
 
 func TestGetTransactionReceipt(t *testing.T) {

--- a/nil/services/rpc/server.go
+++ b/nil/services/rpc/server.go
@@ -23,7 +23,7 @@ func StartRpcServer(
 	started chan<- struct{},
 ) error {
 	// register apis and create handler stack
-	srv := transport.NewServer(cfg.TraceRequests, cfg.DebugSingleRequest, logger, cfg.RPCSlowLogThreshold)
+	srv := transport.NewServer(cfg.TraceRequests, cfg.DebugSingleRequest, logger, cfg.RPCSlowLogThreshold, cfg.KeepHeaders)
 
 	defer srv.Stop()
 

--- a/nil/services/rpc/transport/handler_test.go
+++ b/nil/services/rpc/transport/handler_test.go
@@ -39,7 +39,7 @@ func TestHandlerDoesNotDoubleWriteNull(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			txn := Message{
+			msg := Message{
 				Version: "2.0",
 				ID:      []byte{49},
 				Method:  "test_test",
@@ -80,7 +80,7 @@ func TestHandlerDoesNotDoubleWriteNull(t *testing.T) {
 				streamable: true,
 			}
 
-			args, err := parsePositionalArguments((txn).Params, cb.argTypes)
+			args, err := parsePositionalArguments((msg).Params, cb.argTypes)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -89,7 +89,7 @@ func TestHandlerDoesNotDoubleWriteNull(t *testing.T) {
 			stream := jsoniter.NewStream(jsoniter.ConfigDefault, &buf, 4096)
 
 			h := handler{}
-			h.runMethod(t.Context(), &txn, cb, args, stream)
+			h.runMethod(t.Context(), &msg, cb, args, stream)
 
 			output := buf.String()
 			assert.Equal(t, testParams.expected, output, "expected output should match")

--- a/nil/services/rpc/transport/server_test.go
+++ b/nil/services/rpc/transport/server_test.go
@@ -19,7 +19,7 @@ func TestServer(t *testing.T) {
 			logger := logging.NewLogger("Test server")
 			// Create RPC server and handler.
 			var apis []API
-			server := NewServer(false /* traceRequests */, false /* traceSingleRequest */, logger, 0)
+			server := NewServer(false /* traceRequests */, false /* traceSingleRequest */, logger, 0, []string{})
 			if err := RegisterApisFromWhitelist(apis, conf.Modules, server, logger); err != nil {
 				return nil, logger
 			}

--- a/nil/services/rpc/transport/types.go
+++ b/nil/services/rpc/transport/types.go
@@ -39,7 +39,7 @@ type DataError interface {
 // a RPC session. Implementations must be go-routine safe since the codec can be called in
 // multiple go-routines concurrently.
 type ServerCodec interface {
-	Read() (txns []*Message, isBatch bool, err error)
+	Read() (msgs []*Message, isBatch bool, err error)
 	Close()
 	JsonWriter
 }


### PR DESCRIPTION
this PR adds some logging based on RPC request headers. mostly for debugging and understanding whether client functionality works properly as we release new versions of our CLI / wallet / nil.js

also it reworks a bit our mechanism for event writing to ClickHouse. since we reused `zerolog` interface here (which is rly convenient), there's one small caveat: we need to control global logging level. otherwise event logging may be occasionally disabled