### PR TITLE
[sync committee] Enable skip mode

### DIFF
--- a/nil/cmd/proof_provider/main.go
+++ b/nil/cmd/proof_provider/main.go
@@ -54,6 +54,7 @@ func addFlags(cmd *cobra.Command, cfg *cmdConfig) {
 	cmd.Flags().StringVar(&cfg.TaskListenerRpcEndpoint, "own-endpoint", cfg.TaskListenerRpcEndpoint, "own rpc server endpoint")
 	cmd.Flags().StringVar(&cfg.DbPath, "db-path", "proof_provider.db", "path to database")
 	cmd.Flags().BoolVar(&cfg.Telemetry.ExportMetrics, "metrics", cfg.Telemetry.ExportMetrics, "export metrics via grpc")
+	cmd.Flags().IntVar(&cfg.SkipRate, "skip", cfg.SkipRate, "rate of skip tasks, will skip N from 10, where N is value of option (0 means no skip). Possible values: [0,10]")
 	logLevel := cmd.Flags().String("log-level", "info", "log level: trace|debug|info|warn|error|fatal|panic")
 
 	cmd.PreRun = func(cmd *cobra.Command, args []string) {

--- a/nil/services/synccommittee/core/service_test.go
+++ b/nil/services/synccommittee/core/service_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"math/big"
 	"testing"
 	"time"
@@ -48,7 +49,7 @@ func (s *SyncCommitteeTestSuite) SetupSuite() {
 	var err error
 	s.scDb, err = db.NewBadgerDbInMemory()
 	s.Require().NoError(err)
-	ethClientMock := &rollupcontract.EthClientMock{ChainIDFunc: func(ctx context.Context) (*big.Int, error) { return big.NewInt(0), nil }}
+	ethClientMock := &rollupcontract.EthClientMock{ChainIDFunc: func(ctx context.Context) (*big.Int, error) { return big.NewInt(0), errors.New("Empty mocked call") }}
 	s.syncCommittee, err = New(cfg, s.scDb, ethClientMock)
 	s.Require().NoError(err)
 	syncCommitteeMetrics, err := metrics.NewSyncCommitteeMetrics()

--- a/nil/services/synccommittee/proofprovider/service.go
+++ b/nil/services/synccommittee/proofprovider/service.go
@@ -19,6 +19,7 @@ import (
 type Config struct {
 	SyncCommitteeRpcEndpoint string
 	TaskListenerRpcEndpoint  string
+	SkipRate                 int
 	Telemetry                *telemetry.Config
 }
 
@@ -26,6 +27,7 @@ func NewDefaultConfig() *Config {
 	return &Config{
 		SyncCommitteeRpcEndpoint: "tcp://127.0.0.1:8530",
 		TaskListenerRpcEndpoint:  "tcp://127.0.0.1:8531",
+		SkipRate:                 0,
 		Telemetry: &telemetry.Config{
 			ServiceName: "proof_provider",
 		},
@@ -59,7 +61,7 @@ func New(config *Config, database db.DB) (*ProofProvider, error) {
 	taskExecutor, err := executor.New(
 		executor.DefaultConfig(),
 		taskRpcClient,
-		newTaskHandler(taskStorage, timer, logger),
+		newTaskHandler(taskStorage, taskResultStorage, config.SkipRate, timer, logger),
 		metricsHandler,
 		logger,
 	)

--- a/nil/services/synccommittee/proofprovider/task_handler_test.go
+++ b/nil/services/synccommittee/proofprovider/task_handler_test.go
@@ -38,8 +38,9 @@ func (s *TaskHandlerTestSuite) SetupSuite() {
 	s.Require().NoError(err)
 
 	s.taskStorage = storage.NewTaskStorage(s.database, common.NewTimer(), metricsHandler, logger)
+	taskResultStorage := storage.NewTaskResultStorage(s.database, logger)
 	s.timer = testaide.NewTestTimer()
-	s.taskHandler = newTaskHandler(s.taskStorage, s.timer, logger)
+	s.taskHandler = newTaskHandler(s.taskStorage, taskResultStorage, 0, s.timer, logger)
 }
 
 func TestTaskHandlerSuite(t *testing.T) {


### PR DESCRIPTION
**Add mode `skip-proof` for prover:**  run without actual proof. It useful when need to check whole pipeline without powerful prover network.

**Allow start sync committee service without L1 contract access** for check main functionality even no access to L1 contract.
