### PR TITLE
Niljs faucet allow topup in Number and change client transport prop to readonly

### DIFF
--- a/niljs/src/clients/BaseClient.ts
+++ b/niljs/src/clients/BaseClient.ts
@@ -12,18 +12,18 @@ class BaseClient {
   /**
    * The ITransport to be used in the client. See {@link ITransport}.
    *
-   * @protected
+   * @readonly
    * @type {ITransport}
    */
-  protected transport: ITransport;
+  readonly transport: ITransport;
 
   /**
    * The ID of the shard with which the client needs to interact.
    * The shard with this ID will be used in every call made by the client.
-   * @protected
+   * @public
    * @type {number | undefined}
    */
-  protected shardId?: number;
+  public shardId?: number;
 
   /**
    * Creates an instance of BaseClient.


### PR DESCRIPTION
This patch is changing `niljs` client's class `transport` property modifier. We often want to use it like `smartAccount.client.transport`. And, generally there is no sense in protected property usage here.