### PR TITLE
[loadgen] Increase waiting time

### DIFF
--- a/nil/tests/nil_load_generator_service/nil_load_generator_test.go
+++ b/nil/tests/nil_load_generator_service/nil_load_generator_test.go
@@ -75,7 +75,7 @@ func (s *NilLoadGeneratorRpc) TestSmartAccountBalanceModification() {
 			s.Require().NoError(err)
 		}
 		return len(resSmartAccounts) != 0
-	}, 20*time.Second, 100*time.Millisecond)
+	}, 60*time.Second, 100*time.Millisecond)
 
 	for i, addr := range resSmartAccounts {
 		s.Require().Positive(smartAccountsBalance[i].Uint64(),


### PR DESCRIPTION
Now tests for load generator is flaky. We reason - we don't have enough time to generate SmartAccounts, that's why in this PR increased waiting time for this operation.