### PR TITLE
[execution] unify config accessor management between gas prices and validators

### DIFF
--- a/nil/internal/collate/block_listener.go
+++ b/nil/internal/collate/block_listener.go
@@ -238,6 +238,7 @@ func SetRequestHandler(
 
 			if err := writeBlockToStream(s, b); err != nil {
 				logError(logger, err, "Failed to handle output block")
+				return
 			}
 		}
 	}

--- a/nil/internal/collate/proposer.go
+++ b/nil/internal/collate/proposer.go
@@ -83,13 +83,13 @@ func (p *proposer) GenerateProposal(ctx context.Context, txFabric db.DB) (*execu
 		return nil, fmt.Errorf("failed to fetch previous block: %w", err)
 	}
 
-	configAccessor, err := config.NewConfigAccessorTx(tx, nil)
+	configAccessor, err := config.NewConfigAccessorFromBlockWithTx(tx, block, p.params.ShardId)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create config accessor: %w", err)
 	}
 
 	p.executionState, err = execution.NewExecutionState(tx, p.params.ShardId, execution.StateParams{
-		GetBlockFromDb: true,
+		Block:          block,
 		ConfigAccessor: configAccessor,
 	})
 	if err != nil {

--- a/nil/internal/config/config.go
+++ b/nil/internal/config/config.go
@@ -118,6 +118,7 @@ func NewConfigAccessorByNumberTx(ctx context.Context, tx db.RoTx, mainShardBlock
 	return NewConfigAccessorTx(tx, &mainShardHash)
 }
 
+// NewConfigAccessorTx creates a new configAccessorImpl reading the whole trie from the MPT.
 func NewConfigAccessorTx(tx db.RoTx, mainShardHash *common.Hash) (ConfigAccessor, error) {
 	trie, err := GetConfigTrie(tx, mainShardHash)
 	if err != nil {
@@ -135,16 +136,6 @@ func NewConfigAccessorFromMap(data map[string][]byte) ConfigAccessor {
 		data,
 		make(map[string][]byte),
 	}
-}
-
-// NewConfigAccessor creates a new configAccessorImpl reading the whole trie from the MPT.
-func NewConfigAccessor(ctx context.Context, db db.DB, mainShardHash *common.Hash) (ConfigAccessor, error) {
-	tx, err := db.CreateRoTx(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create read-only transaction: %w", err)
-	}
-	defer tx.Rollback()
-	return NewConfigAccessorTx(tx, mainShardHash)
 }
 
 // Commit updates the config trie with the current state of the configAccessorImpl.

--- a/nil/internal/consensus/ibft/validators.go
+++ b/nil/internal/consensus/ibft/validators.go
@@ -8,7 +8,6 @@ import (
 	"github.com/NilFoundation/nil/nil/internal/config"
 	"github.com/NilFoundation/nil/nil/internal/db"
 	"github.com/NilFoundation/nil/nil/internal/types"
-	"github.com/rs/zerolog"
 )
 
 func (i *backendIBFT) calcProposer(height, round uint64) (*config.ValidatorInfo, error) {
@@ -70,7 +69,7 @@ type validatorValue struct {
 }
 
 func (v *validatorValue) getValidators(ctx context.Context) ([]config.ValidatorInfo, error) {
-	return config.GetValidatorListForShard(ctx, v.txFabric, types.BlockNumber(v.height), v.shardId, zerolog.Nop())
+	return config.GetValidatorListForShard(ctx, v.txFabric, types.BlockNumber(v.height), v.shardId)
 }
 
 func (v *validatorValue) init(ctx context.Context) {

--- a/nil/internal/execution/execution_state_test.go
+++ b/nil/internal/execution/execution_state_test.go
@@ -82,7 +82,7 @@ func (s *SuiteExecutionState) TestExecState() {
 
 	s.Run("CheckAccount", func() {
 		es, err := NewExecutionState(tx, shardId, StateParams{
-			BlockHash:      blockRes.BlockHash,
+			Block:          blockRes.Block,
 			ConfigAccessor: config.GetStubAccessor(),
 		})
 		s.Require().NoError(err)
@@ -220,7 +220,7 @@ func newState(t *testing.T) *ExecutionState {
 	tx, err := database.CreateRwTx(ctx)
 	require.NoError(t, err)
 
-	cfgAccessor, err := config.NewConfigAccessor(ctx, database, nil)
+	cfgAccessor, err := config.NewConfigAccessorTx(tx, nil)
 	require.NoError(t, err)
 
 	require.NoError(t, config.SetParamGasPrice(cfgAccessor, &config.ParamGasPrice{
@@ -658,7 +658,7 @@ contracts:
 
 	params := NewBlockGeneratorParams(1, 2)
 
-	gen, err := NewBlockGenerator(ctx, params, database, nil, nil)
+	gen, err := NewBlockGenerator(ctx, params, database, nil)
 	require.NoError(b, err)
 	_, err = gen.GenerateZeroState(zeroState)
 	require.NoError(b, err)
@@ -686,7 +686,7 @@ contracts:
 		tx, _ := database.CreateRwTx(ctx)
 		proposal.PrevBlockHash, _ = db.ReadLastBlockHash(tx, 1)
 
-		gen, err = NewBlockGenerator(ctx, params, database, nil, nil)
+		gen, err = NewBlockGenerator(ctx, params, database, nil)
 		require.NoError(b, err)
 		_, err = gen.GenerateBlock(proposal, nil)
 		require.NoError(b, err)

--- a/nil/internal/execution/transactions_test.go
+++ b/nil/internal/execution/transactions_test.go
@@ -39,7 +39,6 @@ func (s *TransactionsSuite) TestValidateExternalTransaction() {
 	defer tx.Rollback()
 
 	es, err := NewExecutionState(tx, types.BaseShardId, StateParams{
-		GetBlockFromDb: true,
 		ConfigAccessor: config.GetStubAccessor(),
 	})
 	s.Require().NoError(err)

--- a/nil/internal/execution/zerostate_test.go
+++ b/nil/internal/execution/zerostate_test.go
@@ -119,7 +119,7 @@ config:
   gasPrice:
     shards: ["1", "2", "3"]
 `
-	configAccessor, err := config.NewConfigAccessor(t.Context(), database, nil)
+	configAccessor, err := config.NewConfigAccessorTx(tx, nil)
 	require.NoError(t, err)
 	state, err = NewExecutionState(tx, 0, StateParams{ConfigAccessor: configAccessor})
 	require.NoError(t, err)

--- a/nil/internal/readthroughdb/read_through.go
+++ b/nil/internal/readthroughdb/read_through.go
@@ -196,7 +196,7 @@ func NewReadThroughDb(client client.DbClient, baseDb db.DB) (db.DB, error) {
 	return db, nil
 }
 
-func NewReadThroughDbWithMasterChain(ctx context.Context, client client.Client, cacheDb db.DB, masterBlockNumber transport.BlockNumber) (db.DB, error) {
+func NewReadThroughDbWithMainShard(ctx context.Context, client client.Client, cacheDb db.DB, masterBlockNumber transport.BlockNumber) (db.DB, error) {
 	block, err := client.GetBlock(ctx, types.MainShardId, masterBlockNumber, false)
 	if err != nil {
 		return nil, err
@@ -257,5 +257,5 @@ func NewReadThroughDbWithMasterChain(ctx context.Context, client client.Client, 
 // Construct from endpoint string and db.DB
 func NewReadThroughWithEndpoint(ctx context.Context, endpoint string, cacheDb db.DB, masterBlockNumber transport.BlockNumber) (db.DB, error) {
 	client := rpc.NewClient(endpoint, logging.NewLogger("db_client"))
-	return NewReadThroughDbWithMasterChain(ctx, client, cacheDb, masterBlockNumber)
+	return NewReadThroughDbWithMainShard(ctx, client, cacheDb, masterBlockNumber)
 }

--- a/nil/internal/signer/block_verifier.go
+++ b/nil/internal/signer/block_verifier.go
@@ -8,7 +8,6 @@ import (
 	"github.com/NilFoundation/nil/nil/internal/config"
 	"github.com/NilFoundation/nil/nil/internal/db"
 	"github.com/NilFoundation/nil/nil/internal/types"
-	"github.com/rs/zerolog"
 )
 
 var errBlockVerify = errors.New("failed to verify block")
@@ -25,8 +24,8 @@ func NewBlockVerifier(shardId types.ShardId, db db.DB) *BlockVerifier {
 	}
 }
 
-func (b *BlockVerifier) VerifyBlock(ctx context.Context, block *types.Block, logger zerolog.Logger) error {
-	validatorsList, err := config.GetValidatorListForShard(ctx, b.db, block.Id, b.shardId, logger)
+func (b *BlockVerifier) VerifyBlock(ctx context.Context, block *types.Block) error {
+	validatorsList, err := config.GetValidatorListForShard(ctx, b.db, block.Id, b.shardId)
 	if err != nil {
 		return fmt.Errorf("%w: failed to get validators set: %w", errBlockVerify, err)
 	}

--- a/nil/services/rpc/jsonrpc/eth_block_test.go
+++ b/nil/services/rpc/jsonrpc/eth_block_test.go
@@ -33,7 +33,7 @@ func (suite *SuiteEthBlock) SetupSuite() {
 	suite.db, err = db.NewBadgerDbInMemory()
 	suite.Require().NoError(err)
 
-	suite.lastBlockHash = execution.GenerateZeroState(suite.T(), suite.ctx, types.MainShardId, suite.db)
+	suite.lastBlockHash = execution.GenerateZeroState(suite.T(), types.MainShardId, suite.db).Hash(types.MainShardId)
 	for i := 1; i < int(types.BlockNumber(2)); i++ {
 		txns := make([]*types.Transaction, 0, i)
 		for j := range i {

--- a/nil/services/rpc/jsonrpc/send_transaction_test.go
+++ b/nil/services/rpc/jsonrpc/send_transaction_test.go
@@ -26,20 +26,20 @@ type SuiteSendTransaction struct {
 
 func (suite *SuiteSendTransaction) SetupSuite() {
 	shardId := types.MainShardId
-	ctx := context.Background()
+	ctx := suite.T().Context()
 
 	var err error
 	suite.db, err = db.NewBadgerDbInMemory()
 	suite.Require().NoError(err)
 
-	mainBlockHash := execution.GenerateZeroState(suite.T(), ctx, types.MainShardId, suite.db)
+	mainBlock := execution.GenerateZeroState(suite.T(), types.MainShardId, suite.db)
 
 	tx, err := suite.db.CreateRwTx(ctx)
 	suite.Require().NoError(err)
 	defer tx.Rollback()
 
 	es, err := execution.NewExecutionState(tx, shardId, execution.StateParams{
-		BlockHash:      mainBlockHash,
+		Block:          mainBlock,
 		ConfigAccessor: config.GetStubAccessor(),
 	})
 	suite.Require().NoError(err)

--- a/nil/tests/read_through/read_through_db_test.go
+++ b/nil/tests/read_through/read_through_db_test.go
@@ -51,7 +51,7 @@ func (s *SuiteReadThroughDb) initCache() {
 	s.cache.DbInit = func() db.DB {
 		inDb, err := db.NewBadgerDbInMemory()
 		check.PanicIfErr(err)
-		db, err := readthroughdb.NewReadThroughDbWithMasterChain(s.cache.Context, s.server.Client, inDb, transport.LatestBlockNumber)
+		db, err := readthroughdb.NewReadThroughDbWithMainShard(s.cache.Context, s.server.Client, inDb, transport.LatestBlockNumber)
 		check.PanicIfErr(err)
 		return db
 	}


### PR DESCRIPTION
We decided to change approach to configuration management a bit. At the moment of block generation (with height=h) we have committed known block (h-1). This block has a link to mainShardHash that is a base for config accessor.
Such approach is quite consistent and decrease chances to face with an issue when we don't have an access to main shard block because it's not replicated yet.