### PR TITLE
[filters] fix polling in case of context cancellation

### DIFF
--- a/nil/services/rpc/filters/filters.go
+++ b/nil/services/rpc/filters/filters.go
@@ -157,9 +157,8 @@ func (m *FiltersManager) PollBlocks(delay time.Duration) {
 		select {
 		case <-m.ctx.Done():
 			return
-		default:
+		case <-time.After(delay):
 		}
-		time.Sleep(delay)
 
 		lastHash, err := m.getLastBlockHash()
 		if err != nil {


### PR DESCRIPTION
Sometimes we get following issue in CI:
```
../../services/rpc/filters/filters.go:177 > processBlockHash failed error="DB::Get key: \"Blocks:0:\\x00\\x00)\\x91\\b)F\\x1d\\x0f\\x1d\\x8e\\xb2C\\xac\\x9f\\x1c\\xe7Y\\x03\\x94\\bai$\\x05\\xa7\\x80\\x1c3\\x11\\xe0\\xcb\" error: DB Closed
```

That happens because we had sleep that couldn't be interrupted by context cancellation. This patch fixes it.