### PR TITLE
Allow to specify pprof port in nild command-line arguments

### DIFF
--- a/nil/cmd/nild/main.go
+++ b/nil/cmd/nild/main.go
@@ -36,7 +36,7 @@ func main() {
 
 	logging.ApplyComponentsFilter(logFilter)
 
-	profiling.Start(profiling.DefaultPort)
+	profiling.Start(cfg.PprofPort)
 
 	database, err := openDb(cfg.DB.Path, cfg.DB.AllowDrop, logger)
 	check.PanicIfErr(err)
@@ -148,6 +148,7 @@ func parseArgs() *nildconfig.Config {
 
 	// For backward compatibility
 	rootCmd.PersistentFlags().IntVar(&cfg.RPCPort, "port", cfg.RPCPort, "http port for rpc server")
+	rootCmd.PersistentFlags().IntVar(&cfg.PprofPort, "pprof-port", cfg.PprofPort, "port to serve pprof profiling information")
 	check.PanicIfErr(rootCmd.PersistentFlags().MarkHidden("port"))
 
 	runCmd := &cobra.Command{

--- a/nil/services/nilservice/config.go
+++ b/nil/services/nilservice/config.go
@@ -43,6 +43,9 @@ type Config struct {
 	RPCPort        int                   `yaml:"rpcPort,omitempty"`
 	BootstrapPeers network.AddrInfoSlice `yaml:"bootstrapPeers,omitempty"`
 
+	// Profiling
+	PprofPort int `yaml:"pprofPort,omitempty"`
+
 	// Admin
 	AdminSocketPath string `yaml:"adminSocket,omitempty"`
 
@@ -79,7 +82,10 @@ type Config struct {
 	L1Fetcher rollup.L1BlockFetcher `yaml:"-"`
 }
 
-const DefaultNShards types.ShardId = 5
+const (
+	DefaultNShards   types.ShardId = 5
+	DefaultPprofPort uint32        = 6060
+)
 
 func NewDefaultConfig() *Config {
 	return &Config{
@@ -99,6 +105,7 @@ func NewDefaultConfig() *Config {
 		Telemetry: telemetry.NewDefaultConfig(),
 		Replay:    NewDefaultReplayConfig(),
 		RpcNode:   NewDefaultRpcNodeConfig(),
+		PprofPort: int(DefaultPprofPort),
 	}
 }
 


### PR DESCRIPTION
Currently we run multiple instances in production, and pprof port is always 6600 without any ability to override it. This means that only one instance (randomly) succeeds at opening this port first, and we can only connect to that specific instance to get profiling information.

Right now we're trying to figure out a few bugs that happen where an ability to take stack trace of all threads is very important. Thus, this PR makes pprof port configurable.