### PR TITLE
Add main keys to configuration

### DIFF
--- a/nil/cmd/nil_load_generator/main.go
+++ b/nil/cmd/nil_load_generator/main.go
@@ -30,6 +30,7 @@ func main() {
 	rootCmd.Flags().StringVar(&cfg.ThresholdAmount, "threshold-amount", "3000000000", "threshold amount")
 	rootCmd.Flags().StringVar(&cfg.SwapAmount, "swap-amount", "1000", "swap amount")
 	rootCmd.Flags().StringVar(&cfg.RpcSwapLimit, "rpc-swap-limit", "10000000", "rpc swap limit")
+	rootCmd.Flags().StringVar(&cfg.MainKeysPath, "main-keys-path", "keys.yaml", "path to keys.yaml")
 	rootCmd.Flags().Uint32Var(&cfg.UniswapAccounts, "rpc-uniswap-accounts", 5, "number of uniswap accounts")
 	rootCmd.Flags().StringVar(&cfg.LogLevel, "log-level", "info", "log level: trace|debug|info|warn|error|fatal|panic")
 

--- a/nil/internal/collate/syncer.go
+++ b/nil/internal/collate/syncer.go
@@ -30,7 +30,6 @@ type SyncerConfig struct {
 	ShardId         types.ShardId
 	Timeout         time.Duration // pull blocks if no new blocks appear in the topic for this duration
 	BootstrapPeers  []network.AddrInfo
-	ZeroState       string
 	ZeroStateConfig *execution.ZeroStateConfig
 }
 
@@ -357,23 +356,14 @@ func (s *Syncer) GenerateZerostate(ctx context.Context) error {
 		return nil
 	}
 
-	if len(s.config.BlockGeneratorParams.MainKeysPath) != 0 && s.config.ShardId == types.BaseShardId {
-		if err := execution.LoadMainKeys(s.config.BlockGeneratorParams.MainKeysPath); err != nil {
-			if err := execution.DumpMainKeys(s.config.BlockGeneratorParams.MainKeysPath); err != nil {
-				return err
-			}
-		}
-	}
-
 	s.logger.Info().Msg("Generating zero-state...")
-
 	gen, err := execution.NewBlockGenerator(ctx, s.config.BlockGeneratorParams, s.db, nil, nil)
 	if err != nil {
 		return err
 	}
 	defer gen.Rollback()
 
-	if _, err := gen.GenerateZeroState(s.config.ZeroState, s.config.ZeroStateConfig); err != nil {
+	if _, err := gen.GenerateZeroState(s.config.ZeroStateConfig); err != nil {
 		return err
 	}
 	return nil

--- a/nil/internal/execution/block_generator.go
+++ b/nil/internal/execution/block_generator.go
@@ -148,7 +148,7 @@ func (g *BlockGenerator) updateGasPrices(gasPrices []types.Uint256) error {
 	return nil
 }
 
-func (g *BlockGenerator) GenerateZeroState(zeroStateYaml string, config *ZeroStateConfig) (*types.Block, error) {
+func (g *BlockGenerator) GenerateZeroState(config *ZeroStateConfig) (*types.Block, error) {
 	g.logger.Info().Msg("Generating zero-state...")
 	g.executionState.BaseFee = types.DefaultGasPrice
 
@@ -160,7 +160,7 @@ func (g *BlockGenerator) GenerateZeroState(zeroStateYaml string, config *ZeroSta
 		g.executionState.MainChainHash = mainBlockHash
 	}
 
-	if err := g.executionState.GenerateMergedZeroState(config, zeroStateYaml); err != nil {
+	if err := g.executionState.GenerateZeroState(config); err != nil {
 		return nil, err
 	}
 

--- a/nil/internal/execution/execution_state_test.go
+++ b/nil/internal/execution/execution_state_test.go
@@ -233,7 +233,9 @@ func newState(t *testing.T) *ExecutionState {
 	state.BaseFee = types.DefaultGasPrice
 	require.NoError(t, err)
 
-	err = state.GenerateZeroStateYaml(DefaultZeroStateConfig)
+	defaultZeroStateConfig, err := CreateDefaultZeroStateConfig(MainPublicKey)
+	require.NoError(t, err)
+	err = state.GenerateZeroState(defaultZeroStateConfig)
 	require.NoError(t, err)
 	return state
 }
@@ -650,11 +652,15 @@ contracts:
   contract: tests/Counter
 `, address.Hex())
 
+	zeroState, err := ParseZeroStateConfig(zerostateCfg)
+	require.NoError(b, err)
+	zeroState.MainPublicKey = MainPublicKey
+
 	params := NewBlockGeneratorParams(1, 2)
 
 	gen, err := NewBlockGenerator(ctx, params, database, nil, nil)
 	require.NoError(b, err)
-	_, err = gen.GenerateZeroState(zerostateCfg, nil)
+	_, err = gen.GenerateZeroState(zeroState)
 	require.NoError(b, err)
 
 	txn := types.NewEmptyTransaction()

--- a/nil/internal/execution/zerostate_test.go
+++ b/nil/internal/execution/zerostate_test.go
@@ -32,11 +32,13 @@ type SuiteZeroState struct {
 }
 
 func (suite *SuiteZeroState) SetupSuite() {
+	var err error
 	suite.ctx = context.Background()
 
-	zeroStateConfig, err := ParseZeroStateConfig(DefaultZeroStateConfig)
+	defaultZeroStateConfig, err := CreateDefaultZeroStateConfig(MainPublicKey)
 	suite.Require().NoError(err)
-	faucetAddress := zeroStateConfig.GetContractAddress("Faucet")
+
+	faucetAddress := defaultZeroStateConfig.GetContractAddress("Faucet")
 	suite.Require().NotNil(faucetAddress)
 	suite.faucetAddr = *faucetAddress
 
@@ -121,7 +123,12 @@ config:
 	require.NoError(t, err)
 	state, err = NewExecutionState(tx, 0, StateParams{ConfigAccessor: configAccessor})
 	require.NoError(t, err)
-	err = state.GenerateZeroStateYaml(configYaml)
+
+	zeroState, err := ParseZeroStateConfig(configYaml)
+	require.NoError(t, err)
+	zeroState.MainPublicKey = MainPublicKey
+
+	err = state.GenerateZeroState(zeroState)
 	require.NoError(t, err)
 	require.Equal(t, 0, state.GasPrice.Cmp(types.NewValueFromUint64(1)))
 
@@ -129,7 +136,11 @@ config:
 		ConfigAccessor: config.GetStubAccessor(),
 	})
 	require.NoError(t, err)
-	err = state.GenerateZeroStateYaml(configYaml)
+	zeroState, err = ParseZeroStateConfig(configYaml)
+	require.NoError(t, err)
+	zeroState.MainPublicKey = MainPublicKey
+
+	err = state.GenerateZeroState(zeroState)
 	require.NoError(t, err)
 	require.Equal(t, 0, state.GasPrice.Cmp(types.NewValueFromUint64(2)))
 
@@ -137,7 +148,11 @@ config:
 		ConfigAccessor: config.GetStubAccessor(),
 	})
 	require.NoError(t, err)
-	err = state.GenerateZeroStateYaml(configYaml)
+	zeroState, err = ParseZeroStateConfig(configYaml)
+	require.NoError(t, err)
+	zeroState.MainPublicKey = MainPublicKey
+
+	err = state.GenerateZeroState(zeroState)
 	require.NoError(t, err)
 	require.Equal(t, 0, state.GasPrice.Cmp(types.NewValueFromUint64(3)))
 
@@ -154,9 +169,14 @@ contracts:
   contract: SmartAccount
   ctorArgs: [MainPublicKey]
 `, smartAccountAddr.Hex())
+
 	state, err = NewExecutionState(tx, types.MainShardId, StateParams{ConfigAccessor: configAccessor})
 	require.NoError(t, err)
-	err = state.GenerateZeroStateYaml(configYaml)
+	zeroState, err = ParseZeroStateConfig(configYaml)
+	require.NoError(t, err)
+	zeroState.MainPublicKey = MainPublicKey
+
+	err = state.GenerateZeroState(zeroState)
 	require.NoError(t, err)
 	require.Equal(t, types.DefaultGasPrice, state.GasPrice)
 
@@ -183,7 +203,11 @@ contracts:
 		ConfigAccessor: config.GetStubAccessor(),
 	})
 	require.NoError(t, err)
-	err = state.GenerateZeroStateYaml(configYaml2)
+	zeroState, err = ParseZeroStateConfig(configYaml2)
+	require.NoError(t, err)
+	zeroState.MainPublicKey = MainPublicKey
+
+	err = state.GenerateZeroState(zeroState)
 	require.Error(t, err)
 
 	// Test only one contract should deployed in specific shard
@@ -203,7 +227,11 @@ contracts:
 		ConfigAccessor: config.GetStubAccessor(),
 	})
 	require.NoError(t, err)
-	err = state.GenerateZeroStateYaml(configYaml3)
+	zeroState, err = ParseZeroStateConfig(configYaml3)
+	require.NoError(t, err)
+	zeroState.MainPublicKey = MainPublicKey
+
+	err = state.GenerateZeroState(zeroState)
 	require.NoError(t, err)
 
 	faucetAddr = types.CreateAddress(types.BaseShardId, types.BuildDeployPayload(faucetCode, common.EmptyHash))

--- a/nil/services/nil_load_generator/service.go
+++ b/nil/services/nil_load_generator/service.go
@@ -38,6 +38,7 @@ type Config struct {
 	SwapAmount       string
 	UniswapAccounts  uint32
 	ThresholdAmount  string
+	MainKeysPath     string
 }
 
 var (
@@ -299,7 +300,13 @@ func Run(ctx context.Context, cfg Config, logger zerolog.Logger) error {
 	if err := rpcSwapLimit.Set(cfg.RpcSwapLimit); err != nil {
 		return err
 	}
-	service := cliservice.NewService(ctx, client, execution.MainPrivateKey, faucet)
+
+	mainPrivateKey, _, err := execution.LoadMainKeys(cfg.MainKeysPath)
+	if err != nil {
+		return err
+	}
+
+	service := cliservice.NewService(ctx, client, mainPrivateKey, faucet)
 	shardIdList, err := client.GetShardIdList(ctx)
 	if err != nil {
 		return err

--- a/nil/services/nilservice/config.go
+++ b/nil/services/nilservice/config.go
@@ -66,7 +66,6 @@ type Config struct {
 	TraceEVM             bool   `yaml:"-"`
 	CollatorTickPeriodMs uint32 `yaml:"-"`
 	Topology             string `yaml:"-"`
-	ZeroStateYaml        string `yaml:"-"`
 
 	// Consensus
 	Validators       map[types.ShardId][]config.ValidatorInfo `yaml:"validators,omitempty"`

--- a/nil/tests/async_await/async_await_test.go
+++ b/nil/tests/async_await/async_await_test.go
@@ -90,10 +90,14 @@ contracts:
 	nShards := uint32(3)
 	port := 10425
 
+	zeroState, err := execution.ParseZeroStateConfig(s.zerostateCfg)
+	s.Require().NoError(err)
+	zeroState.MainPublicKey = execution.MainPublicKey
+
 	const disableConsensus = true
 	s.Start(&nilservice.Config{
 		NShards:          nShards,
-		ZeroStateYaml:    s.zerostateCfg,
+		ZeroState:        zeroState,
 		DisableConsensus: disableConsensus,
 	}, port)
 

--- a/nil/tests/block_replay/block_replay_test.go
+++ b/nil/tests/block_replay/block_replay_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/NilFoundation/nil/nil/common"
 	"github.com/NilFoundation/nil/nil/internal/db"
-	"github.com/NilFoundation/nil/nil/internal/execution"
 	"github.com/NilFoundation/nil/nil/internal/types"
 	"github.com/NilFoundation/nil/nil/services/nilservice"
 	"github.com/NilFoundation/nil/nil/services/rpc"
@@ -42,10 +41,9 @@ type SuiteBlockReplay struct {
 
 func (s *SuiteBlockReplay) SetupSuite() {
 	s.cfg = &nilservice.Config{
-		NShards:       4,
-		HttpUrl:       rpc.GetSockPath(s.T()),
-		ZeroStateYaml: execution.DefaultZeroStateConfig,
-		RunMode:       nilservice.NormalRunMode,
+		NShards: 4,
+		HttpUrl: rpc.GetSockPath(s.T()),
+		RunMode: nilservice.NormalRunMode,
 	}
 
 	s.DbInit = func() db.DB {

--- a/nil/tests/cli_call/cli_call_test.go
+++ b/nil/tests/cli_call/cli_call_test.go
@@ -45,10 +45,15 @@ contracts:
 }
 
 func (s *SuiteCliTestCall) SetupTest() {
+	var err error
+	zeroState, err := execution.ParseZeroStateConfig(s.zerostateCfg)
+	s.Require().NoError(err)
+	zeroState.MainPublicKey = execution.MainPublicKey
+
 	s.Start(&nilservice.Config{
 		NShards:              2,
 		CollatorTickPeriodMs: 200,
-		ZeroStateYaml:        s.zerostateCfg,
+		ZeroState:            zeroState,
 	}, 10525)
 
 	s.client, s.endpoint = s.StartRPCNode(tests.WithDhtBootstrapByValidators, nil)

--- a/nil/tests/config/config_test.go
+++ b/nil/tests/config/config_test.go
@@ -109,6 +109,7 @@ func (s *SuiteConfigParams) TestConfigReadWriteGasPrice() {
 				Contract: contracts.NameConfigTest,
 			},
 		},
+		MainPublicKey: execution.MainPublicKey,
 	}
 
 	// Manually set gas price for all shards. It is necessary because the initial prices are set only during the first

--- a/nil/tests/deploy/deployment_test.go
+++ b/nil/tests/deploy/deployment_test.go
@@ -58,10 +58,15 @@ contracts:
 }
 
 func (s *SuiteDeployment) SetupTest() {
+	var err error
+	zeroState, err := execution.ParseZeroStateConfig(s.zerostateCfg)
+	s.Require().NoError(err)
+	zeroState.MainPublicKey = execution.MainPublicKey
+
 	s.Start(&nilservice.Config{
 		NShards:              s.ShardsNum,
 		HttpUrl:              rpc.GetSockPath(s.T()),
-		ZeroStateYaml:        s.zerostateCfg,
+		ZeroState:            zeroState,
 		CollatorTickPeriodMs: 300,
 		RunMode:              nilservice.CollatorsOnlyRunMode,
 	})

--- a/nil/tests/economy/economy_test.go
+++ b/nil/tests/economy/economy_test.go
@@ -92,10 +92,14 @@ contracts:
 	s.abiTest, err = contracts.GetAbi(contracts.NameTest)
 	s.Require().NoError(err)
 
+	zeroState, err := execution.ParseZeroStateConfig(zerostateCfg)
+	s.Require().NoError(err)
+	zeroState.MainPublicKey = execution.MainPublicKey
+
 	s.Start(&nilservice.Config{
 		NShards:              s.ShardsNum,
 		HttpUrl:              rpc.GetSockPath(s.T()),
-		ZeroStateYaml:        zerostateCfg,
+		ZeroState:            zeroState,
 		CollatorTickPeriodMs: 200,
 		RunMode:              nilservice.CollatorsOnlyRunMode,
 	})

--- a/nil/tests/modifiers/rpc_modifiers_test.go
+++ b/nil/tests/modifiers/rpc_modifiers_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/NilFoundation/nil/nil/internal/abi"
 	"github.com/NilFoundation/nil/nil/internal/contracts"
 	"github.com/NilFoundation/nil/nil/internal/crypto"
+	"github.com/NilFoundation/nil/nil/internal/execution"
 	"github.com/NilFoundation/nil/nil/internal/types"
 	"github.com/NilFoundation/nil/nil/services/nilservice"
 	"github.com/NilFoundation/nil/nil/services/rpc"
@@ -40,7 +41,7 @@ func (s *SuiteModifiersRpc) SetupSuite() {
 	s.abi, err = contracts.GetAbi(contracts.NameTransactionCheck)
 	s.Require().NoError(err)
 
-	zerostate := fmt.Sprintf(`
+	zerostateYaml := fmt.Sprintf(`
 contracts:
 - name: SmartAccount
   address: %s
@@ -53,11 +54,15 @@ contracts:
   contract: tests/TransactionCheck
 `, s.smartAccountAddr.Hex(), hexutil.Encode(s.smartAccountPublicKey), s.testAddr)
 
+	zeroState, err := execution.ParseZeroStateConfig(zerostateYaml)
+	s.Require().NoError(err)
+	zeroState.MainPublicKey = execution.MainPublicKey
+
 	s.Start(&nilservice.Config{
-		NShards:       4,
-		HttpUrl:       rpc.GetSockPath(s.T()),
-		ZeroStateYaml: zerostate,
-		RunMode:       nilservice.CollatorsOnlyRunMode,
+		NShards:   4,
+		HttpUrl:   rpc.GetSockPath(s.T()),
+		ZeroState: zeroState,
+		RunMode:   nilservice.CollatorsOnlyRunMode,
 	})
 }
 

--- a/nil/tests/multitoken/multitoken_test.go
+++ b/nil/tests/multitoken/multitoken_test.go
@@ -98,11 +98,16 @@ contracts:
 }
 
 func (s *SuiteMultiTokenRpc) SetupTest() {
+	var err error
+	zeroState, err := execution.ParseZeroStateConfig(s.zerostateCfg)
+	s.Require().NoError(err)
+	zeroState.MainPublicKey = execution.MainPublicKey
+
 	s.Start(&nilservice.Config{
-		NShards:       s.ShardsNum,
-		HttpUrl:       rpc.GetSockPath(s.T()),
-		ZeroStateYaml: s.zerostateCfg,
-		RunMode:       nilservice.CollatorsOnlyRunMode,
+		NShards:   s.ShardsNum,
+		HttpUrl:   rpc.GetSockPath(s.T()),
+		ZeroState: zeroState,
+		RunMode:   nilservice.CollatorsOnlyRunMode,
 	})
 }
 

--- a/nil/tests/opcodes/opcodes_test.go
+++ b/nil/tests/opcodes/opcodes_test.go
@@ -52,7 +52,7 @@ contracts:
   contract: SmartAccount
   ctorArgs: [{{ .SmartAccountOwnerPublicKey }}]
 `
-	zerostate, err := common.ParseTemplate(zerostateTmpl, map[string]interface{}{
+	zerostateYaml, err := common.ParseTemplate(zerostateTmpl, map[string]interface{}{
 		"SmartAccountOwnerPublicKey": hexutil.Encode(execution.MainPublicKey),
 		"TestAddress1":               s.senderAddress1.Hex(),
 		"TestAddress2":               s.smartAccountAddress1.Hex(),
@@ -60,11 +60,15 @@ contracts:
 	})
 	s.Require().NoError(err)
 
+	zeroState, err := execution.ParseZeroStateConfig(zerostateYaml)
+	s.Require().NoError(err)
+	zeroState.MainPublicKey = execution.MainPublicKey
+
 	s.Start(&nilservice.Config{
-		NShards:       4,
-		HttpUrl:       rpc.GetSockPath(s.T()),
-		ZeroStateYaml: zerostate,
-		RunMode:       nilservice.CollatorsOnlyRunMode,
+		NShards:   4,
+		HttpUrl:   rpc.GetSockPath(s.T()),
+		ZeroState: zeroState,
+		RunMode:   nilservice.CollatorsOnlyRunMode,
 	})
 }
 

--- a/nil/tests/regression/regression_test.go
+++ b/nil/tests/regression/regression_test.go
@@ -49,11 +49,15 @@ contracts:
 }
 
 func (s *SuiteRegression) SetupTest() {
+	zeroStateConfig, err := execution.ParseZeroStateConfig(s.zerostateCfg)
+	s.Require().NoError(err)
+	zeroStateConfig.MainPublicKey = execution.MainPublicKey
+
 	s.Start(&nilservice.Config{
-		NShards:       s.ShardsNum,
-		HttpUrl:       rpc.GetSockPath(s.T()),
-		RunMode:       nilservice.CollatorsOnlyRunMode,
-		ZeroStateYaml: s.zerostateCfg,
+		NShards:   s.ShardsNum,
+		HttpUrl:   rpc.GetSockPath(s.T()),
+		RunMode:   nilservice.CollatorsOnlyRunMode,
+		ZeroState: zeroStateConfig,
 	})
 }
 

--- a/nil/tests/rpc_suite.go
+++ b/nil/tests/rpc_suite.go
@@ -79,6 +79,12 @@ func (s *RpcSuite) Start(cfg *nilservice.Config) {
 		cfg.L1Fetcher = GetDummyL1Fetcher()
 	}
 
+	if cfg.ZeroState == nil {
+		var err error
+		cfg.ZeroState, err = execution.CreateDefaultZeroStateConfig(execution.MainPublicKey)
+		s.Require().NoError(err)
+	}
+
 	var serviceInterop chan nilservice.ServiceInterop
 	if cfg.RunMode == nilservice.CollatorsOnlyRunMode {
 		serviceInterop = make(chan nilservice.ServiceInterop, 1)

--- a/nil/tests/smart-account/smart_account_test.go
+++ b/nil/tests/smart-account/smart_account_test.go
@@ -21,10 +21,9 @@ type SuiteSmartAccountRpc struct {
 
 func (s *SuiteSmartAccountRpc) SetupSuite() {
 	s.Start(&nilservice.Config{
-		NShards:       4,
-		HttpUrl:       rpc.GetSockPath(s.T()),
-		ZeroStateYaml: execution.DefaultZeroStateConfig,
-		RunMode:       nilservice.CollatorsOnlyRunMode,
+		NShards: 4,
+		HttpUrl: rpc.GetSockPath(s.T()),
+		RunMode: nilservice.CollatorsOnlyRunMode,
 	})
 }
 


### PR DESCRIPTION
In the future we need to get rid of generation mainKeys inside our cluster. But for now for replication - the best way to share them inside configuration and generate new one if we don't do it. 