### PR TITLE
Set initial random shard-id in playground

### DIFF
--- a/explorer_frontend/src/features/contracts/models/base.ts
+++ b/explorer_frontend/src/features/contracts/models/base.ts
@@ -79,11 +79,13 @@ export const setDeploymentArg = createEvent<{
 export const $importedAddress = createStore<string>("");
 export const setAssignAddress = createEvent<string>();
 
-export const $shardId = createStore<number | null>(1);
+export const $shardId = createStore<number | null>(null);
 
 export const setShardId = createEvent<number | null>();
+export const setRandomShardId = createEvent();
 export const incrementShardId = createEvent("increment");
 export const decrementShardId = createEvent("decrement");
+export const triggerShardIdValidation = createEvent();
 
 export const deploySmartContract = createEvent();
 export const deploySmartContractFx = createEffect<


### PR DESCRIPTION
We had a discussion about shard id and decided to change a little the mechanics of shard id.
What we want:
- When user opens modal initially and there is no previously used shard id, we need to set as a default value any random number in the range from `0` to `shards amount`.
- When user opens modal second time, we need to preserve previously used shard id, because it is more probable theat user is going to use it again.
- Important notes - always trigger validation on default value