### PR TITLE
Fix integer out of range error on smart account topup in Playground

### DIFF
--- a/explorer_frontend/src/features/account-connector/init.ts
+++ b/explorer_frontend/src/features/account-connector/init.ts
@@ -100,7 +100,7 @@ createSmartAccountFx.use(async ({ privateKey, endpoint }) => {
       {
         smartAccountAddress: smartAccount.address,
         faucetAddress: faucets.NIL,
-        amount: 1e18,
+        amount: BigInt(1e18),
       },
       client,
     );


### PR DESCRIPTION
This diff adds `BigInt` conversion to 1e18 value to fix niljs error "Integer out of safe range". In Javascript such values should be used with `bigint` type. 