### PR TITLE
[nild] Introduce caching to blockchain config

### DIFF
--- a/nil/internal/config/cache.go
+++ b/nil/internal/config/cache.go
@@ -1,0 +1,173 @@
+package config
+
+import (
+	"context"
+	"sync"
+
+	"github.com/NilFoundation/nil/nil/common/check"
+	"github.com/NilFoundation/nil/nil/internal/db"
+	"github.com/NilFoundation/nil/nil/internal/types"
+	lru "github.com/hashicorp/golang-lru/v2"
+)
+
+var GlobalConfigCache *ConfigCache
+
+func InitGlobalConfigCache(nShards uint32, txFabric db.DB) error {
+	var err error
+	GlobalConfigCache, err = NewConfigCache(nShards, txFabric)
+	return err
+}
+
+func GetConfigParams(ctx context.Context, txFabric db.DB, shardId types.ShardId, height uint64) (*ConfigParams, error) {
+	if GlobalConfigCache != nil {
+		return GlobalConfigCache.GetParams(ctx, shardId, height)
+	}
+	value := &cacheValue{
+		txFabric: txFabric,
+		shardId:  shardId,
+		height:   height,
+	}
+	// SAFETY: value is not shared
+	if err := value.initUnsafe(ctx); err != nil {
+		return nil, err
+	}
+	return &value.ConfigParams, nil
+}
+
+const lruCacheSize = 16
+
+type ConfigCache struct {
+	configLru []*lru.Cache[uint64, *cacheValue]
+
+	txFabric db.DB
+}
+
+func NewConfigCache(nShards uint32, txFabric db.DB) (*ConfigCache, error) {
+	configLru := make([]*lru.Cache[uint64, *cacheValue], 0, nShards)
+	for range nShards {
+		cache, err := lru.New[uint64, *cacheValue](lruCacheSize)
+		if err != nil {
+			return nil, err
+		}
+		configLru = append(configLru, cache)
+	}
+	return &ConfigCache{
+		configLru: configLru,
+		txFabric:  txFabric,
+	}, nil
+}
+
+func (c *ConfigCache) GetParams(ctx context.Context, shardId types.ShardId, height uint64) (*ConfigParams, error) {
+	if int(shardId) >= len(c.configLru) {
+		return nil, types.NewError(types.ErrorShardIdIsTooBig)
+	}
+
+	cache := c.configLru[shardId]
+	value := &cacheValue{
+		txFabric: c.txFabric,
+		shardId:  shardId,
+		height:   height,
+	}
+
+	// Note:  this is suboptimal, but hashicorp/golang-lru doesn't provide GetOrAdd,
+	//		  there is a PR though: https://github.com/hashicorp/golang-lru/pull/170
+	cache.ContainsOrAdd(height, value)
+	value, ok := cache.Get(height)
+	check.PanicIfNot(ok)
+
+	value.init(ctx)
+	if value.err != nil {
+		// This is likely to happen if we try to get validators for a height that is not yet available.
+		// In this case, we should not cache the error, because the error is not permanent.
+		cache.Remove(height)
+		return nil, value.err
+	}
+	return &value.ConfigParams, nil
+}
+
+type ConfigParams struct {
+	ValidatorInfo []ValidatorInfo
+	PublicKeys    *PublicKeyMap
+	GasPrice      *ParamGasPrice
+	L1BlockInfo   *ParamL1BlockInfo
+}
+
+type cacheValue struct {
+	ConfigParams
+
+	txFabric db.DB
+
+	shardId types.ShardId
+	height  uint64
+
+	err error
+
+	once sync.Once
+}
+
+func mergeValidators(input []ListValidators) []ValidatorInfo {
+	var result []ValidatorInfo
+	visited := make(map[Pubkey]struct{})
+
+	for _, shardValidators := range input {
+		for _, v := range shardValidators.List {
+			if _, ok := visited[v.PublicKey]; ok {
+				continue
+			}
+			visited[v.PublicKey] = struct{}{}
+			result = append(result, v)
+		}
+	}
+	return result
+}
+
+func (v *cacheValue) getValidatorsList(configAccessor ConfigAccessor) ([]ValidatorInfo, error) {
+	validatorsList, err := getParamImpl[ParamValidators](configAccessor)
+	if err != nil {
+		return nil, err
+	}
+	if v.shardId.IsMainShard() {
+		return mergeValidators(validatorsList.Validators), nil
+	}
+	if int(v.shardId)-1 >= len(validatorsList.Validators) {
+		return nil, types.NewError(types.ErrorShardIdIsTooBig)
+	}
+	return validatorsList.Validators[v.shardId-1].List, nil
+}
+
+func (v *cacheValue) initUnsafe(ctx context.Context) error {
+	tx, err := v.txFabric.CreateRoTx(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	block, err := db.ReadBlockByNumber(tx, v.shardId, types.BlockNumber(max(v.height, 1)-1))
+	if err != nil {
+		return err
+	}
+	var configAccessor ConfigAccessor
+	configAccessor, err = NewConfigAccessorFromBlockWithTx(tx, block, v.shardId)
+	if err != nil {
+		return err
+	}
+	v.ValidatorInfo, err = v.getValidatorsList(configAccessor)
+	if err != nil {
+		return err
+	}
+	v.PublicKeys, err = CreateValidatorsPublicKeyMap(v.ValidatorInfo)
+	if err != nil {
+		return err
+	}
+	v.GasPrice, err = GetParamGasPrice(configAccessor)
+	if err != nil {
+		return err
+	}
+	v.L1BlockInfo, err = GetParamL1Block(configAccessor)
+	return err
+}
+
+func (v *cacheValue) init(ctx context.Context) {
+	v.once.Do(func() {
+		v.err = v.initUnsafe(ctx)
+	})
+}

--- a/nil/internal/consensus/ibft/validators.go
+++ b/nil/internal/consensus/ibft/validators.go
@@ -1,23 +1,18 @@
 package ibft
 
 import (
-	"context"
-	"sync"
-
 	"github.com/NilFoundation/nil/nil/common/logging"
 	"github.com/NilFoundation/nil/nil/internal/config"
-	"github.com/NilFoundation/nil/nil/internal/db"
-	"github.com/NilFoundation/nil/nil/internal/types"
 )
 
 func (i *backendIBFT) calcProposer(height, round uint64, prevValidator *uint64) (*config.ValidatorInfo, uint64, error) {
-	validators, err := i.validatorsCache.getValidators(i.ctx, height)
+	params, err := config.GetConfigParams(i.ctx, i.txFabric, i.shardId, height)
 	if err != nil {
 		i.logger.Error().
 			Err(err).
 			Uint64(logging.FieldRound, round).
 			Uint64(logging.FieldHeight, height).
-			Msg("Failed to get validators")
+			Msg("Failed to get validators' params")
 		return nil, 0, err
 	}
 
@@ -28,57 +23,6 @@ func (i *backendIBFT) calcProposer(height, round uint64, prevValidator *uint64) 
 		seed = *prevValidator + round + 1
 	}
 
-	index := seed % uint64(len(validators))
-	return &validators[index], index, nil
-}
-
-type validatorsMap struct {
-	shardId  types.ShardId
-	txFabtic db.DB
-	m        sync.Map
-}
-
-func newValidatorsMap(txFabric db.DB, shardId types.ShardId) *validatorsMap {
-	return &validatorsMap{
-		txFabtic: txFabric,
-		shardId:  shardId,
-	}
-}
-
-func (m *validatorsMap) getValidators(ctx context.Context, height uint64) ([]config.ValidatorInfo, error) {
-	vAny, _ := m.m.LoadOrStore(height, &validatorValue{
-		txFabric: m.txFabtic,
-		shardId:  m.shardId,
-		height:   height,
-	})
-	v, _ := vAny.(*validatorValue)
-	v.init(ctx)
-	if v.err != nil {
-		// This is likely to happen if we try to get validators for a height that is not yet available.
-		// In this case, we should not cache the error, because the error is not permanent.
-		m.m.Delete(height)
-	}
-	return v.value, v.err
-}
-
-type validatorValue struct {
-	txFabric db.DB
-
-	shardId types.ShardId
-	height  uint64
-
-	value []config.ValidatorInfo
-	err   error
-
-	once sync.Once
-}
-
-func (v *validatorValue) getValidators(ctx context.Context) ([]config.ValidatorInfo, error) {
-	return config.GetValidatorListForShard(ctx, v.txFabric, types.BlockNumber(v.height), v.shardId)
-}
-
-func (v *validatorValue) init(ctx context.Context) {
-	v.once.Do(func() {
-		v.value, v.err = v.getValidators(ctx)
-	})
+	index := seed % uint64(len(params.ValidatorInfo))
+	return &params.ValidatorInfo[index], index, nil
 }

--- a/nil/internal/consensus/ibft/verifier.go
+++ b/nil/internal/consensus/ibft/verifier.go
@@ -54,7 +54,7 @@ func (i *backendIBFT) IsValidValidator(msg *protoIBFT.IbftMessage) bool {
 		height = expectedHeight
 	}
 
-	validators, err := i.validatorsCache.getValidators(i.transportCtx, height)
+	params, err := config.GetConfigParams(i.transportCtx, i.txFabric, i.shardId, height)
 	if err != nil {
 		logger.Error().
 			Err(err).
@@ -62,15 +62,7 @@ func (i *backendIBFT) IsValidValidator(msg *protoIBFT.IbftMessage) bool {
 		return false
 	}
 
-	pubkeys, err := config.CreateValidatorsPublicKeyMap(validators)
-	if err != nil {
-		logger.Error().
-			Err(err).
-			Msg("Failed to get validators public keys")
-		return false
-	}
-
-	_, ok := pubkeys.Find(config.Pubkey(msg.From))
+	_, ok := params.PublicKeys.Find(config.Pubkey(msg.From))
 	if !ok {
 		logger.Error().
 			Msg("public key not found in validators list")

--- a/nil/internal/signer/block_verifier.go
+++ b/nil/internal/signer/block_verifier.go
@@ -25,17 +25,12 @@ func NewBlockVerifier(shardId types.ShardId, db db.DB) *BlockVerifier {
 }
 
 func (b *BlockVerifier) VerifyBlock(ctx context.Context, block *types.Block) error {
-	validatorsList, err := config.GetValidatorListForShard(ctx, b.db, block.Id, b.shardId)
+	params, err := config.GetConfigParams(ctx, b.db, b.shardId, block.Id.Uint64())
 	if err != nil {
-		return fmt.Errorf("%w: failed to get validators set: %w", errBlockVerify, err)
+		return fmt.Errorf("%w: failed to get validators' params: %w", errBlockVerify, err)
 	}
 
-	pubkeys, err := config.CreateValidatorsPublicKeyMap(validatorsList)
-	if err != nil {
-		return fmt.Errorf("%w: failed to get validators public keys: %w", errBlockVerify, err)
-	}
-
-	if err := block.VerifySignature(pubkeys.Keys(), b.shardId); err != nil {
+	if err := block.VerifySignature(params.PublicKeys.Keys(), b.shardId); err != nil {
 		return fmt.Errorf("%w: failed to verify signature: %w", errBlockVerify, err)
 	}
 	return nil

--- a/nil/services/nilservice/config.go
+++ b/nil/services/nilservice/config.go
@@ -64,6 +64,7 @@ type Config struct {
 	TraceEVM             bool   `yaml:"-"`
 	CollatorTickPeriodMs uint32 `yaml:"-"`
 	Topology             string `yaml:"-"`
+	EnableConfigCache    bool   `yaml:"-"`
 
 	// Consensus
 	Validators       map[types.ShardId][]config.ValidatorInfo `yaml:"validators,omitempty"`
@@ -96,8 +97,9 @@ func NewDefaultConfig() *Config {
 		NetworkKeysPath:   "network-keys.yaml",
 		ValidatorKeysPath: "validator-keys.yaml",
 
-		GracefulShutdown: true,
-		Topology:         collate.TrivialShardTopologyId,
+		GracefulShutdown:  true,
+		Topology:          collate.TrivialShardTopologyId,
+		EnableConfigCache: true,
 
 		Validators: make(map[types.ShardId][]config.ValidatorInfo),
 

--- a/nil/services/nilservice/service.go
+++ b/nil/services/nilservice/service.go
@@ -349,6 +349,13 @@ func CreateNode(ctx context.Context, name string, cfg *Config, database db.DB, i
 		return nil, err
 	}
 
+	if cfg.EnableConfigCache {
+		if err := config.InitGlobalConfigCache(cfg.NShards, database); err != nil {
+			logger.Error().Err(err).Msg("Failed to initialize global config cache")
+			return nil, err
+		}
+	}
+
 	if err := telemetry.Init(ctx, cfg.Telemetry); err != nil {
 		logger.Error().Err(err).Msg("Failed to initialize telemetry")
 		return nil, err

--- a/nil/tests/basic/basic_test.go
+++ b/nil/tests/basic/basic_test.go
@@ -60,6 +60,9 @@ func (s *SuiteRpc) SetupTest() {
 	s.Start(&nilservice.Config{
 		NShards: 5,
 		HttpUrl: rpc.GetSockPath(s.T()),
+
+		// NOTE: caching won't work with parallel tests in this module, because global cache will be shared
+		EnableConfigCache: true,
 	})
 }
 

--- a/nil/tests/read_through/read_through_db_test.go
+++ b/nil/tests/read_through/read_through_db_test.go
@@ -30,6 +30,7 @@ type SuiteReadThroughDb struct {
 func (s *SuiteReadThroughDb) SetupTest() {
 	s.server.SetT(s.T())
 	s.cache.SetT(s.T())
+
 	s.num = 0
 
 	s.cfg = &nilservice.Config{


### PR DESCRIPTION
This patch introduces an LRU cache for blockchain config. This cache is shared between syncers and validators. It could be useful if the validator gets behind, in which case we switch to the syncer, which can use the cached entries. It is also useful for the validators because we require the same height's config in different places throughout the validation. 

The caching is disabled in sharded suite because otherwise the cache will be shared between instances, but it is enabled in rpc suite. 