### PR TITLE
Fix find and replace dialog in playground

### DIFF
--- a/explorer_frontend/src/features/code/Code.tsx
+++ b/explorer_frontend/src/features/code/Code.tsx
@@ -148,8 +148,6 @@ export const Code = () => {
             className={css({
               width: "100%",
               height: `calc(100% - ${isMobile ? "32px - 8px - 8px - 48px - 8px - 48px - 8px" : "48px - 8px"})`,
-              overflow: "auto",
-              overscrollBehavior: "contain",
               backgroundColor: COLORS.gray900,
               borderTopLeftRadius: "12px",
               borderTopRightRadius: "12px",
@@ -167,6 +165,9 @@ export const Code = () => {
               }}
               className={css({
                 paddingBottom: "0!important",
+                height: "100%",
+                overflow: "auto",
+                overscrollBehavior: "contain",
               })}
               data-testid="code-field"
             />


### PR DESCRIPTION
Actually currently we have a built-in "find and replace" dialog in the code field. But due to some css styling it was typically hidden. Find and replace dialog should be always visible because it is needed to go from one fragment of code to another without loosing find and replace panel.

https://github.com/user-attachments/assets/9e2110a7-4b92-4808-8c22-e97fbfaf9c73

