### PR TITLE
Rename endpoint to rpcUrl in the code

### DIFF
--- a/explorer_frontend/src/features/account-connector/ActiveComponent.ts
+++ b/explorer_frontend/src/features/account-connector/ActiveComponent.ts
@@ -1,5 +1,5 @@
 export enum ActiveComponent {
-  Endpoint = "Endpoint",
+  RpcUrl = "RpcUrl",
   Main = "Main",
   Topup = "Topup",
   SmartAccountSelector = "SmartAccountSelector",

--- a/explorer_frontend/src/features/account-connector/components/AccountContainer.tsx
+++ b/explorer_frontend/src/features/account-connector/components/AccountContainer.tsx
@@ -5,12 +5,12 @@ import { useSwipeable } from "react-swipeable";
 import { useStyletron } from "styletron-react";
 import { ActiveComponent } from "../ActiveComponent";
 import { $activeComponent, setActiveComponent } from "../model";
-import EndpointScreen from "./EndpointScreen.tsx";
 import { MainScreen } from "./MainScreen";
+import { RpcUrlScreen } from "./RpcUrlScreen.tsx";
 import { TopUpPanel } from "./TopUpPanel";
 
 const featureMap = new Map();
-featureMap.set(ActiveComponent.Endpoint, EndpointScreen);
+featureMap.set(ActiveComponent.RpcUrl, RpcUrlScreen);
 featureMap.set(ActiveComponent.Main, MainScreen);
 featureMap.set(ActiveComponent.Topup, TopUpPanel);
 
@@ -19,8 +19,8 @@ const AccountContainer = () => {
   const Component = activeComponent ? featureMap.get(activeComponent) : null;
   const [css] = useStyletron();
   const handlers = useSwipeable({
-    onSwipedLeft: () => setActiveComponent(ActiveComponent.Endpoint),
-    onSwipedRight: () => setActiveComponent(ActiveComponent.Endpoint),
+    onSwipedLeft: () => setActiveComponent(ActiveComponent.RpcUrl),
+    onSwipedRight: () => setActiveComponent(ActiveComponent.RpcUrl),
   });
 
   return (

--- a/explorer_frontend/src/features/account-connector/components/MainScreen.tsx
+++ b/explorer_frontend/src/features/account-connector/components/MainScreen.tsx
@@ -25,8 +25,8 @@ import Linkicon from "../assets/link.svg";
 import {
   $balance,
   $balanceToken,
-  $endpoint,
   $latestActivity,
+  $rpcUrl,
   $smartAccount,
   clearLatestActivity,
   createSmartAccountFx,
@@ -48,7 +48,7 @@ const btnOverrides: ButtonOverrides = {
 const MainScreen = () => {
   const [css] = useStyletron();
   const [copied, setCopied] = useState(false);
-  const endpoint = useUnit($endpoint);
+  const rpcUrl = useUnit($rpcUrl);
   const latestActivity = useUnit($latestActivity);
   const [smartAccount, balance, balanceToken, isPendingSmartAccountCreation, rpcIsHealthy] =
     useUnit([$smartAccount, $balance, $balanceToken, createSmartAccountFx.pending, $rpcIsHealthy]);
@@ -83,8 +83,8 @@ const MainScreen = () => {
 
   // Handle copy functionality
   const handleCopy = async () => {
-    if (endpoint && typeof endpoint === "string") {
-      await navigator.clipboard.writeText(endpoint);
+    if (rpcUrl && typeof rpcUrl === "string") {
+      await navigator.clipboard.writeText(rpcUrl);
 
       setCopied(true);
 
@@ -136,7 +136,7 @@ const MainScreen = () => {
             <CopyButton textToCopy={address} disabled={address === null} color={COLORS.gray200} />
           </div>
         )}
-        {endpoint !== null && (
+        {rpcUrl !== null && (
           <div
             className={css({
               display: "flex",
@@ -148,7 +148,7 @@ const MainScreen = () => {
             {/* Read-Only Input */}
             <Input
               placeholder="Enter your RPC URL"
-              value={endpoint}
+              value={rpcUrl}
               readOnly
               overrides={{
                 Root: {

--- a/explorer_frontend/src/features/account-connector/components/RpcUrlScreen.tsx
+++ b/explorer_frontend/src/features/account-connector/components/RpcUrlScreen.tsx
@@ -11,18 +11,18 @@ import animationData from "../assets/wallet-creation.json";
 import {
   $balance,
   $balanceToken,
-  $endpoint,
   $initializingSmartAccountError,
   $initializingSmartAccountState,
+  $rpcUrl,
   $smartAccount,
   createSmartAccountFx,
   initilizeSmartAccount,
   setActiveComponent,
-  setEndpoint,
+  setRpcUrl,
 } from "../model";
-import { type ValidationResult, validateRpcEndpoint } from "../validation";
+import { type ValidationResult, validateRpcUrl } from "../validation";
 
-const EndpointScreen = () => {
+export const RpcUrlScreen = () => {
   const [css] = useStyletron();
   const [error, setError] = useState("");
   const [isDisabled, setIsDisabled] = useState(false);
@@ -36,7 +36,7 @@ const EndpointScreen = () => {
     initializingSmartAccountState,
     initializingSmartAccountError,
     isPendingSmartAccountCreation,
-    endpoint,
+    rpcUrl,
   ] = useUnit([
     $smartAccount,
     $balance,
@@ -44,9 +44,9 @@ const EndpointScreen = () => {
     $initializingSmartAccountState,
     $initializingSmartAccountError,
     createSmartAccountFx.pending,
-    $endpoint,
+    $rpcUrl,
   ]);
-  const [inputValue, setInputValue] = useState(endpoint);
+  const [inputValue, setInputValue] = useState(rpcUrl);
   const animationContainerRef = useRef<HTMLDivElement | null>(null);
 
   // Initialize Lottie animation on mount
@@ -66,7 +66,7 @@ const EndpointScreen = () => {
 
   // Handles connect button press
   const handleConnect = () => {
-    const validation: ValidationResult = validateRpcEndpoint(inputValue);
+    const validation: ValidationResult = validateRpcUrl(inputValue);
     if (!validation.isValid) {
       setError(validation.error);
       return;
@@ -75,16 +75,16 @@ const EndpointScreen = () => {
     setError("");
     setIsDisabled(true);
 
-    setEndpoint(inputValue);
+    setRpcUrl(inputValue);
     initilizeSmartAccount();
   };
 
-  // Opens a new browser tab to fetch the endpoint URL
-  const handleGetEndpoint = () => {
+  // Opens a new browser tab to fetch the rpcUrl URL
+  const handleGetRpcUrl = () => {
     if (RPC_TELEGRAM_BOT) {
       window.open(RPC_TELEGRAM_BOT, "_blank");
     } else {
-      console.error("VITE_GET_ENDPOINT_URL is not set.");
+      console.error("RPC_TELEGRAM_BOT runtime variable is not set.");
     }
   };
 
@@ -195,10 +195,8 @@ const EndpointScreen = () => {
         >
           Connect
         </Button>
-
-        {/* Get Endpoint Button */}
         <Button
-          onClick={handleGetEndpoint}
+          onClick={handleGetRpcUrl}
           kind={BUTTON_KIND.secondary}
           disabled={isDisabled}
           style={{
@@ -214,5 +212,3 @@ const EndpointScreen = () => {
     </div>
   );
 };
-
-export default EndpointScreen;

--- a/explorer_frontend/src/features/account-connector/model.ts
+++ b/explorer_frontend/src/features/account-connector/model.ts
@@ -14,21 +14,20 @@ export const initializePrivateKey = createEvent();
 export const $smartAccount = createStore<SmartAccountV1 | null>(null);
 export const $balance = createStore<bigint | null>(null);
 export const $balanceToken = createStore<Record<string, bigint> | null>(null);
-export const $endpoint = createStore<string>("");
+export const $rpcUrl = createStore<string>("");
 export const $topUpError = createStore<string>("");
 
-export const $latestActivity = createStore<{ txHash: string; successful: boolean } | null>(null);
+export const $latestActivity = createStore<{
+  txHash: string;
+  successful: boolean;
+} | null>(null);
 
-export const $accountConnectorWithEndpoint = combine(
-  $privateKey,
-  $endpoint,
-  (privateKey, endpoint) => ({
-    privateKey,
-    endpoint,
-  }),
-);
+export const $accountConnectorWithRpcUrl = combine($privateKey, $rpcUrl, (privateKey, rpcUrl) => ({
+  privateKey,
+  rpcUrl,
+}));
 
-export const setEndpoint = createEvent<string>();
+export const setRpcUrl = createEvent<string>();
 
 export const fetchBalanceFx = accountConnectorDomain.createEffect<SmartAccountV1, bigint>();
 
@@ -40,7 +39,7 @@ export const fetchBalanceTokensFx = accountConnectorDomain.createEffect<
 export const createSmartAccountFx = accountConnectorDomain.createEffect<
   {
     privateKey: Hex;
-    endpoint: string;
+    rpcUrl: string;
   },
   SmartAccountV1
 >();
@@ -56,7 +55,7 @@ export const regenrateAccountEvent = createEvent();
 
 export const topUpEvent = createEvent();
 
-export const $activeComponent = createStore<ActiveComponent | null>(ActiveComponent.Endpoint);
+export const $activeComponent = createStore<ActiveComponent | null>(ActiveComponent.RpcUrl);
 
 export const setActiveComponent = createEvent<ActiveComponent>();
 
@@ -81,7 +80,7 @@ export const topupSmartAccountTokenFx = accountConnectorDomain.createEffect<
       amount: string;
     };
     faucets: Record<string, Hex>;
-    endpoint: string;
+    rpcUrl: string;
   },
   void
 >();
@@ -96,6 +95,9 @@ export const $initializingSmartAccountError = accountConnectorDomain.createStore
 
 export const resetTopUpError = createEvent();
 
-export const addActivity = createEvent<{ txHash: string; successful: boolean }>();
+export const addActivity = createEvent<{
+  txHash: string;
+  successful: boolean;
+}>();
 
 export const clearLatestActivity = createEvent();

--- a/explorer_frontend/src/features/account-connector/validation.ts
+++ b/explorer_frontend/src/features/account-connector/validation.ts
@@ -5,13 +5,13 @@ export type ValidationResult = {
   isValid: boolean;
 };
 
-// Validates if the provided RPC endpoint matches the expected format
-export const validateRpcEndpoint = (rpcEndpoint: string): ValidationResult => {
+// Validates if the provided RPC url matches the expected format
+export const validateRpcUrl = (rpcUrl: string): ValidationResult => {
   const RPC_REGEX = /^https:\/\/api\.devnet\.nil\.foundation\/api\/.+\/.+$/;
-  if (RPC_REGEX.test(rpcEndpoint)) {
+  if (RPC_REGEX.test(rpcUrl)) {
     return { isValid: true, error: "" };
   }
-  return { isValid: false, error: "Invalid RPC endpoint format" };
+  return { isValid: false, error: "Invalid RPC rpcUrl format" };
 };
 
 export const MAX_AMOUNT_NIL = 1;

--- a/explorer_frontend/src/features/cometa/init.ts
+++ b/explorer_frontend/src/features/cometa/init.ts
@@ -1,21 +1,16 @@
 import { CometaService, HttpTransport } from "@nilfoundation/niljs";
 import { combine, sample } from "effector";
-import { $endpoint } from "../account-connector/model";
-import {
-  $cometaService,
-  $commetaEndpoint,
-  createCometaService,
-  createCometaServiceFx,
-} from "./model";
+import { $rpcUrl } from "../account-connector/model";
+import { $cometaApiUrl, $cometaService, createCometaService, createCometaServiceFx } from "./model";
 
-const $refinedEndpoint = combine(
-  $endpoint,
-  $commetaEndpoint,
-  (endpoint, customEndpoint) => endpoint || customEndpoint,
+const $refinedCometaApiUrl = combine(
+  $rpcUrl,
+  $cometaApiUrl,
+  (rpcUrl, customCometaApiUrl) => rpcUrl || customCometaApiUrl,
 );
 
-$refinedEndpoint.watch((endpoint) => {
-  if (endpoint) {
+$refinedCometaApiUrl.watch((url) => {
+  if (url) {
     createCometaService();
   }
 });
@@ -32,7 +27,7 @@ $cometaService.on(createCometaServiceFx.doneData, (_, cometaService) => cometaSe
 
 sample({
   clock: createCometaService,
-  source: $refinedEndpoint,
+  source: $refinedCometaApiUrl,
   target: createCometaServiceFx,
 });
 

--- a/explorer_frontend/src/features/cometa/model.ts
+++ b/explorer_frontend/src/features/cometa/model.ts
@@ -6,7 +6,7 @@ const { COMETA_SERVICE_API_URL, RPC_API_URL } = getRuntimeConfigOrThrow();
 
 export const cometaDomain = createDomain("cometa");
 
-export const $commetaEndpoint = cometaDomain.createStore(
+export const $cometaApiUrl = cometaDomain.createStore(
   COMETA_SERVICE_API_URL || RPC_API_URL || null,
 );
 export const $cometaService = cometaDomain.createStore<CometaService | null>(null);

--- a/explorer_frontend/src/features/contracts/init.ts
+++ b/explorer_frontend/src/features/contracts/init.ts
@@ -4,7 +4,7 @@ import { combine, merge, sample } from "effector";
 import { persist } from "effector-storage/local";
 import { debug } from "patronum";
 import type { App } from "../../types";
-import { $endpoint, $smartAccount } from "../account-connector/model";
+import { $rpcUrl, $smartAccount } from "../account-connector/model";
 import { $solidityVersion, compileCodeFx } from "../code/model";
 import { $cometaService } from "../cometa/model";
 import { $shardsAmount } from "../shards/models/model";
@@ -261,11 +261,11 @@ sample({
 sample({
   source: combine({
     app: $activeApp,
-    endpoint: $endpoint,
+    rpcUrl: $rpcUrl,
   }),
   filter: $activeAppWithState.map((app) => !!app?.address),
   clock: choseApp,
-  fn: ({ endpoint, app }) => ({ address: app?.address!, endpoint }),
+  fn: ({ rpcUrl, app }) => ({ address: app?.address!, rpcUrl }),
   target: fetchBalanceFx,
 });
 
@@ -353,7 +353,7 @@ sample({
       functionName,
       args,
       abi: activeApp?.abi!,
-      endpoint: $endpoint.getState(),
+      rpcUrl: $rpcUrl.getState(),
       address: activeApp?.address!,
       appName: activeApp?.name,
     };
@@ -424,7 +424,7 @@ sample({
       functionName,
       args,
       abi: activeApp?.abi!,
-      endpoint: $endpoint.getState(),
+      rpcUrl: $rpcUrl.getState(),
       address: activeApp?.address!,
       smartAccount: smartAccount!,
       ...(value ? { value } : {}),

--- a/explorer_frontend/src/features/contracts/models/base.ts
+++ b/explorer_frontend/src/features/contracts/models/base.ts
@@ -242,15 +242,15 @@ export const $tokens = createStore<Record<`0x${string}`, bigint>>({});
 export const fetchBalanceFx = createEffect<
   {
     address: `0x${string}`;
-    endpoint: string;
+    rpcUrl: string;
   },
   {
     tokens: Record<`0x${string}`, bigint>;
     balance: bigint;
   }
->(async ({ address, endpoint }) => {
+>(async ({ address, rpcUrl }) => {
   const client = new PublicClient({
-    transport: new HttpTransport({ endpoint }),
+    transport: new HttpTransport({ endpoint: rpcUrl }),
   });
   const [tokens, balance] = await Promise.all([
     client.getTokens(address, "latest"),
@@ -282,7 +282,7 @@ export const callFx = createEffect<
     functionName: string;
     abi: Abi;
     args: unknown[];
-    endpoint: string;
+    rpcUrl: string;
     address: `0x${string}`;
   },
   {
@@ -290,9 +290,9 @@ export const callFx = createEffect<
     result: unknown;
     appName?: string;
   }
->(async ({ functionName, args, endpoint, abi, address, appName }) => {
+>(async ({ functionName, args, rpcUrl, abi, address, appName }) => {
   const client = new PublicClient({
-    transport: new HttpTransport({ endpoint }),
+    transport: new HttpTransport({ endpoint: rpcUrl }),
   });
 
   const data = await client.call(

--- a/explorer_frontend/src/features/healthcheck/init.ts
+++ b/explorer_frontend/src/features/healthcheck/init.ts
@@ -1,6 +1,6 @@
 import { combine, sample } from "effector";
 import { interval } from "patronum";
-import { $endpoint } from "../account-connector/model";
+import { $rpcUrl } from "../account-connector/model";
 import { loadedPlaygroundPage } from "../code/model";
 import { playgroundRoute, playgroundWithHashRoute } from "../routing/routes/playgroundRoute";
 import { $isPageVisible, $rpcIsHealthy, checkRpcHealthFx, pageVisibilityChanged } from "./model";
@@ -19,7 +19,7 @@ const { tick } = interval({
 sample({
   clock: tick,
   target: checkRpcHealthFx,
-  source: $endpoint,
+  source: $rpcUrl,
   filter: combine(
     $isPageVisible,
     playgroundRoute.$isOpened,
@@ -30,7 +30,7 @@ sample({
 });
 
 sample({
-  clock: $endpoint,
+  clock: $rpcUrl,
   target: checkRpcHealthFx,
 });
 

--- a/explorer_frontend/src/features/healthcheck/model.ts
+++ b/explorer_frontend/src/features/healthcheck/model.ts
@@ -9,12 +9,12 @@ export const checkRpcHealthFx = healthcheckDomain.createEffect<string, boolean>(
 export const pageVisibilityChanged = healthcheckDomain.createEvent<boolean>();
 export const $isPageVisible = healthcheckDomain.createStore(document.visibilityState === "visible");
 
-checkRpcHealthFx.use(async (endpoint: string) => {
-  if (!endpoint) return true;
+checkRpcHealthFx.use(async (rpcUrl: string) => {
+  if (!rpcUrl) return true;
 
   try {
     const client = new PublicClient({
-      transport: new HttpTransport({ endpoint }),
+      transport: new HttpTransport({ endpoint: rpcUrl }),
     });
 
     const response = await client.chainId();

--- a/explorer_frontend/src/features/tokens/init.ts
+++ b/explorer_frontend/src/features/tokens/init.ts
@@ -1,11 +1,11 @@
 import { FaucetClient, HttpTransport } from "@nilfoundation/niljs";
 import { sample } from "effector";
-import { $endpoint } from "../account-connector/model";
+import { $rpcUrl } from "../account-connector/model";
 import { $faucets, fetchFaucetsEvent, fetchFaucetsFx } from "./model";
 
-fetchFaucetsFx.use(async (endpoint) => {
+fetchFaucetsFx.use(async (rpcUrl) => {
   const faucetClient = new FaucetClient({
-    transport: new HttpTransport({ endpoint }),
+    transport: new HttpTransport({ endpoint: rpcUrl }),
   });
 
   return await faucetClient.getAllFaucets();
@@ -13,12 +13,12 @@ fetchFaucetsFx.use(async (endpoint) => {
 
 sample({
   clock: fetchFaucetsEvent,
-  source: $endpoint,
+  source: $rpcUrl,
   target: fetchFaucetsFx,
 });
 
-$endpoint.watch((endpoint) => {
-  if (endpoint) {
+$rpcUrl.watch((rpcUrl) => {
+  if (rpcUrl) {
     fetchFaucetsEvent();
   }
 });


### PR DESCRIPTION
We've already renamed endpoint to rpc url in the interface, but in code it is still a mismatch in names.
This diff changes nothing functionally, only renames `endpoint` in the code where it should be `rpc url`.