### PR TITLE
Fix issue with playground RPC input hidden border

### DIFF
--- a/explorer_frontend/src/features/account-connector/components/MainScreen.tsx
+++ b/explorer_frontend/src/features/account-connector/components/MainScreen.tsx
@@ -156,9 +156,10 @@ const MainScreen = () => {
               overrides={{
                 Root: {
                   style: {
-                    flex: 1, // Makes input take full available width
+                    flex: 1,
                     height: "48px",
                     background: COLORS.gray700,
+                    boxShadow: "none",
                     ":hover": {
                       background: COLORS.gray600,
                     },
@@ -166,7 +167,6 @@ const MainScreen = () => {
                 },
               }}
             />
-
             {/* Copy Button */}
             <Button
               kind={BUTTON_KIND.secondary}


### PR DESCRIPTION
This PR solves the bug mentioned [here](https://github.com/NilFoundation/nil/issues/304). Currently, the RPC input, after connecting the wallet is a readOnly input and would confuse users form trying to edit as it appears as a normal input box where you can click on it and the borders get highlighted, just as every input box getting active. This PR would make the RPC input box inactive and not allow for focussing so that it behaves as a non-interactive UI component, removing a confusion for the interaction with the input box. 