### PR TITLE
Fix spelling errors 

### DIFF
--- a/nil/internal/abi/abi.go
+++ b/nil/internal/abi/abi.go
@@ -32,7 +32,7 @@ import (
 )
 
 // The ABI holds information about a contract's context and available
-// invokable methods. It will allow you to type check function calls and
+// invocable methods. It will allow you to type check function calls and
 // packs data accordingly.
 type ABI struct {
 	Constructor Method

--- a/nil/services/synccommittee/prover/tracer/state_db.go
+++ b/nil/services/synccommittee/prover/tracer/state_db.go
@@ -75,7 +75,7 @@ func (mtc *transactionTraceContext) processOpcode(
 	// Finish in reverse order to keep rw_counter sequential.
 	// Each operation consists of read stack -> read data -> write data -> write stack (we
 	// ignore specific memory parts like returndata, etc for now). Intermediate stages could be omitted, but
-	// to keep RW ctr correct, stack tracer should be run the first on new opcode, and be finilized the last on previous opcode.
+	// to keep RW ctr correct, stack tracer should be run the first on new opcode, and be finalized the last on previous opcode.
 	// TODO: add check that only one of first 3 is run
 	mtc.memoryTracer.FinishPrevOpcodeTracing()
 	mtc.expTracer.FinishPrevOpcodeTracing()
@@ -208,7 +208,7 @@ func (tsdb *TracerStateDB) getOrNewAccount(addr types.Address) (*execution.Accou
 	return &createdAcc.AccountState, nil
 }
 
-// OutTransactions don't requre handling, they are just included into block
+// OutTransactions don't require handling, they are just included into block
 func (tsdb *TracerStateDB) HandleInTransaction(transaction *types.Transaction) (err error) {
 	tsdb.logger.Trace().
 		Int64("seqno", int64(transaction.Seqno)).
@@ -657,7 +657,7 @@ func (tsdb *TracerStateDB) RevertToSnapshot(int) {
 // Snapshot returns an identifier for the current revision of the state.
 func (tsdb *TracerStateDB) Snapshot() int {
 	// Snapshot is needed for rollback when an error was returned by the EVM.
-	// We could just ignore failing transactions in proof provider. In case revert occures, we fail in RevertToSnapshot(int)
+	// We could just ignore failing transactions in proof provider. In case revert occurs, we fail in RevertToSnapshot(int)
 	return 0
 }
 

--- a/nix/solc.nix
+++ b/nix/solc.nix
@@ -87,12 +87,12 @@ let
 
           checkPhase = ''
             pushd ..
-            # IPC tests need aleth avaliable, so we disable it
+            # IPC tests need aleth available, so we disable it
             sed -i "s/IPC_ENABLED=true/IPC_ENABLED=false\nIPC_FLAGS=\"--no-ipc\"/" ./scripts/tests.sh
             for i in ./scripts/*.sh ./scripts/*.py ./test/*.sh ./test/*.py; do
               patchShebangs "$i"
             done
-            ## TODO: reenable tests below after adding evmone and hera and their dependencies to nixpkgs
+            ## TODO: re-enable tests below after adding evmone and hera and their dependencies to nixpkgs
             #TERM=xterm ./scripts/tests.sh ${lib.optionalString z3Support "--no-smt"}
             popd
           '';


### PR DESCRIPTION
- **`abi.go`**:  
  - Fixed wording in comments: `"invokable"` → `"invocable"`  

- **`state_db.go`**:  
  - `"finilized"` → `"finalized"`  
  - `"requre"` → `"require"`  
  - `"occures"` → `"occurs"`  

- **`solc.nix`**:  
  - `"avaliable"` → `"available"`  
  - `"reenable"` → `"re-enable"`  
