### PR TITLE
Add playground rpc api healthcheck

### DIFF
--- a/explorer_frontend/src/features/account-connector/components/MainScreen.tsx
+++ b/explorer_frontend/src/features/account-connector/components/MainScreen.tsx
@@ -17,6 +17,7 @@ import { useUnit } from "effector-react";
 import { useEffect, useState } from "react";
 import { useStyletron } from "styletron-react";
 import { formatEther } from "viem";
+import { $rpcIsHealthy } from "../../healthcheck/model";
 import { OverflowEllipsis, useMobile } from "../../shared";
 import { ActiveComponent } from "../ActiveComponent";
 import CheckmarkIcon from "../assets/checkmark.svg";
@@ -49,12 +50,8 @@ const MainScreen = () => {
   const [copied, setCopied] = useState(false);
   const endpoint = useUnit($endpoint);
   const latestActivity = useUnit($latestActivity);
-  const [smartAccount, balance, balanceToken, isPendingSmartAccountCreation] = useUnit([
-    $smartAccount,
-    $balance,
-    $balanceToken,
-    createSmartAccountFx.pending,
-  ]);
+  const [smartAccount, balance, balanceToken, isPendingSmartAccountCreation, rpcIsHealthy] =
+    useUnit([$smartAccount, $balance, $balanceToken, createSmartAccountFx.pending, $rpcIsHealthy]);
   const [isPendingTopUp] = useUnit([topUpSmartAccountBalanceFx.pending]);
   const displayBalance = balance === null ? "-" : formatEther(balance);
   const [isMobile] = useMobile();
@@ -319,7 +316,7 @@ const MainScreen = () => {
         kind={BUTTON_KIND.primary}
         onClick={() => setActiveComponent(ActiveComponent.Topup)}
         isLoading={isPendingTopUp}
-        disabled={isPendingTopUp || isPendingSmartAccountCreation || !smartAccount}
+        disabled={isPendingTopUp || isPendingSmartAccountCreation || !smartAccount || !rpcIsHealthy}
         overrides={btnOverrides}
         className={css({
           whiteSpace: "nowrap",

--- a/explorer_frontend/src/features/contracts/components/Contracts/Contract.tsx
+++ b/explorer_frontend/src/features/contracts/components/Contracts/Contract.tsx
@@ -86,18 +86,22 @@ export const Contract: FC<ContractProps> = ({ contract, deployedApps, disabled }
                 ...expandProperty("borderRadius", "8px"),
                 ...expandProperty("transition", "background-color 0.15s ease-in"),
                 ":hover": {
-                  backgroundColor: COLORS.gray700,
+                  ...(disabled
+                    ? { backgroundColor: COLORS.gray800 }
+                    : { backgroundColor: COLORS.gray700 }),
                 },
-                cursor: "pointer",
+                cursor: disabled ? "auto" : "pointer",
                 ":first-child": {
                   marginTop: "12px",
                 },
               })}
               key={address}
               onClick={() => {
+                if (disabled) return;
                 choseApp({ address, bytecode });
               }}
               onKeyDown={() => {
+                if (disabled) return;
                 choseApp({ address, bytecode });
               }}
             >

--- a/explorer_frontend/src/features/contracts/components/Contracts/Contracts.tsx
+++ b/explorer_frontend/src/features/contracts/components/Contracts/Contracts.tsx
@@ -16,6 +16,7 @@ import { useStyletron } from "styletron-react";
 import { LayoutComponent, setActiveComponent } from "../../../../pages/playground/model";
 import { $smartAccount } from "../../../account-connector/model";
 import { compileCodeFx } from "../../../code/model";
+import { $rpcIsHealthy } from "../../../healthcheck/model";
 import { useMobile } from "../../../shared";
 import { Contract } from "./Contract";
 import { SmartAccountNotConnectedWarning } from "./SmartAccountNotConnectedWarning";
@@ -23,11 +24,12 @@ import { SmartAccountNotConnectedWarning } from "./SmartAccountNotConnectedWarni
 const MemoizedWarning = memo(SmartAccountNotConnectedWarning);
 
 export const Contracts = () => {
-  const [deployedApps, contracts, compilingContracts, smartAccount] = useUnit([
+  const [deployedApps, contracts, compilingContracts, smartAccount, rpcIsHealthy] = useUnit([
     $contractWithState,
     $contracts,
     compileCodeFx.pending,
     $smartAccount,
+    $rpcIsHealthy,
   ]);
   const [css] = useStyletron();
   const [isMobile] = useMobile();
@@ -113,7 +115,7 @@ export const Contracts = () => {
               key={`${contract.bytecode}-${i}`}
               contract={contract}
               deployedApps={appsToShow}
-              disabled={!smartAccountExists}
+              disabled={!smartAccountExists || !rpcIsHealthy}
             />
           );
         })}

--- a/explorer_frontend/src/features/healthcheck/components/NetworkErrorNotification.tsx
+++ b/explorer_frontend/src/features/healthcheck/components/NetworkErrorNotification.tsx
@@ -1,0 +1,27 @@
+import { COLORS, Notification, WarningIcon } from "@nilfoundation/ui-kit";
+import type { FC } from "react";
+import { useMobile } from "../../shared/hooks/useMobile";
+
+export const NetworkErrorNotification: FC = () => {
+  const [isMobile] = useMobile();
+  return (
+    <Notification
+      overrides={{
+        Body: {
+          style: {
+            position: "fixed",
+            bottom: "20px",
+            right: "16px",
+            zIndex: 9999,
+            background: COLORS.red800,
+            width: isMobile ? "300px" : "450px",
+          },
+        },
+      }}
+      icon={<WarningIcon />}
+      closeable={true}
+    >
+      Something is wrong with the network or you have an incorrect RPC url.
+    </Notification>
+  );
+};

--- a/explorer_frontend/src/features/healthcheck/index.ts
+++ b/explorer_frontend/src/features/healthcheck/index.ts
@@ -1,0 +1,1 @@
+export * from "./components/NetworkErrorNotification";

--- a/explorer_frontend/src/features/healthcheck/init.ts
+++ b/explorer_frontend/src/features/healthcheck/init.ts
@@ -1,0 +1,37 @@
+import { combine, sample } from "effector";
+import { interval } from "patronum";
+import { $endpoint } from "../account-connector/model";
+import { loadedPlaygroundPage } from "../code/model";
+import { playgroundRoute, playgroundWithHashRoute } from "../routing/routes/playgroundRoute";
+import { $isPageVisible, $rpcIsHealthy, checkRpcHealthFx, pageVisibilityChanged } from "./model";
+
+$isPageVisible.on(pageVisibilityChanged, (_, isVisible) => isVisible);
+document.addEventListener("visibilitychange", () => {
+  pageVisibilityChanged(document.visibilityState === "visible");
+});
+
+const { tick } = interval({
+  timeout: 1000 * 10,
+  start: loadedPlaygroundPage,
+  leading: true,
+});
+
+sample({
+  clock: tick,
+  target: checkRpcHealthFx,
+  source: $endpoint,
+  filter: combine(
+    $isPageVisible,
+    playgroundRoute.$isOpened,
+    playgroundWithHashRoute.$isOpened,
+    (isVisible, isPlaygroundOpened, isPlaygroundWithHashOpened) =>
+      isVisible && (isPlaygroundOpened || isPlaygroundWithHashOpened),
+  ),
+});
+
+sample({
+  clock: $endpoint,
+  target: checkRpcHealthFx,
+});
+
+$rpcIsHealthy.on(checkRpcHealthFx.doneData, (_, data) => data);

--- a/explorer_frontend/src/features/healthcheck/model.ts
+++ b/explorer_frontend/src/features/healthcheck/model.ts
@@ -1,0 +1,25 @@
+import { HttpTransport, PublicClient } from "@nilfoundation/niljs";
+import { createDomain } from "effector";
+
+export const healthcheckDomain = createDomain("healthcheck");
+
+export const $rpcIsHealthy = healthcheckDomain.createStore<boolean>(true);
+export const checkRpcHealthFx = healthcheckDomain.createEffect<string, boolean>();
+
+export const pageVisibilityChanged = healthcheckDomain.createEvent<boolean>();
+export const $isPageVisible = healthcheckDomain.createStore(document.visibilityState === "visible");
+
+checkRpcHealthFx.use(async (endpoint: string) => {
+  if (!endpoint) return true;
+
+  try {
+    const client = new PublicClient({
+      transport: new HttpTransport({ endpoint }),
+    });
+
+    const response = await client.chainId();
+    return typeof response === "number";
+  } catch {
+    return false;
+  }
+});

--- a/explorer_frontend/src/init.ts
+++ b/explorer_frontend/src/init.ts
@@ -10,3 +10,4 @@ import "./features/account-connector/init";
 import "./pages/playground/init";
 import "./features/tokens/init";
 import "./features/cometa/init";
+import "./features/healthcheck/init";

--- a/explorer_frontend/src/pages/playground/PlaygroundPage.tsx
+++ b/explorer_frontend/src/pages/playground/PlaygroundPage.tsx
@@ -8,6 +8,8 @@ import { AccountPane } from "../../features/account-connector";
 import { Code } from "../../features/code/Code";
 import { loadedPlaygroundPage } from "../../features/code/model";
 import { ContractsContainer, closeApp } from "../../features/contracts";
+import { NetworkErrorNotification } from "../../features/healthcheck";
+import { $rpcIsHealthy } from "../../features/healthcheck/model";
 import { Logs } from "../../features/logs/components/Logs";
 import { useMobile } from "../../features/shared";
 import { Navbar } from "../../features/shared/components/Layout/Navbar";
@@ -16,7 +18,7 @@ import { fetchSolidityCompiler } from "../../services/compiler";
 import { PlaygroundMobileLayout } from "./PlaygroundMobileLayout";
 
 export const PlaygroundPage = () => {
-  const [isDownloading] = useUnit([fetchSolidityCompiler.pending]);
+  const [isDownloading, isRPCHealthy] = useUnit([fetchSolidityCompiler.pending, $rpcIsHealthy]);
   const [css] = useStyletron();
   const [isMobile] = useMobile();
 
@@ -30,6 +32,7 @@ export const PlaygroundPage = () => {
 
   return (
     <div className={css(isMobile ? mobileContainerStyle : styles.container)}>
+      {!isRPCHealthy && <NetworkErrorNotification />}
       <Navbar>
         <AccountPane />
       </Navbar>


### PR DESCRIPTION
When rpc api is inaccessible or user has an invalid rpc url, we want to let them know something is wrong.
We are going to display a warning if api is inaccessible and disable some UI features as well.

RPC check is made every 10 seconds or on any endpoint change. If user is not on the page the check is not made for the sake of optimizing resources.