### PR TITLE
Add duplication of deployment errors to deploy modal

### DIFF
--- a/explorer_frontend/src/features/code/Code.tsx
+++ b/explorer_frontend/src/features/code/Code.tsx
@@ -185,7 +185,7 @@ export const Code = () => {
               className={css({
                 paddingBottom: "0!important",
                 height: "100%",
-                overflow: "auto",
+                overflow: "auto!important",
                 overscrollBehavior: "contain",
               })}
               data-testid="code-field"

--- a/explorer_frontend/src/features/contracts/components/Deploy/DeployTab.tsx
+++ b/explorer_frontend/src/features/contracts/components/Deploy/DeployTab.tsx
@@ -5,6 +5,7 @@ import {
   FormControl,
   HeadingMedium,
   Input,
+  ParagraphSmall,
   SPACE,
 } from "@nilfoundation/ui-kit";
 import { useUnit } from "effector-react";
@@ -12,6 +13,7 @@ import { useStyletron } from "styletron-react";
 import { $smartAccount } from "../../../account-connector/model";
 import { $constructor } from "../../init";
 import {
+  $deploySmartContractError,
   $deploymentArgs,
   $shardId,
   $shardIdIsValid,
@@ -23,14 +25,16 @@ import {
 import { ShardIdInput } from "./ShardIdInput";
 
 export const DeployTab = () => {
-  const [smartAccount, args, constuctorAbi, pending, shardId, shardIdIsValid] = useUnit([
-    $smartAccount,
-    $deploymentArgs,
-    $constructor,
-    deploySmartContractFx.pending,
-    $shardId,
-    $shardIdIsValid,
-  ]);
+  const [smartAccount, args, constuctorAbi, pending, shardId, shardIdIsValid, deployError] =
+    useUnit([
+      $smartAccount,
+      $deploymentArgs,
+      $constructor,
+      deploySmartContractFx.pending,
+      $shardId,
+      $shardIdIsValid,
+      $deploySmartContractError,
+    ]);
   const [css] = useStyletron();
 
   return (
@@ -134,6 +138,11 @@ export const DeployTab = () => {
         >
           Deploy
         </Button>
+        {deployError && (
+          <ParagraphSmall color={COLORS.red400} marginTop={SPACE[16]}>
+            {deployError}
+          </ParagraphSmall>
+        )}
       </div>
     </>
   );

--- a/explorer_frontend/src/features/contracts/init.ts
+++ b/explorer_frontend/src/features/contracts/init.ts
@@ -18,9 +18,9 @@ import {
   $callParams,
   $callResult,
   $contracts,
+  $deploySmartContractError,
   $deployedContracts,
   $deploymentArgs,
-  $error,
   $errors,
   $importedAddress,
   $importedSmartContractAddress,
@@ -82,9 +82,6 @@ $activeApp.on(choseApp, (_, { address, bytecode }) => {
   };
 });
 $activeApp.reset(closeApp);
-
-$error.on(compileCodeFx.failData, (_, error) => `${error}`);
-$error.reset(compileCodeFx.doneData);
 
 $deploymentArgs.on(setDeploymentArg, (args, { key, value }) => {
   return {
@@ -200,6 +197,10 @@ sample({
   clock: deploySmartContract,
   target: deploySmartContractFx,
 });
+
+$deploySmartContractError.reset($activeApp);
+$deploySmartContractError.reset(deploySmartContract);
+$deploySmartContractError.on(deploySmartContractFx.failData, (_, error) => String(error));
 
 $importedSmartContractAddress.on(setImportedSmartContractAddress, (_, address) => address);
 $importedSmartContractAddress.reset($activeApp);

--- a/explorer_frontend/src/features/contracts/models/base.ts
+++ b/explorer_frontend/src/features/contracts/models/base.ts
@@ -52,8 +52,6 @@ export const $contractWithState = combine($contracts, $deployedContracts, (contr
   return contractsWithAddress;
 });
 
-export const $error = createStore<string | null>(null);
-
 export const $activeAppWithState = combine($activeApp, $contracts, (activeApp, contracts) => {
   if (activeApp === null) {
     return null;
@@ -86,6 +84,8 @@ export const setRandomShardId = createEvent();
 export const incrementShardId = createEvent("increment");
 export const decrementShardId = createEvent("decrement");
 export const triggerShardIdValidation = createEvent();
+
+export const $deploySmartContractError = createStore<string | null>(null);
 
 export const deploySmartContract = createEvent();
 export const deploySmartContractFx = createEffect<


### PR DESCRIPTION
This diff improves UX by displaying deployment errors in the Deploy modal itself as long as in the logs panel. Previously errors were displayed only in the logs, which was not visible when modal was open (cz it has a backdrop).