### PR TITLE
[syncer] don't abort bootstrap if snapshot is not fetched

### DIFF
--- a/nil/internal/collate/bootstrap.go
+++ b/nil/internal/collate/bootstrap.go
@@ -69,22 +69,21 @@ func fetchShardSnap(ctx context.Context, nm *network.Manager, peerId network.Pee
 }
 
 // Fetch DB snapshot via libp2p.
-func fetchSnapshot(ctx context.Context, nm *network.Manager, peerAddr *network.AddrInfo, db db.DB) error {
+func fetchSnapshot(ctx context.Context, nm *network.Manager, peerAddr *network.AddrInfo, db db.DB, logger zerolog.Logger) error {
 	if nm == nil {
 		return nil
 	}
 
-	logger := logging.NewLogger("bootstrap").With().Logger()
 	if peerAddr == nil {
 		logger.Info().Msg("Peer address is empty. Snapshot won't be fetched")
 		return nil
 	}
-	logger.Info().Msgf("Start to fetch data snapshot from %s", peerAddr)
 
 	peerId, err := nm.Connect(ctx, *peerAddr)
 	if err != nil {
-		logger.Error().Err(err).Msgf("Failed to connect to %s", peerAddr)
+		logger.Error().Err(err).Msgf("Failed to connect to %s to fetch snapshot", peerAddr)
 		return err
 	}
+	logger.Info().Msgf("Start to fetch data snapshot from %s", peerAddr)
 	return fetchShardSnap(ctx, nm, peerId, db, logger)
 }

--- a/nil/internal/collate/syncer.go
+++ b/nil/internal/collate/syncer.go
@@ -131,14 +131,10 @@ func (s *Syncer) FetchSnapshot(ctx context.Context) error {
 	if snapIsRequired, err := s.shardIsEmpty(ctx); err != nil {
 		return err
 	} else if snapIsRequired {
-		var err error
 		for _, peer := range s.config.BootstrapPeers {
-			if err = fetchSnapshot(ctx, s.networkManager, &peer, s.db); err == nil {
+			if err = fetchSnapshot(ctx, s.networkManager, &peer, s.db, s.logger); err == nil {
 				return nil
 			}
-		}
-		if err != nil {
-			return fmt.Errorf("failed to fetch snapshot: %w", err)
 		}
 	}
 	return nil


### PR DESCRIPTION
Fetching of snapshot is optional. We still can apply blocks one by one. We should log errors but not terminate application in case of issues.

Follow-up 5505b9171eae3e4f0d612b58de66e1bee4f877bb