### PR TITLE
[execution] make main shard validation self-sufficient 

### DIFF
--- a/nil/internal/collate/proposer.go
+++ b/nil/internal/collate/proposer.go
@@ -128,9 +128,6 @@ func (p *proposer) GenerateProposal(ctx context.Context, txFabric db.DB) (*execu
 func (p *proposer) fetchPrevBlock(tx db.RoTx) (*types.Block, error) {
 	b, hash, err := db.ReadLastBlock(tx, p.params.ShardId)
 	if err != nil {
-		if errors.Is(err, db.ErrKeyNotFound) {
-			return nil, nil
-		}
 		return nil, err
 	}
 

--- a/nil/internal/collate/validator.go
+++ b/nil/internal/collate/validator.go
@@ -38,7 +38,8 @@ func (s *Validator) VerifyProposal(ctx context.Context, proposal *execution.Prop
 	}
 	defer gen.Rollback()
 
-	res, err := gen.BuildBlock(proposal)
+	gasPrices := gen.CollectGasPrices(proposal.PrevBlockHash, proposal.ShardHashes)
+	res, err := gen.BuildBlock(proposal, gasPrices)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate block: %w", err)
 	}
@@ -68,5 +69,6 @@ func (s *Validator) InsertProposal(ctx context.Context, proposal *execution.Prop
 		InTransactions:  res.InTxns,
 		OutTransactions: res.OutTxns,
 		ChildBlocks:     proposal.ShardHashes,
+		Config:          res.ConfigParams,
 	})
 }

--- a/nil/internal/execution/Makefile.inc
+++ b/nil/internal/execution/Makefile.inc
@@ -3,5 +3,5 @@ ssz_execution: nil/internal/execution/proposal_encoding.go ssz_types
 
 nil/internal/execution/proposal_encoding.go: nil/internal/execution/proposal.go
 	cd nil/internal/execution && go run github.com/NilFoundation/fastssz/sszgen --path proposal.go \
-		-include ../types/bitflags.go,../types/value.go,../types/address.go,../types/code.go,../types/account.go,../types/signature.go,../types/block.go,../types/collator.go,../types/transaction.go,../types/shard.go,../../common/length.go,../../common/hash.go \
+		-include ../types/uint256.go,../types/bitflags.go,../types/value.go,../types/address.go,../types/code.go,../types/account.go,../types/signature.go,../types/block.go,../types/collator.go,../types/transaction.go,../types/shard.go,../../common/length.go,../../common/hash.go \
 		--objs Proposal

--- a/nil/internal/execution/block_generator.go
+++ b/nil/internal/execution/block_generator.go
@@ -181,7 +181,7 @@ func (g *BlockGenerator) prepareExecutionState(proposal *Proposal) error {
 			g.logger.Err(err).Msg("Failed to marshal execution state")
 			esJson = nil
 		}
-		//nolint:musttag
+
 		proposalJson, err := json.Marshal(proposal)
 		if err != nil {
 			g.logger.Err(err).Msg("Failed to marshal block proposal")

--- a/nil/internal/execution/fee.go
+++ b/nil/internal/execution/fee.go
@@ -1,7 +1,6 @@
 package execution
 
 import (
-	"errors"
 	"sync"
 
 	"github.com/NilFoundation/nil/nil/internal/types"
@@ -11,14 +10,6 @@ import (
 var lock sync.Mutex
 
 func (es *ExecutionState) UpdateBaseFee(prevBlock *types.Block) error {
-	if prevBlock == nil {
-		// If we can't read the previous block, we don't change the gas price
-		es.GasPrice = types.DefaultGasPrice
-		err := errors.New("previous block not found")
-		logger.Error().Err(err).Msg("Gas price won't be changed")
-		return err
-	}
-
 	es.BaseFee = calculateBaseFee(prevBlock.BaseFee, prevBlock.GasUsed)
 	if es.BaseFee.Cmp(prevBlock.BaseFee) != 0 {
 		logger.Debug().

--- a/nil/internal/execution/state.go
+++ b/nil/internal/execution/state.go
@@ -1366,6 +1366,7 @@ func (es *ExecutionState) BuildBlock(blockId types.BlockNumber) (*BlockGeneratio
 	}
 
 	configRoot := common.EmptyHash
+	var configParams map[string][]byte
 	if es.ShardId.IsMainShard() {
 		var err error
 		prevBlock, err := db.ReadBlock(es.tx, es.ShardId, es.PrevBlock)
@@ -1377,6 +1378,9 @@ func (es *ExecutionState) BuildBlock(blockId types.BlockNumber) (*BlockGeneratio
 		}
 		if configRoot, err = es.GetConfigAccessor().Commit(es.tx, configRoot); err != nil {
 			return nil, fmt.Errorf("failed to update config trie: %w", err)
+		}
+		if configParams, err = es.GetConfigAccessor().GetParams(); err != nil {
+			return nil, fmt.Errorf("failed to read config params: %w", err)
 		}
 	}
 
@@ -1402,10 +1406,11 @@ func (es *ExecutionState) BuildBlock(blockId types.BlockNumber) (*BlockGeneratio
 	}
 
 	return &BlockGenerationResult{
-		Block:     block,
-		BlockHash: block.Hash(es.ShardId),
-		InTxns:    es.InTransactions,
-		OutTxns:   outTxnValues,
+		Block:        block,
+		BlockHash:    block.Hash(es.ShardId),
+		InTxns:       es.InTransactions,
+		OutTxns:      outTxnValues,
+		ConfigParams: configParams,
 	}, nil
 }
 

--- a/nil/internal/types/collator.go
+++ b/nil/internal/types/collator.go
@@ -5,8 +5,8 @@ type Neighbor struct {
 	ShardId ShardId `json:"shardId"`
 
 	// next block and transaction to read
-	BlockNumber      BlockNumber
-	TransactionIndex TransactionIndex
+	BlockNumber      BlockNumber      `json:"blockNumber"`
+	TransactionIndex TransactionIndex `json:"transactionIndex"`
 }
 
 type CollatorState struct {

--- a/nil/tests/cometa/cometa_test.go
+++ b/nil/tests/cometa/cometa_test.go
@@ -125,6 +125,8 @@ func (s *SuiteCometa) SetupTest() {
 		ZeroStateYaml:        s.zerostateCfg,
 	})
 	s.cometaClient = *cometa.NewClient(s.Endpoint)
+	tests.WaitShardTick(s.T(), s.Context, s.Client, types.MainShardId)
+	tests.WaitShardTick(s.T(), s.Context, s.Client, types.BaseShardId)
 }
 
 func (s *SuiteCometa) TestTwinContracts() {

--- a/nil/tests/economy/economy_test.go
+++ b/nil/tests/economy/economy_test.go
@@ -99,6 +99,8 @@ contracts:
 		CollatorTickPeriodMs: 200,
 		RunMode:              nilservice.CollatorsOnlyRunMode,
 	})
+	tests.WaitShardTick(s.T(), s.Context, s.Client, types.MainShardId)
+	tests.WaitShardTick(s.T(), s.Context, s.Client, types.BaseShardId)
 }
 
 func (s *SuiteEconomy) TearDownSuite() {


### PR DESCRIPTION
Before this patch we had following schema:
Main shard proposer should choose main shard hashes and send them to validators.
Validators update main shard config with corresponding gas prices of that shards.

Such schema has following pitfalls: we have all syncers dependent from each other
because main shard should be able to read their gas prices. And other shards
need a config from main shard. Such approach makes synchronization quite complex:
main shard should wait 1+ shards and 1+ shards should wait for the main shard.

After this patch validation of main shard will be independent because
we include gas prices of shard blocks into proposal.
Reverse operation is performed by using gas prices from configuration.