### PR TITLE
[faucet] Actually track seqnos in the service

### DIFF
--- a/nil/services/faucet/jsonrpc.go
+++ b/nil/services/faucet/jsonrpc.go
@@ -44,11 +44,10 @@ func (c *APIImpl) fetchSeqno(ctx context.Context, addr types.Address) (types.Seq
 }
 
 func (c *APIImpl) getOrFetchSeqno(ctx context.Context, faucetAddress types.Address) (types.Seqno, error) {
-	// todo: uncomment after switching all users (e.g. docs and tests) to the faucet service
-	// seqno, ok := c.seqnos[faucetAddress]
-	// if ok {
-	//	return seqno, nil
-	// }
+	seqno, ok := c.seqnos[faucetAddress]
+	if ok {
+		return seqno, nil
+	}
 
 	seqno, err := c.fetchSeqno(ctx, faucetAddress)
 	if err != nil {


### PR DESCRIPTION
Closes https://github.com/NilFoundation/nil/issues/95

The legacy faucet was removed some time ago, so we can explicitly track seqnos for faucet contracts.