### PR TITLE
fix logging level for rpc events

### DIFF
--- a/nil/common/logging/ch_logger.go
+++ b/nil/common/logging/ch_logger.go
@@ -22,7 +22,7 @@ func (l CHLogger) Disable() CHLogger {
 }
 
 func (l CHLogger) Log() *zerolog.Event {
-	// cheap trick to ensure these logs are always written
+	// cheap trick to ensure these logs are written ± always
 	// despite of zerolog global log level
-	return l.l.WithLevel(zerolog.PanicLevel) //nolint:zerologlint
+	return l.l.WithLevel(zerolog.WarnLevel) //nolint:zerologlint
 }


### PR DESCRIPTION
currently logs which are written with `panic` level are being broadcasted to console from journald. this makes any debugging much harder 