### PR TITLE
[syncer] drop per-shard snapshot bootstrap

### DIFF
--- a/nil/contracts/solidity/tests/Token.sol
+++ b/nil/contracts/solidity/tests/Token.sol
@@ -13,7 +13,7 @@ contract Token is NilTokenBase {
 
     receive() external payable {}
 
-    function verifyExternal(uint256 hash, bytes calldata signature) external view returns (bool) {
+    function verifyExternal(uint256, bytes calldata) external pure returns (bool) {
         return true;
     }
 

--- a/nil/internal/collate/scheduler.go
+++ b/nil/internal/collate/scheduler.go
@@ -84,9 +84,6 @@ func (s *Scheduler) Run(ctx context.Context, syncer *Syncer, consensus Consensus
 	s.consensus = consensus
 	s.syncer = syncer
 
-	// Enable handler for snapshot relaying
-	SetBootstrapHandler(ctx, s.networkManager, s.params.ShardId, s.txFabric)
-
 	// Enable handler for blocks relaying
 	SetRequestHandler(ctx, s.networkManager, s.params.ShardId, s.txFabric, s.logger)
 

--- a/nil/internal/db/tables.go
+++ b/nil/internal/db/tables.go
@@ -1,7 +1,6 @@
 package db
 
 import (
-	"bytes"
 	"fmt"
 
 	"github.com/NilFoundation/nil/nil/common"
@@ -42,61 +41,6 @@ func ShardTableName(tableName ShardedTableName, shardId types.ShardId) TableName
 
 func ShardBlocksTrieTableName(blockId types.BlockNumber) ShardedTableName {
 	return ShardedTableName(fmt.Sprintf("%s%d", shardBlocksTrieTable, blockId))
-}
-
-func IsKeyFromShardBlocksTrieTable(key []byte, shardId types.ShardId) bool {
-	return shardId.IsMainShard() && bytes.HasPrefix(key, []byte(shardBlocksTrieTable))
-}
-
-func CreateKeyFromShardTableChecker(shardId types.ShardId) func([]byte) bool {
-	shardTableNames := []ShardedTableName{
-		blockTable,
-		blockTimestampTable,
-		codeTable,
-
-		ContractTrieTable,
-		StorageTrieTable,
-		TransactionTrieTable,
-		ReceiptTrieTable,
-		TokenTrieTable,
-		ConfigTrieTable,
-		ContractTable,
-		BlockHashByNumberIndex,
-		BlockHashAndInTransactionIndexByTransactionHash,
-		BlockHashAndOutTransactionIndexByTransactionHash,
-		AsyncCallContextTable,
-	}
-
-	shardTables := make([]TableName, len(shardTableNames))
-	for i, t := range shardTableNames {
-		shardTables[i] = ShardTableName(t, shardId)
-	}
-
-	systemTables := []TableName{
-		LastBlockTable,
-		collatorStateTable,
-	}
-
-	systemKeys := make(map[string]struct{})
-	for _, t := range systemTables {
-		k := MakeKey(t, shardId.Bytes())
-		systemKeys[string(k)] = struct{}{}
-	}
-
-	return func(key []byte) bool {
-		if _, exists := systemKeys[string(key)]; exists {
-			return true
-		}
-		if IsKeyFromShardBlocksTrieTable(key, shardId) {
-			return true
-		}
-		for _, shardedTable := range shardTables {
-			if IsKeyFromTable(shardedTable, key) {
-				return true
-			}
-		}
-		return false
-	}
 }
 
 type BlockHashAndTransactionIndex struct {

--- a/nil/internal/network/addr_info.go
+++ b/nil/internal/network/addr_info.go
@@ -16,8 +16,8 @@ func (a *AddrInfo) Set(value string) error {
 	return nil
 }
 
-func (a *AddrInfo) String() string {
-	mu, err := peer.AddrInfoToP2pAddrs((*peer.AddrInfo)(a))
+func (a AddrInfo) String() string {
+	mu, err := peer.AddrInfoToP2pAddrs((*peer.AddrInfo)(&a))
 	if err != nil {
 		return err.Error()
 	}


### PR DESCRIPTION
Anyway we decided that all validator/archive_nodes replicate all data of all shards. So no need to support per-shard snapshotting.