### PR TITLE
Sync Committee: Storage interfaces refactoring

### DIFF
--- a/nil/services/synccommittee/core/aggregator.go
+++ b/nil/services/synccommittee/core/aggregator.go
@@ -28,10 +28,15 @@ type AggregatorMetrics interface {
 	RecordBlockBatchSize(ctx context.Context, batchSize int64)
 }
 
-type Aggregator struct {
+type AggregatorBlockStorage interface {
+	TryGetLatestFetched(ctx context.Context) (*types.MainBlockRef, error)
+	SetBlockBatch(ctx context.Context, batch *types.BlockBatch) error
+}
+
+type aggregator struct {
 	logger         zerolog.Logger
 	rpcClient      client.Client
-	blockStorage   storage.BlockStorage
+	blockStorage         AggregatorBlockStorage
 	taskStorage    storage.TaskStorage
 	batchCommitter batches.BatchCommitter
 	timer          common.Timer
@@ -41,17 +46,17 @@ type Aggregator struct {
 
 func NewAggregator(
 	rpcClient client.Client,
-	blockStorage storage.BlockStorage,
+	blockStorage AggregatorBlockStorage,
 	taskStorage storage.TaskStorage,
 	timer common.Timer,
 	logger zerolog.Logger,
 	metrics AggregatorMetrics,
 	pollingDelay time.Duration,
-) *Aggregator {
-	aggregator := &Aggregator{
-		rpcClient:    rpcClient,
-		blockStorage: blockStorage,
-		taskStorage:  taskStorage,
+) *aggregator {
+	agg := &aggregator{
+		rpcClient: rpcClient,
+		blockStorage:    blockStorage,
+		taskStorage:     taskStorage,
 		batchCommitter: batches.NewBatchCommitter(
 			v1.NewEncoder(logger),
 			blob.NewBuilder(),
@@ -63,16 +68,16 @@ func NewAggregator(
 		metrics: metrics,
 	}
 
-	aggregator.workerAction = concurrent.NewSuspendable(aggregator.runIteration, pollingDelay)
-	aggregator.logger = srv.WorkerLogger(logger, aggregator)
-	return aggregator
+	agg.workerAction = concurrent.NewSuspendable(agg.runIteration, pollingDelay)
+	agg.logger = srv.WorkerLogger(logger, agg)
+	return agg
 }
 
-func (agg *Aggregator) Name() string {
+func (agg *aggregator) Name() string {
 	return "aggregator"
 }
 
-func (agg *Aggregator) Run(ctx context.Context, started chan<- struct{}) error {
+func (agg *aggregator) Run(ctx context.Context, started chan<- struct{}) error {
 	agg.logger.Info().Msg("starting blocks fetching")
 
 	err := agg.workerAction.Run(ctx, started)
@@ -86,7 +91,7 @@ func (agg *Aggregator) Run(ctx context.Context, started chan<- struct{}) error {
 	return err
 }
 
-func (agg *Aggregator) Pause(ctx context.Context) error {
+func (agg *aggregator) Pause(ctx context.Context) error {
 	paused, err := agg.workerAction.Pause(ctx)
 	if err != nil {
 		return err
@@ -97,7 +102,7 @@ func (agg *Aggregator) Pause(ctx context.Context) error {
 	return nil
 }
 
-func (agg *Aggregator) Resume(ctx context.Context) error {
+func (agg *aggregator) Resume(ctx context.Context) error {
 	resumed, err := agg.workerAction.Resume(ctx)
 	if err != nil {
 		return err
@@ -108,7 +113,7 @@ func (agg *Aggregator) Resume(ctx context.Context) error {
 	return nil
 }
 
-func (agg *Aggregator) runIteration(ctx context.Context) {
+func (agg *aggregator) runIteration(ctx context.Context) {
 	err := agg.processNewBlocks(ctx)
 
 	if errors.Is(err, types.ErrBatchNotReady) {
@@ -124,7 +129,7 @@ func (agg *Aggregator) runIteration(ctx context.Context) {
 
 // processNewBlocks fetches and processes new blocks for all shards.
 // It handles the overall flow of block synchronization and proof creation.
-func (agg *Aggregator) processNewBlocks(ctx context.Context) error {
+func (agg *aggregator) processNewBlocks(ctx context.Context) error {
 	latestBlock, err := agg.fetchLatestBlockRef(ctx)
 	if err != nil {
 		return err
@@ -139,7 +144,7 @@ func (agg *Aggregator) processNewBlocks(ctx context.Context) error {
 }
 
 // fetchLatestBlocks retrieves the latest block for main shard
-func (agg *Aggregator) fetchLatestBlockRef(ctx context.Context) (*types.MainBlockRef, error) {
+func (agg *aggregator) fetchLatestBlockRef(ctx context.Context) (*types.MainBlockRef, error) {
 	block, err := agg.rpcClient.GetBlock(ctx, coreTypes.MainShardId, "latest", false)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching latest block from shard %d: %w", coreTypes.MainShardId, err)
@@ -149,7 +154,7 @@ func (agg *Aggregator) fetchLatestBlockRef(ctx context.Context) (*types.MainBloc
 
 // processShardBlocks handles the processing of new blocks for the main shard.
 // It fetches new blocks, updates the storage, and records relevant metrics.
-func (agg *Aggregator) processShardBlocks(ctx context.Context, actualLatest types.MainBlockRef) error {
+func (agg *aggregator) processShardBlocks(ctx context.Context, actualLatest types.MainBlockRef) error {
 	latestFetched, err := agg.blockStorage.TryGetLatestFetched(ctx)
 	if err != nil {
 		return fmt.Errorf("error reading latest fetched block for the main shard: %w", err)
@@ -175,7 +180,7 @@ func (agg *Aggregator) processShardBlocks(ctx context.Context, actualLatest type
 }
 
 // fetchAndProcessBlocks retrieves a range of blocks for a main shard, stores them, creates proof tasks
-func (agg *Aggregator) fetchAndProcessBlocks(ctx context.Context, blocksRange types.BlocksRange) error {
+func (agg *aggregator) fetchAndProcessBlocks(ctx context.Context, blocksRange types.BlocksRange) error {
 	shardId := coreTypes.MainShardId
 	const requestBatchSize = 20
 	results, err := agg.rpcClient.GetBlocksRange(ctx, shardId, blocksRange.Start, blocksRange.End+1, true, requestBatchSize)
@@ -200,7 +205,7 @@ func (agg *Aggregator) fetchAndProcessBlocks(ctx context.Context, blocksRange ty
 	return nil
 }
 
-func (agg *Aggregator) createBlockBatch(ctx context.Context, mainShardBlock *jsonrpc.RPCBlock) (*types.BlockBatch, error) {
+func (agg *aggregator) createBlockBatch(ctx context.Context, mainShardBlock *jsonrpc.RPCBlock) (*types.BlockBatch, error) {
 	childIds, err := types.ChildBlockIds(mainShardBlock)
 	if err != nil {
 		return nil, err
@@ -222,7 +227,7 @@ func (agg *Aggregator) createBlockBatch(ctx context.Context, mainShardBlock *jso
 }
 
 // handleBlockBatch checks the validity of a block and stores it if valid.
-func (agg *Aggregator) handleBlockBatch(ctx context.Context, batch *types.BlockBatch) error {
+func (agg *aggregator) handleBlockBatch(ctx context.Context, batch *types.BlockBatch) error {
 	latestFetched, err := agg.blockStorage.TryGetLatestFetched(ctx)
 	if err != nil {
 		return fmt.Errorf("error reading latest fetched block from storage: %w", err)
@@ -249,7 +254,7 @@ func (agg *Aggregator) handleBlockBatch(ctx context.Context, batch *types.BlockB
 }
 
 // createProofTask generates proof tasks for block batch
-func (agg *Aggregator) createProofTasks(ctx context.Context, batch *types.BlockBatch) error {
+func (agg *aggregator) createProofTasks(ctx context.Context, batch *types.BlockBatch) error {
 	currentTime := agg.timer.NowTime()
 	proofTasks, err := batch.CreateProofTasks(currentTime)
 	if err != nil {

--- a/nil/services/synccommittee/core/aggregator_test.go
+++ b/nil/services/synccommittee/core/aggregator_test.go
@@ -26,11 +26,11 @@ type AggregatorTestSuite struct {
 	cancellation context.CancelFunc
 
 	db           db.DB
-	blockStorage storage.BlockStorage
+	blockStorage *storage.BlockStorage
 	taskStorage  storage.TaskStorage
 
 	rpcClientMock *client.ClientMock
-	aggregator    *Aggregator
+	aggregator    *aggregator
 }
 
 func TestAggregatorTestSuite(t *testing.T) {

--- a/nil/services/synccommittee/core/aggregator_test.go
+++ b/nil/services/synccommittee/core/aggregator_test.go
@@ -27,7 +27,7 @@ type AggregatorTestSuite struct {
 
 	db           db.DB
 	blockStorage *storage.BlockStorage
-	taskStorage  storage.TaskStorage
+	taskStorage  *storage.TaskStorage
 
 	rpcClientMock *client.ClientMock
 	aggregator    *aggregator
@@ -50,7 +50,6 @@ func (s *AggregatorTestSuite) SetupSuite() {
 	timer := common.NewTimer()
 	s.blockStorage = storage.NewBlockStorage(s.db, timer, metricsHandler, logger)
 	s.taskStorage = storage.NewTaskStorage(s.db, timer, metricsHandler, logger)
-
 	s.rpcClientMock = &client.ClientMock{}
 
 	s.aggregator = NewAggregator(

--- a/nil/services/synccommittee/core/block_tasks_integration_test.go
+++ b/nil/services/synccommittee/core/block_tasks_integration_test.go
@@ -22,10 +22,11 @@ type BlockTasksIntegrationTestSuite struct {
 	ctx          context.Context
 	cancellation context.CancelFunc
 
-	db           db.DB
-	timer        common.Timer
+	db    db.DB
+	timer common.Timer
+
 	taskStorage  storage.TaskStorage
-	blockStorage storage.BlockStorage
+	blockStorage *storage.BlockStorage
 
 	scheduler scheduler.TaskScheduler
 }

--- a/nil/services/synccommittee/core/block_tasks_integration_test.go
+++ b/nil/services/synccommittee/core/block_tasks_integration_test.go
@@ -25,7 +25,7 @@ type BlockTasksIntegrationTestSuite struct {
 	db    db.DB
 	timer common.Timer
 
-	taskStorage  storage.TaskStorage
+	taskStorage  *storage.TaskStorage
 	blockStorage *storage.BlockStorage
 
 	scheduler scheduler.TaskScheduler

--- a/nil/services/synccommittee/core/proposer_test.go
+++ b/nil/services/synccommittee/core/proposer_test.go
@@ -30,9 +30,9 @@ type ProposerTestSuite struct {
 	params           *ProposerParams
 	db               db.DB
 	timer            common.Timer
-	storage          storage.BlockStorage
+	storage          *storage.BlockStorage
 	ethClient        *rollupcontract.EthClientMock
-	proposer         *Proposer
+	proposer         *proposer
 	testData         *types.ProposalData
 	callContractMock *callContractMock
 }

--- a/nil/services/synccommittee/core/service.go
+++ b/nil/services/synccommittee/core/service.go
@@ -40,7 +40,7 @@ func New(cfg *Config, database db.DB, ethClient rollupcontract.EthClient) (*Sync
 	blockStorage := storage.NewBlockStorage(database, timer, metricsHandler, logger)
 	taskStorage := storage.NewTaskStorage(database, timer, metricsHandler, logger)
 
-	aggregator := NewAggregator(
+	agg := NewAggregator(
 		client,
 		blockStorage,
 		taskStorage,
@@ -80,7 +80,7 @@ func New(cfg *Config, database db.DB, ethClient rollupcontract.EthClient) (*Sync
 	s := &SyncCommittee{
 		Service: srv.NewService(
 			logger,
-			proposer, aggregator, taskScheduler, taskListener,
+			proposer, agg, taskScheduler, taskListener,
 		),
 	}
 

--- a/nil/services/synccommittee/core/service_test.go
+++ b/nil/services/synccommittee/core/service_test.go
@@ -25,7 +25,7 @@ type SyncCommitteeTestSuite struct {
 
 	url           string
 	nShards       uint32
-	blockStorage  storage.BlockStorage
+	blockStorage  *storage.BlockStorage
 	syncCommittee *SyncCommittee
 	scDb          db.DB
 }

--- a/nil/services/synccommittee/internal/rpc/client.go
+++ b/nil/services/synccommittee/internal/rpc/client.go
@@ -11,7 +11,7 @@ import (
 	"github.com/rs/zerolog"
 )
 
-var retryConfig common.RetryConfig = common.RetryConfig{
+var retryConfig = common.RetryConfig{
 	ShouldRetry: common.LimitRetries(5),
 	NextDelay:   common.DelayExponential(100*time.Millisecond, time.Second),
 }

--- a/nil/services/synccommittee/internal/rpc/task_debug_rpc_test.go
+++ b/nil/services/synccommittee/internal/rpc/task_debug_rpc_test.go
@@ -29,8 +29,8 @@ type TaskSchedulerDebugRpcTestSuite struct {
 	scheduler scheduler.TaskScheduler
 
 	database db.DB
+	storage  *storage.TaskStorage
 	timer    *common.TestTimerImpl
-	storage  storage.TaskStorage
 }
 
 func TestTaskSchedulerDebugRpcTestSuite(t *testing.T) {

--- a/nil/services/synccommittee/internal/scheduler/task_result_sender_test.go
+++ b/nil/services/synccommittee/internal/scheduler/task_result_sender_test.go
@@ -24,8 +24,9 @@ type TaskResultSenderSuite struct {
 	cancel context.CancelFunc
 
 	database      db.DB
-	logger        zerolog.Logger
-	resultStorage storage.TaskResultStorage
+	resultStorage *storage.TaskResultStorage
+
+	logger zerolog.Logger
 }
 
 func TestTaskResultSenderSuite(t *testing.T) {

--- a/nil/services/synccommittee/internal/storage/block_storage_test.go
+++ b/nil/services/synccommittee/internal/storage/block_storage_test.go
@@ -23,7 +23,7 @@ type BlockStorageTestSuite struct {
 	db           db.DB
 	ctx          context.Context
 	cancellation context.CancelFunc
-	bs           BlockStorage
+	bs           *BlockStorage
 }
 
 func (s *BlockStorageTestSuite) SetupSuite() {

--- a/nil/services/synccommittee/internal/storage/task_result_storage_test.go
+++ b/nil/services/synccommittee/internal/storage/task_result_storage_test.go
@@ -18,7 +18,7 @@ type TaskResultStorageSuite struct {
 	cancel context.CancelFunc
 
 	database db.DB
-	storage  TaskResultStorage
+	storage  *TaskResultStorage
 }
 
 func TestTaskResultStorageSuite(t *testing.T) {
@@ -64,7 +64,7 @@ func (s *TaskResultStorageSuite) Test_Put_Same_Task_Result_N_Times() {
 	s.Require().Equal(result, resultFromStorage)
 }
 
-func (s *TaskResultStorageSuite) Test_Delete_Same_Task_Result_N_Times() {
+func (s *TaskResultStorageSuite) Test_SetAsSubmitted_Same_Task_Result_N_Times() {
 	result := types.NewFailureProviderTaskResult(
 		types.NewTaskId(),
 		testaide.RandomExecutorId(),
@@ -75,7 +75,7 @@ func (s *TaskResultStorageSuite) Test_Delete_Same_Task_Result_N_Times() {
 	s.Require().NoError(err)
 
 	for range 3 {
-		err := s.storage.Delete(s.ctx, result.TaskId)
+		err := s.storage.SetAsSubmitted(s.ctx, result.TaskId)
 		s.Require().NoError(err)
 
 		nextRes, err := s.storage.TryGetPending(s.ctx)
@@ -101,7 +101,7 @@ func (s *TaskResultStorageSuite) Test_Put_Get_Delete_Results() {
 
 		resultsFromStorage = append(resultsFromStorage, resultFromStorage)
 
-		err = s.storage.Delete(s.ctx, resultFromStorage.TaskId)
+		err = s.storage.SetAsSubmitted(s.ctx, resultFromStorage.TaskId)
 		s.Require().NoError(err)
 	}
 

--- a/nil/services/synccommittee/internal/storage/task_storage_test.go
+++ b/nil/services/synccommittee/internal/storage/task_storage_test.go
@@ -24,7 +24,7 @@ type TaskStorageSuite struct {
 	suite.Suite
 	database db.DB
 	timer    common.Timer
-	ts       TaskStorage
+	ts       *TaskStorage
 	ctx      context.Context
 }
 

--- a/nil/services/synccommittee/proofprovider/task_handler_test.go
+++ b/nil/services/synccommittee/proofprovider/task_handler_test.go
@@ -21,7 +21,7 @@ type TaskHandlerTestSuite struct {
 	cancellation context.CancelFunc
 	database     db.DB
 	timer        common.Timer
-	taskStorage  storage.TaskStorage
+	taskStorage  *storage.TaskStorage
 	taskHandler  api.TaskHandler
 }
 

--- a/nil/services/synccommittee/proofprovider/task_state_change_handler.go
+++ b/nil/services/synccommittee/proofprovider/task_state_change_handler.go
@@ -6,19 +6,22 @@ import (
 	"github.com/NilFoundation/nil/nil/common/logging"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/api"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/log"
-	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/storage"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
 	"github.com/rs/zerolog"
 )
 
+type TaskResultSaver interface {
+	Put(ctx context.Context, result *types.TaskResult) error
+}
+
 type taskStateChangeHandler struct {
-	resultStorage     storage.TaskResultStorage
+	resultStorage     TaskResultSaver
 	currentExecutorId types.TaskExecutorId
 	logger            zerolog.Logger
 }
 
 func newTaskStateChangeHandler(
-	resultStorage storage.TaskResultStorage,
+	resultStorage TaskResultSaver,
 	currentExecutorId types.TaskExecutorId,
 	logger zerolog.Logger,
 ) api.TaskStateChangeHandler {


### PR DESCRIPTION
### Sync Committee: Storage interfaces refactoring

These changes are aimed to decouple storage-related logic of core SC components (mainly `Aggregator` and `Proposer`) and ease ongoing development of `Observer`

### BlockStorage
* Separated block storage functionality into distinct interfaces: `AggregatorBlocks`, `ProposerBlocks` and `ProvedBlockSetter`;
* Updated related code and tests to use these new interfaces;

### TaskStorage
* Moved `TaskStorage` and `TaskResultStorage` from `storage` package to the packages which use them;
* Declared new interfaces `AggregatorTasks`, `HandlerTasks` and `TaskResultSaver` with limited sets of methods;
