### PR TITLE
[docs] card removal to avoid confusion

### DIFF
--- a/docs/nil/intro.mdx
+++ b/docs/nil/intro.mdx
@@ -43,7 +43,6 @@ Learn more about the architecture of =nil; and its specification.
 ## Featured content
 
 <CardSection>
-    <Card id='newrelease' date='03 February 2025' title='New release' description='' to='https://docs.nil.foundation/nil/migration-guides/february-0302-2025-release' tagLabel='Migration guides'/>
     <Card id='featuredlifecycle' date='14 December 2024' title='Transaction lifecycle' description='' to='https://docs.nil.foundation/nil/core-concepts/transaction-lifecycle' tagLabel='Core concepts'/>
     <Card id='featured patterns' date='11 November 2024' title='Design patterns' description='' to='https://docs.nil.foundation/nil/guides/design-patterns' tagLabel='Guides'/>
 </CardSection>


### PR DESCRIPTION
This diff removes the 'New release' card from the index page because it will no longer refer to the actual new release and there's no corresponding migration guide to link the new card to.