### PR TITLE
disable macos builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,53 +26,54 @@ jobs:
       - name: run check
         run: nix build .#checks.x86_64-linux.${{ matrix.check == 'nil' && 'others' || matrix.check }} -L
 
-  nix_check_macos:
-    name: macOS CI (${{ matrix.platform.os}}, ${{ matrix.platform.arch }}) - ${{ matrix.check }}
-    environment: prod
-    runs-on: ${{ matrix.platform.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        # Add other checks later, when they are stabilized, and caching will be configured for Nix.
-        check: ["clijs"]
-        platform:
-          # N.B. The architecture is chosen by GitHub at `runs-on` depending on the label (`os`)
-          # See https://github.com/actions/runner-images?tab=readme-ov-file#available-images
-          # The other fields only affect the logic of our steps
-          - os: macos-latest
-            arch: aarch64
-            nixArch: aarch64-darwin
-          # we're out of CI runners capacity right now. this needs to be returned later
-          # - os: macos-15-large
-          #   arch: x64
-          #   nixArch: x86_64-darwin
-    steps:
-      - name: checkout local actions
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+  # TODO: enable check after adding caches to the build
+  # nix_check_macos:
+  #   name: macOS CI (${{ matrix.platform.os}}, ${{ matrix.platform.arch }}) - ${{ matrix.check }}
+  #   environment: prod
+  #   runs-on: ${{ matrix.platform.os }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       # Add other checks later, when they are stabilized, and caching will be configured for Nix.
+  #       check: ["clijs"]
+  #       platform:
+  #         # N.B. The architecture is chosen by GitHub at `runs-on` depending on the label (`os`)
+  #         # See https://github.com/actions/runner-images?tab=readme-ov-file#available-images
+  #         # The other fields only affect the logic of our steps
+  #         - os: macos-latest
+  #           arch: aarch64
+  #           nixArch: aarch64-darwin
+  #         # we're out of CI runners capacity right now. this needs to be returned later
+  #         # - os: macos-15-large
+  #         #   arch: x64
+  #         #   nixArch: x86_64-darwin
+  #   steps:
+  #     - name: checkout local actions
+  #       uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0
 
-      # https://github.com/NixOS/nix/issues/2242#issuecomment-2336841344
-      - name: macOS 15 eDSRecordAlreadyExists workaround
-        run: echo "NIX_FIRST_BUILD_UID=30001" >> "$GITHUB_ENV"
+  #     # https://github.com/NixOS/nix/issues/2242#issuecomment-2336841344
+  #     - name: macOS 15 eDSRecordAlreadyExists workaround
+  #       run: echo "NIX_FIRST_BUILD_UID=30001" >> "$GITHUB_ENV"
 
-      - name: Install Nix
-        uses: cachix/install-nix-action@v27
-        with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-          extra_nix_config: |
-            max-jobs = 1
+  #     - name: Install Nix
+  #       uses: cachix/install-nix-action@v27
+  #       with:
+  #         github_access_token: ${{ secrets.GITHUB_TOKEN }}
+  #         extra_nix_config: |
+  #           max-jobs = 1
 
-      - name: Run check
-        run: nix build .#checks.${{ matrix.platform.nixArch }}.${{ matrix.check == 'nil' && 'others' || matrix.check }} -L
+  #     - name: Run check
+  #       run: nix build .#checks.${{ matrix.platform.nixArch }}.${{ matrix.check == 'nil' && 'others' || matrix.check }} -L
 
-      - name: Upload nil binary as artifact
-        if: github.event_name == 'workflow_dispatch'
-        uses: actions/upload-artifact@v4
-        with:
-          name: clijs-darwin-${{ matrix.platform.arch }}
-          path: |
-            result/clijs
+  #     - name: Upload nil binary as artifact
+  #       if: github.event_name == 'workflow_dispatch'
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: clijs-darwin-${{ matrix.platform.arch }}
+  #         path: |
+  #           result/clijs
 
   ensure_cluster_builds_macos:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
currently macos builds don't have any caching. this is rly frustrating, cause every CI checks takes 1h+

for sure we'll fix this later, but as a temporary solution I propose to disable em