### PR TITLE
Show warnings on solidity compilation in playground

### DIFF
--- a/explorer_frontend/src/features/account-connector/init.ts
+++ b/explorer_frontend/src/features/account-connector/init.ts
@@ -160,7 +160,7 @@ topUpSmartAccountBalanceFx.use(async (smartAccount) => {
 
   await faucetClient.topUpAndWaitUntilCompletion(
     {
-      smartAccount: smartAccount.address,
+      smartAccountAddress: smartAccount.address,
       faucetAddress: faucets.NIL,
       amount: convertEthToWei(0.1),
     },

--- a/explorer_frontend/src/features/code/init.ts
+++ b/explorer_frontend/src/features/code/init.ts
@@ -54,7 +54,22 @@ compileCodeFx.use(async ({ version, code }) => {
     }
   }
 
-  return contracts;
+  const errors = res.errors || [];
+  const severeErrors = errors.filter((error) => error.severity === "error");
+
+  if (severeErrors.length > 0) {
+    throw new Error(severeErrors.map((error) => error.formattedMessage).join("\n"));
+  }
+
+  const warnings = errors.filter((error) => error.severity === "warning");
+  const refinedWarnings = warnings.map((warning) => {
+    return {
+      message: warning.formattedMessage,
+      line: warning.sourceLocation?.start || 0,
+    };
+  });
+
+  return { apps: contracts, warnings: refinedWarnings };
 });
 
 $solidityVersion.on(changeSolidityVersion, (_, version) => version);

--- a/explorer_frontend/src/features/code/model.ts
+++ b/explorer_frontend/src/features/code/model.ts
@@ -28,7 +28,13 @@ export const compileCodeFx = codeDomain.createEffect<
     code: string;
     version: string;
   },
-  App[]
+  {
+    apps: App[];
+    warnings: {
+      message: string;
+      line: number;
+    }[];
+  }
 >();
 
 export const $codeSnippetHash = codeDomain.createStore<string | null>(null);

--- a/explorer_frontend/src/features/contracts/init.ts
+++ b/explorer_frontend/src/features/contracts/init.ts
@@ -67,7 +67,7 @@ import { exportApp, exportAppFx } from "./models/exportApp";
 
 compileCodeFx.doneData.watch(console.log);
 
-$contracts.on(compileCodeFx.doneData, (_, apps) => apps);
+$contracts.on(compileCodeFx.doneData, (_, { apps }) => apps);
 $contracts.reset(compileCodeFx.fail);
 
 persist({

--- a/explorer_frontend/src/features/logs/init.tsx
+++ b/explorer_frontend/src/features/logs/init.tsx
@@ -90,7 +90,27 @@ $logs.on(importSmartContractFx.failData, (logs, error) => {
   ];
 });
 
-$logs.on(compileCodeFx.doneData, (logs) => {
+$logs.on(compileCodeFx.doneData, (logs, { warnings }) => {
+  if (warnings.length > 0) {
+    return [
+      ...logs,
+      {
+        id: nanoid(),
+        topic: LogTopic.Compilation,
+        type: LogType.Warn,
+        shortDescription: (
+          <MonoParagraphMedium color={COLORS.yellow200}>Compiled with warnings</MonoParagraphMedium>
+        ),
+        payload: (
+          <MonoParagraphMedium color={COLORS.gray50}>
+            {warnings.map((warning) => formatSolidityError(warning.message)).join("\n")}
+          </MonoParagraphMedium>
+        ),
+        timestamp: Date.now(),
+      },
+    ];
+  }
+
   return [
     ...logs,
     {


### PR DESCRIPTION
We actually don't display compilation warnings in Playground compiler.
What this diff does - is display of compilation warnings instead of `Compilation successful` log.