### PR TITLE
[nild] Remove BaseRevision

### DIFF
--- a/nil/cmd/cometa/main.go
+++ b/nil/cmd/cometa/main.go
@@ -54,7 +54,7 @@ func processRun(cfg *config) error {
 		cfg.cometaCfg.NodeEndpoint,
 		zerolog.Nop(),
 		map[string]string{
-			"User-Agent": "cometa/" + version.GetGitRevision(),
+			"User-Agent": "cometa/" + version.GetGitRevCount(),
 		},
 	)
 	ctx := context.Background()

--- a/nil/cmd/nil/common/rpc_client.go
+++ b/nil/cmd/nil/common/rpc_client.go
@@ -22,7 +22,7 @@ func InitRpcClient(cfg *Config, logger zerolog.Logger) {
 		cfg.RPCEndpoint,
 		logger,
 		map[string]string{
-			"User-Agent": "nil-cli/" + version.GetGitRevision(),
+			"User-Agent": "nil-cli/" + version.GetGitRevCount(),
 		},
 	)
 

--- a/nil/cmd/nil_block_generator/internal/commands/client.go
+++ b/nil/cmd/nil_block_generator/internal/commands/client.go
@@ -79,7 +79,7 @@ func GetRpcClient(rpcEndpoint string, logger zerolog.Logger) *rpc.Client {
 		rpcEndpoint,
 		logger,
 		map[string]string{
-			"User-Agent": "nil-block-generatr-cli/" + version.GetGitRevision(),
+			"User-Agent": "nil-block-generatr-cli/" + version.GetGitRevCount(),
 		},
 	)
 }

--- a/nil/common/version/version.go
+++ b/nil/common/version/version.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 	"runtime"
 	"runtime/debug"
-	"strconv"
 	"strings"
 	"sync"
 
@@ -33,22 +32,6 @@ const (
 	unknownVersion  string = "<unknown>"
 )
 
-const BaseRevision = 5000
-
-// This revision increase is needed due to the move to the new repository.
-// TODO(@isergeyam): This is actually a dirty hack; we need to resolve the versioning gracefully.
-// See https://github.com/NilFoundation/nil/issues/39
-func updateGitRevision(revision string) string {
-	if revision == "0" || revision == "1" || revision == "" {
-		return revision
-	}
-	rev, err := strconv.Atoi(revision)
-	if err == nil {
-		return strconv.Itoa(rev + BaseRevision)
-	}
-	return revision
-}
-
 func GetVersionInfo() versionInfo {
 	versionInfoCacheMutex.Lock()
 	defer versionInfoCacheMutex.Unlock()
@@ -68,7 +51,6 @@ func GetVersionInfo() versionInfo {
 			versionInfoCache = versionInfo{GitTag: matches[1], GitRevision: matches[2], GitCommit: matches[3]}
 		}
 	}
-	versionInfoCache.GitRevision = updateGitRevision(versionInfoCache.GitRevision)
 	return versionInfoCache
 }
 

--- a/nil/common/version/version.go
+++ b/nil/common/version/version.go
@@ -13,7 +13,7 @@ import (
 
 type versionInfo struct {
 	GitTag      string
-	GitRevision string
+	GitRevCount string
 	GitCommit   string
 }
 
@@ -35,7 +35,7 @@ const (
 func GetVersionInfo() versionInfo {
 	versionInfoCacheMutex.Lock()
 	defer versionInfoCacheMutex.Unlock()
-	if versionInfoCache.GitRevision == "" {
+	if versionInfoCache.GitRevCount == "" {
 		// If the versionMagic string has been patched with something that looks like a version
 		// then use it. Otherwise initialize the version with some sane default.
 		re := regexp.MustCompile(`(\d+\.\d+\.\d+)-(\d+)-([a-f0-9]+)`)
@@ -43,12 +43,12 @@ func GetVersionInfo() versionInfo {
 
 		if len(matches) == 0 {
 			if _, gitCommit, err := ParseBuildInfo(); err == nil {
-				versionInfoCache = versionInfo{GitTag: "0.1.0", GitRevision: "1", GitCommit: gitCommit}
+				versionInfoCache = versionInfo{GitTag: "0.1.0", GitRevCount: "1", GitCommit: gitCommit}
 			} else {
-				versionInfoCache = versionInfo{GitTag: "0.1.0", GitRevision: "1", GitCommit: unknownVersion}
+				versionInfoCache = versionInfo{GitTag: "0.1.0", GitRevCount: "1", GitCommit: unknownVersion}
 			}
 		} else {
-			versionInfoCache = versionInfo{GitTag: matches[1], GitRevision: matches[2], GitCommit: matches[3]}
+			versionInfoCache = versionInfo{GitTag: matches[1], GitRevCount: matches[2], GitCommit: matches[3]}
 		}
 	}
 	return versionInfoCache
@@ -99,15 +99,15 @@ func BuildVersionString(appTitle string) string {
 		"OS":       runtime.GOOS,
 		"Arch":     runtime.GOARCH,
 		"Commit":   GetVersionInfo().GitCommit,
-		"Revision": GetGitRevision(),
+		"Revision": GetGitRevCount(),
 	})
 }
 
-func GetGitRevision() string {
-	if GetVersionInfo().GitRevision == "" {
+func GetGitRevCount() string {
+	if GetVersionInfo().GitRevCount == "" {
 		return unknownRevision
 	}
-	return GetVersionInfo().GitRevision
+	return GetVersionInfo().GitRevCount
 }
 
 func FormatVersion(template string, templateArgs map[string]any) string {

--- a/nil/services/cometa/client.go
+++ b/nil/services/cometa/client.go
@@ -52,7 +52,7 @@ func (c *Client) sendRequest(method string, params []any) (json.RawMessage, erro
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("User-Agent", "cometa/"+version.GetGitRevision())
+	req.Header.Set("User-Agent", "cometa/"+version.GetGitRevCount())
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {

--- a/nil/services/faucet/client.go
+++ b/nil/services/faucet/client.go
@@ -49,7 +49,7 @@ func (c *Client) sendRequest(method string, params []any) (json.RawMessage, erro
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("User-Agent", "faucet/"+version.GetGitRevision())
+	req.Header.Set("User-Agent", "faucet/"+version.GetGitRevCount())
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {

--- a/nil/services/nil_load_generator/client.go
+++ b/nil/services/nil_load_generator/client.go
@@ -46,7 +46,7 @@ func (c *Client) sendRequest(method string, params []any) (json.RawMessage, erro
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("User-Agent", "nilloadgen/"+version.GetGitRevision())
+	req.Header.Set("User-Agent", "nilloadgen/"+version.GetGitRevCount())
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {

--- a/nil/services/rpc/internal/http/connection.go
+++ b/nil/services/rpc/internal/http/connection.go
@@ -3,14 +3,19 @@ package http
 import (
 	"io"
 	"net/http"
+	"strconv"
 	"time"
+
+	"github.com/NilFoundation/nil/nil/common/check"
+	"github.com/NilFoundation/nil/nil/common/version"
 )
 
 const (
 	MaxRequestContentLength  = 1024 * 1024 * 32 // 32MB
-	minSupportedRevision     = 356
 	minSupportedNiljsVersion = "0.24.0"
 )
+
+var minSupportedRevision = 1
 
 type (
 	remoteCtxKey    struct{}
@@ -25,6 +30,12 @@ type HttpServerConn struct {
 	io.Reader
 	io.Writer
 	Request *http.Request
+}
+
+func init() {
+	num, err := strconv.Atoi(version.GetGitRevision())
+	check.PanicIfErr(err)
+	minSupportedRevision = num
 }
 
 // Close does nothing and always returns nil.

--- a/nil/services/rpc/internal/http/connection.go
+++ b/nil/services/rpc/internal/http/connection.go
@@ -4,14 +4,11 @@ import (
 	"io"
 	"net/http"
 	"time"
-
-	"github.com/NilFoundation/nil/nil/common/version"
 )
 
 const (
 	MaxRequestContentLength  = 1024 * 1024 * 32 // 32MB
-	currentHeight            = 356
-	minSupportedRevision     = version.BaseRevision + currentHeight
+	minSupportedRevision     = 356
 	minSupportedNiljsVersion = "0.24.0"
 )
 

--- a/nil/services/rpc/internal/http/connection.go
+++ b/nil/services/rpc/internal/http/connection.go
@@ -3,19 +3,14 @@ package http
 import (
 	"io"
 	"net/http"
-	"strconv"
 	"time"
-
-	"github.com/NilFoundation/nil/nil/common/check"
-	"github.com/NilFoundation/nil/nil/common/version"
 )
 
 const (
 	MaxRequestContentLength  = 1024 * 1024 * 32 // 32MB
+	minSupportedRevision     = 356
 	minSupportedNiljsVersion = "0.24.0"
 )
-
-var minSupportedRevision = 1
 
 type (
 	remoteCtxKey    struct{}
@@ -30,12 +25,6 @@ type HttpServerConn struct {
 	io.Reader
 	io.Writer
 	Request *http.Request
-}
-
-func init() {
-	num, err := strconv.Atoi(version.GetGitRevision())
-	check.PanicIfErr(err)
-	minSupportedRevision = num
 }
 
 // Close does nothing and always returns nil.


### PR DESCRIPTION
I think all our clients already update they cli to a new versions, that's why we don't need to handle corner case with old [revision](https://github.com/NilFoundation/nil/issues/39).