### PR TITLE
[execution] Fix nested sendRequests

### DIFF
--- a/nil/tests/rpc_suite.go
+++ b/nil/tests/rpc_suite.go
@@ -351,3 +351,8 @@ func getContractInfo(addr types.Address, valuesMap ReceiptInfo) *ContractInfo {
 	}
 	return value
 }
+
+func (s *RpcSuite) CheckBalance(infoMap ReceiptInfo, balance types.Value, accounts []types.Address) types.Value {
+	s.T().Helper()
+	return CheckBalance(s.T(), s.Context, s.Client, infoMap, balance, accounts)
+}


### PR DESCRIPTION
If the callee of `sendRequest` also calls `sendRequest`, it leads to incorrect inheritance of the request chain.
`sendRequest` should not wait for another `sendRequest`, it should wait for only `awaitCall`.
Three new test cases covering these statements have been added.