### PR TITLE
Add cometa niljs integration tests

### DIFF
--- a/academy/token-split/task/deploy_and_test_tokensplitter.ts
+++ b/academy/token-split/task/deploy_and_test_tokensplitter.ts
@@ -1,11 +1,11 @@
 import {
-    FaucetClient,
-    HttpTransport,
-    PublicClient,
-    convertEthToWei,
-    generateSmartAccount,
-    waitTillCompleted,
-    type Token,
+  FaucetClient,
+  HttpTransport,
+  PublicClient,
+  type Token,
+  convertEthToWei,
+  generateSmartAccount,
+  waitTillCompleted,
 } from "@nilfoundation/niljs";
 
 import { type Abi, encodeFunctionData } from "viem";
@@ -15,181 +15,216 @@ import { task } from "hardhat/config";
 dotenv.config();
 
 task(
-    "deploy-test-tokensplitter",
-    "Deploys TokenSplitter, sends tokens to it, splits them, and verifies balances"
+  "deploy-test-tokensplitter",
+  "Deploys TokenSplitter, sends tokens to it, splits them, and verifies balances",
 ).setAction(async () => {
-    console.log("🚀 Starting TokenSplitter Deployment and Test Script");
+  console.log("🚀 Starting TokenSplitter Deployment and Test Script");
 
-    // --- Configuration ---
-    const deployerShard = 1;
-    const recipientShards = [2, 3, 4];
-    const tokenToSplitId = process.env.USDT as `0x${string}`;
-    if (!tokenToSplitId) {
-        throw new Error("❌ Missing USDT environment variable");
-    }
-    const amountsToSplit = [10n, 20n, 5n];
-    const totalAmountToSplit = amountsToSplit.reduce((sum, amount) => sum + amount, 0n);
-    const fundingAmount = totalAmountToSplit + 5n;
-    const feeCredit = convertEthToWei(0.005);
+  // --- Configuration ---
+  const deployerShard = 1;
+  const recipientShards = [2, 3, 4];
+  const tokenToSplitId = process.env.USDT as `0x${string}`;
+  if (!tokenToSplitId) {
+    throw new Error("❌ Missing USDT environment variable");
+  }
+  const amountsToSplit = [10n, 20n, 5n];
+  const totalAmountToSplit = amountsToSplit.reduce(
+    (sum, amount) => sum + amount,
+    0n,
+  );
+  const fundingAmount = totalAmountToSplit + 5n;
+  const feeCredit = convertEthToWei(0.005);
 
-    // --- Import Contract Artifact ---
-    const TokenSplitter = require("../artifacts/contracts/tokenSplitter.sol/TokenSplitter.json");
-    if (!TokenSplitter.abi || !TokenSplitter.bytecode) {
-        throw new Error("❌ TokenSplitter ABI or bytecode not found. Compile contracts first.");
-    }
+  // --- Import Contract Artifact ---
+  const TokenSplitter = require("../artifacts/contracts/tokenSplitter.sol/TokenSplitter.json");
+  if (!TokenSplitter.abi || !TokenSplitter.bytecode) {
+    throw new Error(
+      "❌ TokenSplitter ABI or bytecode not found. Compile contracts first.",
+    );
+  }
 
-    // --- Initialize Clients ---
-    console.log("🔧 Initializing PublicClient and Faucet...");
-    const client = new PublicClient({
-        transport: new HttpTransport({
-            endpoint: process.env.NIL_RPC_ENDPOINT as string,
-        }),
+  // --- Initialize Clients ---
+  console.log("🔧 Initializing PublicClient and Faucet...");
+  const client = new PublicClient({
+    transport: new HttpTransport({
+      endpoint: process.env.NIL_RPC_ENDPOINT as string,
+    }),
+  });
+
+  const faucet = new FaucetClient({
+    transport: new HttpTransport({
+      endpoint: process.env.NIL_RPC_ENDPOINT as string,
+    }),
+  });
+
+  // --- Generate Accounts ---
+  console.log("👤 Generating Deployer and Recipient Accounts...");
+  const deployerWallet = await generateSmartAccount({
+    shardId: deployerShard,
+    rpcEndpoint: process.env.NIL_RPC_ENDPOINT as string,
+    faucetEndpoint: process.env.NIL_RPC_ENDPOINT as string,
+  });
+  console.log(
+    `Deployer account generated: ${deployerWallet.address} (Shard ${deployerShard})`,
+  );
+
+  const recipients: Awaited<ReturnType<typeof generateSmartAccount>>[] = [];
+  for (let i = 0; i < recipientShards.length; i++) {
+    const recipient = await generateSmartAccount({
+      shardId: recipientShards[i],
+      rpcEndpoint: process.env.NIL_RPC_ENDPOINT as string,
+      faucetEndpoint: process.env.NIL_RPC_ENDPOINT as string,
     });
+    console.log(
+      `Recipient ${i + 1} account generated: ${recipient.address} (Shard ${recipientShards[i]})`,
+    );
+    recipients.push(recipient);
+  }
+  const recipientAddresses = recipients.map((r) => r.address);
 
-    const faucet = new FaucetClient({
-        transport: new HttpTransport({
-            endpoint: process.env.NIL_RPC_ENDPOINT as string,
-        }),
-    });
-
-    // --- Generate Accounts ---
-    console.log("👤 Generating Deployer and Recipient Accounts...");
-    const deployerWallet = await generateSmartAccount({
-        shardId: deployerShard,
-        rpcEndpoint: process.env.NIL_RPC_ENDPOINT as string,
-        faucetEndpoint: process.env.NIL_RPC_ENDPOINT as string,
-    });
-    console.log(`Deployer account generated: ${deployerWallet.address} (Shard ${deployerShard})`);
-
-    const recipients: Awaited<ReturnType<typeof generateSmartAccount>>[] = [];
-    for (let i = 0; i < recipientShards.length; i++) {
-        const recipient = await generateSmartAccount({
-            shardId: recipientShards[i],
-            rpcEndpoint: process.env.NIL_RPC_ENDPOINT as string,
-            faucetEndpoint: process.env.NIL_RPC_ENDPOINT as string,
-        });
-        console.log(`Recipient ${i + 1} account generated: ${recipient.address} (Shard ${recipientShards[i]})`);
-        recipients.push(recipient);
-    }
-    const recipientAddresses = recipients.map(r => r.address);
-
-    // --- Fund Deployer Account ---
-    console.log(`💰 Funding Deployer ${deployerWallet.address} with ${fundingAmount} ${tokenToSplitId}...`);
+  // --- Fund Deployer Account ---
+  console.log(
+    `💰 Funding Deployer ${deployerWallet.address} with ${fundingAmount} ${tokenToSplitId}...`,
+  );
+  try {
+    await faucet.topUpAndWaitUntilCompletion(
+      {
+        smartAccountAddress: deployerWallet.address,
+        faucetAddress: tokenToSplitId,
+        amount: fundingAmount,
+      },
+      client,
+    );
+    console.log(`✅ Deployer funded with ${tokenToSplitId}.`);
+  } catch (error) {
+    console.error(
+      `❌ Failed to fund Deployer with ${tokenToSplitId}. Make sure the faucet address is correct and has funds.`,
+      error,
+    );
+    console.log(
+      `💰 Attempting to fund Deployer ${deployerWallet.address} with NIL for gas...`,
+    );
     try {
-        await faucet.topUpAndWaitUntilCompletion(
-            {
-                smartAccountAddress: deployerWallet.address,
-                faucetAddress: tokenToSplitId,
-                amount: fundingAmount,
-            },
-            client
-        );
-        console.log(`✅ Deployer funded with ${tokenToSplitId}.`);
-    } catch (error) {
-        console.error(`❌ Failed to fund Deployer with ${tokenToSplitId}. Make sure the faucet address is correct and has funds.`, error);
-        console.log(`💰 Attempting to fund Deployer ${deployerWallet.address} with NIL for gas...`);
-        try {
-            await faucet.topUpAndWaitUntilCompletion(
-                {
-                    smartAccountAddress: deployerWallet.address,
-                    faucetAddress: process.env.NIL as `0x${string}`,
-                    amount: convertEthToWei(0.1),
-                },
-                client
-            );
-            console.log("✅ Deployer funded with NIL.");
-        } catch (nilError) {
-            console.error("❌ Failed to fund Deployer with NIL as well.", nilError);
-            throw new Error("Funding failed for both token and NIL.");
-        }
-        throw new Error(`Funding with ${tokenToSplitId} failed, but NIL funding succeeded. Cannot proceed without the token to split.`);
-    }
-
-
-    // --- Deploy TokenSplitter Contract ---
-    console.log(`🏗 Deploying TokenSplitter contract from ${deployerWallet.address}...`);
-    const { address: tokenSplitterAddress, hash: deployHash } = await deployerWallet.deployContract({
-        shardId: deployerShard,
-        abi: TokenSplitter.abi as Abi,
-        args: [],
-        bytecode: TokenSplitter.bytecode as `0x${string}`,
-        salt: BigInt(Math.floor(Math.random() * 100000)),
-        feeCredit: feeCredit,
-    });
-    await waitTillCompleted(client, deployHash);
-    console.log(`✅ TokenSplitter deployed at: ${tokenSplitterAddress} (Tx: ${deployHash})`);
-
-    // --- Get Initial Recipient Balances ---
-    console.log("🔍 Getting initial recipient balances...");
-    const initialRecipientBalances: (bigint | undefined)[] = [];
-    for (let i = 0; i < recipients.length; i++) {
-        const initialTokenRecord: Record<string, bigint> = await client.getTokens(recipients[i].address, 'latest');
-        initialRecipientBalances[i] = initialTokenRecord[tokenToSplitId];
-        console.log(`Recipient ${i + 1} (${recipients[i].address}) initial ${tokenToSplitId} balance: ${initialRecipientBalances[i] ?? 0n}`);
-    }
-
-    // --- Call splitTokens ---
-    console.log(`⚡ Calling splitTokens function on ${tokenSplitterAddress}...`);
-    const splitArgs = [
-        tokenToSplitId,
-        recipientAddresses,
-        amountsToSplit,
-    ];
-    const splitTxData = encodeFunctionData({
-        abi: TokenSplitter.abi as Abi,
-        functionName: "splitTokens",
-        args: splitArgs,
-    });
-
-    // Add the tokens directly to the splitTokens transaction
-    const tokensToSendWithSplit: Token[] = [
+      await faucet.topUpAndWaitUntilCompletion(
         {
-            id: tokenToSplitId,
-            amount: totalAmountToSplit,
+          smartAccountAddress: deployerWallet.address,
+          faucetAddress: process.env.NIL as `0x${string}`,
+          amount: convertEthToWei(0.1),
         },
-    ];
+        client,
+      );
+      console.log("✅ Deployer funded with NIL.");
+    } catch (nilError) {
+      console.error("❌ Failed to fund Deployer with NIL as well.", nilError);
+      throw new Error("Funding failed for both token and NIL.");
+    }
+    throw new Error(
+      `Funding with ${tokenToSplitId} failed, but NIL funding succeeded. Cannot proceed without the token to split.`,
+    );
+  }
 
-    const splitHash = await deployerWallet.sendTransaction({
-        to: tokenSplitterAddress,
-        data: splitTxData,
-        tokens: tokensToSendWithSplit,
-        feeCredit: feeCredit,
+  // --- Deploy TokenSplitter Contract ---
+  console.log(
+    `🏗 Deploying TokenSplitter contract from ${deployerWallet.address}...`,
+  );
+  const { address: tokenSplitterAddress, hash: deployHash } =
+    await deployerWallet.deployContract({
+      shardId: deployerShard,
+      abi: TokenSplitter.abi as Abi,
+      args: [],
+      bytecode: TokenSplitter.bytecode as `0x${string}`,
+      salt: BigInt(Math.floor(Math.random() * 100000)),
+      feeCredit: feeCredit,
     });
-    await waitTillCompleted(client, splitHash);
-    console.log(`✅ splitTokens function called (Tx: ${splitHash})`);
+  await waitTillCompleted(client, deployHash);
+  console.log(
+    `✅ TokenSplitter deployed at: ${tokenSplitterAddress} (Tx: ${deployHash})`,
+  );
 
-    // --- Verify Recipient Balances ---
-    console.log("⏳ Waiting for asynchronous transfers to complete (approx 15-30 seconds)...");
-    await new Promise(res => setTimeout(res, 30000));
+  // --- Get Initial Recipient Balances ---
+  console.log("🔍 Getting initial recipient balances...");
+  const initialRecipientBalances: (bigint | undefined)[] = [];
+  for (let i = 0; i < recipients.length; i++) {
+    const initialTokenRecord: Record<string, bigint> = await client.getTokens(
+      recipients[i].address,
+      "latest",
+    );
+    initialRecipientBalances[i] = initialTokenRecord[tokenToSplitId];
+    console.log(
+      `Recipient ${i + 1} (${recipients[i].address}) initial ${tokenToSplitId} balance: ${initialRecipientBalances[i] ?? 0n}`,
+    );
+  }
 
-    console.log("🔍 Verifying final recipient balances...");
-    let success = true;
-    for (let i = 0; i < recipients.length; i++) {
-        const recipientAddress = recipients[i].address;
-        try {
-            const finalTokenRecord: Record<string, bigint> = await client.getTokens(recipientAddress, 'latest');
-            const finalBalance: bigint = finalTokenRecord[tokenToSplitId] ?? 0n;
-            const expectedBalance = (initialRecipientBalances[i] ?? 0n) + amountsToSplit[i];
+  // --- Call splitTokens ---
+  console.log(`⚡ Calling splitTokens function on ${tokenSplitterAddress}...`);
+  const splitArgs = [tokenToSplitId, recipientAddresses, amountsToSplit];
+  const splitTxData = encodeFunctionData({
+    abi: TokenSplitter.abi as Abi,
+    functionName: "splitTokens",
+    args: splitArgs,
+  });
 
-            console.log(`Recipient ${i + 1} (${recipientAddress}) final ${tokenToSplitId} balance: ${finalBalance} (Expected: ${expectedBalance})`);
+  // Add the tokens directly to the splitTokens transaction
+  const tokensToSendWithSplit: Token[] = [
+    {
+      id: tokenToSplitId,
+      amount: totalAmountToSplit,
+    },
+  ];
 
-            if (finalBalance !== expectedBalance) {
-                console.error(`❌ Verification Failed for Recipient ${i + 1}: Expected ${expectedBalance}, got ${finalBalance}`);
-                success = false;
-            } else {
-                console.log(`✅ Verification Success for Recipient ${i + 1}`);
-            }
-        } catch (error) {
-            console.error(`❌ Error fetching balance for Recipient ${i + 1} (${recipientAddress}):`, error);
-            success = false;
-        }
+  const splitHash = await deployerWallet.sendTransaction({
+    to: tokenSplitterAddress,
+    data: splitTxData,
+    tokens: tokensToSendWithSplit,
+    feeCredit: feeCredit,
+  });
+  await waitTillCompleted(client, splitHash);
+  console.log(`✅ splitTokens function called (Tx: ${splitHash})`);
+
+  // --- Verify Recipient Balances ---
+  console.log(
+    "⏳ Waiting for asynchronous transfers to complete (approx 15-30 seconds)...",
+  );
+  await new Promise((res) => setTimeout(res, 30000));
+
+  console.log("🔍 Verifying final recipient balances...");
+  let success = true;
+  for (let i = 0; i < recipients.length; i++) {
+    const recipientAddress = recipients[i].address;
+    try {
+      const finalTokenRecord: Record<string, bigint> = await client.getTokens(
+        recipientAddress,
+        "latest",
+      );
+      const finalBalance: bigint = finalTokenRecord[tokenToSplitId] ?? 0n;
+      const expectedBalance =
+        (initialRecipientBalances[i] ?? 0n) + amountsToSplit[i];
+
+      console.log(
+        `Recipient ${i + 1} (${recipientAddress}) final ${tokenToSplitId} balance: ${finalBalance} (Expected: ${expectedBalance})`,
+      );
+
+      if (finalBalance !== expectedBalance) {
+        console.error(
+          `❌ Verification Failed for Recipient ${i + 1}: Expected ${expectedBalance}, got ${finalBalance}`,
+        );
+        success = false;
+      } else {
+        console.log(`✅ Verification Success for Recipient ${i + 1}`);
+      }
+    } catch (error) {
+      console.error(
+        `❌ Error fetching balance for Recipient ${i + 1} (${recipientAddress}):`,
+        error,
+      );
+      success = false;
     }
+  }
 
-    if (success) {
-        console.log("🎉 Token splitting test completed successfully!");
-    } else {
-        console.error("❌ Token splitting test failed due to balance mismatches.");
-        throw new Error("Token splitting verification failed.");
-    }
-
+  if (success) {
+    console.log("🎉 Token splitting test completed successfully!");
+  } else {
+    console.error("❌ Token splitting test failed due to balance mismatches.");
+    throw new Error("Token splitting verification failed.");
+  }
 });

--- a/clijs/src/commands/smart-account/deploy.ts
+++ b/clijs/src/commands/smart-account/deploy.ts
@@ -118,7 +118,7 @@ export default class SmartAccountDeploy extends BaseCommand {
       const compileInputPath = path.resolve(flags.compileInput);
       const compileInputContent = fs.readFileSync(compileInputPath, "utf8");
       contractData = await cometaClient.compileContract(compileInputContent);
-      bytecode = contractData.code;
+      bytecode = addHexPrefix(contractData.code);
       abi = contractData.abi as unknown as Abi;
     } else {
       const filename = args.filename;

--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
             solc = solc;
             rollup-bridge-contracts = rollup-bridge-contracts;
           });
-          niljs = (pkgs.callPackage ./nix/niljs.nix { solc = solc; });
+          niljs = (pkgs.callPackage ./nix/niljs.nix { solc = solc; nil = nil; });
           clijs = (pkgs.callPackage ./nix/clijs.nix { nil = nil; });
           nilhardhat = (pkgs.callPackage ./nix/nilhardhat.nix { solc = solc; });
           nildocs = (pkgs.callPackage ./nix/nildocs.nix {

--- a/niljs/package.json
+++ b/niljs/package.json
@@ -29,7 +29,7 @@
   "description": "Typescript library to interact with the Nil blockchain. Can be used in the browser or in Node.js.",
   "scripts": {
     "test:unit": "CI=true vitest -c ./test/vitest.config.ts",
-    "test:integration": "CI=true vitest -c ./test/vitest.integration.config.ts --isolate false",
+    "test:integration": "CI=true vitest -c ./test/vitest.integration.config.ts --isolate false --reporter=verbose",
     "test:coverage": "CI=true vitest -c ./test/vitest.config.ts --coverage",
     "test:examples": "ls ./examples | xargs -I {} tsx ./examples/{}",
     "build": "rimraf dist && rollup -c ./rollup/rollup.config.js --bundleConfigAsCjs",

--- a/niljs/src/clients/CometaClient.ts
+++ b/niljs/src/clients/CometaClient.ts
@@ -1,7 +1,7 @@
 import type { Hex } from "../types/Hex.js";
 import { BaseClient } from "./BaseClient.js";
-import type { ContractData, Location } from "./types/CometaTypes.js";
 import type { CometaClientConfig } from "./types/Configs.js";
+import type { ContractData, Location, TransactionData } from "./types/CometaTypes.js";
 
 /**
  * CometaClient is a client that interacts with the Cometa service.
@@ -53,10 +53,11 @@ class CometaClient extends BaseClient {
    * @param inputJson - The JSON input.
    * @returns The contract metadata.
    */
-  public async compileContract(inputJson: string) {
+  public async compileContract(inputJson: string | Record<string, unknown>) {
+    const inputJsonString = typeof inputJson === "string" ? inputJson : JSON.stringify(inputJson);
     return await this.request<ContractData>({
       method: "cometa_compileContract",
-      params: [inputJson],
+      params: [inputJsonString],
     });
   }
 
@@ -77,10 +78,48 @@ class CometaClient extends BaseClient {
    * @param inputJson - The JSON input for compiler.
    * @param address - Address of the contract.
    */
-  public async registerContract(inputJson: string, address: Hex) {
+  public async registerContract(inputJson: string | Record<string, unknown>, address: Hex) {
+    const inputJsonString = typeof inputJson === "string" ? inputJson : JSON.stringify(inputJson);
+
     return await this.request({
       method: "cometa_registerContract",
-      params: [inputJson, address],
+      params: [inputJsonString, address],
+    });
+  }
+
+  /**
+   * Returns the abi of the contract.
+   * @param address - Address of the contract.
+   * @returns Abi of the contract.
+   */
+  public async getAbi(address: Hex) {
+    return await this.request<string>({
+      method: "cometa_getAbi",
+      params: [address],
+    });
+  }
+
+  /**
+   * Returns the source code of the contract by address.
+   * @param address - Address of the contract.
+   * @returns The source code of the contract.
+   */
+  public async getSourceCode(address: Hex) {
+    return await this.request<Record<string, string>>({
+      method: "cometa_getSourceCode",
+      params: [address],
+    });
+  }
+
+  /**
+   * Accepts an array of transaction data and returns an array of decoded function names called by the transactions.
+   * @param data - The data to decode.
+   * @returns The decoded data.
+   */
+  public async decodeTransactionsCallData(data: TransactionData[]) {
+    return await this.request<string[]>({
+      method: "cometa_decodeTransactionsCallData",
+      params: [data],
     });
   }
 }

--- a/niljs/src/clients/CometaClient.ts
+++ b/niljs/src/clients/CometaClient.ts
@@ -1,7 +1,7 @@
 import type { Hex } from "../types/Hex.js";
 import { BaseClient } from "./BaseClient.js";
-import type { CometaClientConfig } from "./types/Configs.js";
 import type { ContractData, Location, TransactionData } from "./types/CometaTypes.js";
+import type { CometaClientConfig } from "./types/Configs.js";
 
 /**
  * CometaClient is a client that interacts with the Cometa service.

--- a/niljs/src/clients/types/CometaTypes.ts
+++ b/niljs/src/clients/types/CometaTypes.ts
@@ -2,6 +2,8 @@
  * @fileoverview Types for the Cometa client.
  */
 
+import type { Hex } from "../../types/Hex.js";
+
 /**
  * Contract data.
  * @typedef {Object} ContractData
@@ -13,8 +15,8 @@ type ContractData = {
   sourceCode: Record<string, string>;
   sourceMap: string;
   metadata: string;
-  initCode: Uint8Array;
-  code: Uint8Array;
+  initCode: string;
+  code: string;
   sourceFilesList: string[];
   methodIdentifiers: Record<string, string>;
 };
@@ -29,4 +31,12 @@ type Location = {
   length: number;
 };
 
-export type { ContractData, Location };
+/**
+ * Transaction data.
+ */
+type TransactionData = {
+  address: Hex;
+  funcId: Hex;
+};
+
+export type { ContractData, Location, TransactionData };

--- a/niljs/src/encoding/toHex.ts
+++ b/niljs/src/encoding/toHex.ts
@@ -56,6 +56,22 @@ const numberToHex = (num: number | bigint): Hex => {
 };
 
 /**
+ * Converts a base64 string to a hex string.
+ * @param base64 - base64 string
+ * @returns hex string
+ */
+const base64ToHex = (base64: string): Hex => {
+  const binaryString =
+    typeof atob === "function" ? atob(base64) : Buffer.from(base64, "base64").toString("binary");
+
+  return addHexPrefix(
+    Array.from(binaryString)
+      .map((char) => char.charCodeAt(0).toString(16).padStart(2, "0"))
+      .join(""),
+  );
+};
+
+/**
  * Converts a string, number, bigint, boolean, or ByteArrayType to a hex string.
  * @param value The input to convert.
  * @returns The hex string representation of the input.
@@ -78,4 +94,4 @@ const toHex = <T extends string | Uint8Array | boolean | bigint | number>(value:
   return addHexPrefix((value ? 1 : 0).toString(16));
 };
 
-export { toHex };
+export { toHex, base64ToHex };

--- a/niljs/src/utils/hex.ts
+++ b/niljs/src/utils/hex.ts
@@ -8,11 +8,7 @@ const HEX_REGEX = /^[0-9a-fA-F]+$/;
  * @param value The value to check.
  */
 const isHexString = (value: unknown): value is Hex => {
-  return (
-    typeof value === "string" &&
-    value.startsWith("0x") &&
-    HEX_REGEX.test(removeHexPrefix(value) as string)
-  );
+  return typeof value === "string" && HEX_REGEX.test(removeHexPrefix(value) as string);
 };
 
 /**

--- a/niljs/test/integration/cometa.test.ts
+++ b/niljs/test/integration/cometa.test.ts
@@ -1,0 +1,115 @@
+import type { ContractData } from "../../src/clients/types/CometaTypes.js";
+import { base64ToHex } from "../../src/encoding/toHex.js";
+import {
+  CometaService,
+  type Hex,
+  HttpTransport,
+  convertEthToWei,
+  waitTillCompleted,
+} from "../../src/index.js";
+import { testEnv } from "../testEnv.js";
+import { generateTestSmartAccount } from "./helpers.js";
+
+const incrementerContract = `
+  // SPDX-License-Identifier: MIT
+  pragma solidity ^0.8.28;
+  contract Incrementer {
+    uint256 public value;
+    constructor() {
+      value = 0;
+    }
+    function increment() public {
+      value += 1;
+    }
+  }
+`;
+
+let contractAdress: Hex;
+let contractCompilationResult: ContractData;
+
+const sAcc = await generateTestSmartAccount();
+
+const cometaService = new CometaService({
+  transport: new HttpTransport({
+    endpoint: testEnv.cometaServiceEndpoint,
+  }),
+  shardId: 1,
+});
+
+test("compile contract", async () => {
+  const res = await cometaService.compileContract({
+    contractName: "Incrementer:Incrementer",
+    compilerVersion: "0.8.28",
+    settings: {
+      evmVersion: "cancun",
+    },
+    language: "Solidity",
+    sources: {
+      Incrementer: {
+        content: incrementerContract,
+      },
+    },
+  });
+  expect(res).toBeDefined();
+  expect(res.code).toBeDefined();
+  expect(res.abi).toBeDefined();
+  contractCompilationResult = res;
+});
+
+test("register contract", async () => {
+  const { address, hash } = await sAcc.deployContract({
+    bytecode: base64ToHex(contractCompilationResult.initCode),
+    abi: JSON.parse(contractCompilationResult.abi),
+    args: [],
+    feeCredit: convertEthToWei(0.00001),
+    salt: BigInt(Math.floor(Math.random() * 10000000000000000)),
+    shardId: 1,
+  });
+
+  const receipts = await waitTillCompleted(sAcc.client, hash);
+  expect(receipts.some((receipt) => !receipt.success)).toBe(false);
+
+  contractAdress = address;
+
+  const code = await sAcc.client.getCode(address);
+
+  expect(code).toBeDefined();
+  expect(async () => {
+    await cometaService.registerContract(
+      {
+        contractName: "Incrementer:Incrementer",
+        compilerVersion: "0.8.28",
+        settings: {
+          evmVersion: "cancun",
+        },
+        language: "Solidity",
+        sources: {
+          Incrementer: {
+            content: incrementerContract,
+          },
+        },
+      },
+      address,
+    );
+  }).not.toThrow();
+});
+
+test("get abi", async () => {
+  const abi = await cometaService.getAbi(contractAdress);
+  expect(abi).toBeDefined();
+  expect(abi).toBe(contractCompilationResult.abi);
+});
+
+test("get source code", async () => {
+  const sourceCode = await cometaService.getSourceCode(contractAdress);
+  expect(sourceCode).toBeDefined();
+  const { Incrementer } = sourceCode;
+  expect(Incrementer).toBe(incrementerContract);
+});
+
+test("get contract", async () => {
+  const contract = await cometaService.getContract(contractAdress);
+  expect(contract).toBeDefined();
+  expect(contract.name).toBe("Incrementer:Incrementer");
+  expect(contract.sourceCode.Incrementer).toBe(incrementerContract);
+});

--- a/niljs/test/mocks/cometa-config.yml
+++ b/niljs/test/mocks/cometa-config.yml
@@ -1,0 +1,4 @@
+use-badger: true
+db-path: cometa.db
+db-name: nil_db
+db-user: default

--- a/niljs/test/vitest.integration.config.ts
+++ b/niljs/test/vitest.integration.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["test/integration/*.test.ts"],
-    hookTimeout: 20_000,
+    hookTimeout: 40_000,
     testTimeout: 40_000,
     globals: true,
     coverage: {


### PR DESCRIPTION
This diff extends functionality of `CometaService` class of `niljs` so we can use new methods of cometa service, like `cometa_getSourceCode()` in other apps, for instance in block explorer.
In addition, this diff adds integration tests for cometa service to niljs.

In addition, it slighly changes the interfaces of `registerContract()` and `compileContract()`, because for js-users it is going to be much more convenient to provide an object to this method. Previously we accepted only json-like string.