### PR TITLE
Sync Committee: Block Storage Reset

### DIFF
--- a/nil/services/synccommittee/internal/testaide/blocks.go
+++ b/nil/services/synccommittee/internal/testaide/blocks.go
@@ -68,7 +68,10 @@ func NewBatchesSequence(batchesCount int) []*scTypes.BlockBatch {
 	batches := make([]*scTypes.BlockBatch, 0, batchesCount)
 	for range batchesCount {
 		nextBatch := NewBlockBatch(ShardsCount)
-		if len(batches) > 0 {
+		if len(batches) == 0 {
+			nextBatch.MainShardBlock.Number = 0
+			nextBatch.MainShardBlock.ParentHash = common.EmptyHash
+		} else {
 			prevMainBlock := batches[len(batches)-1].MainShardBlock
 			nextBatch.MainShardBlock.ParentHash = prevMainBlock.Hash
 			nextBatch.MainShardBlock.Number = prevMainBlock.Number + 1

--- a/nil/services/synccommittee/internal/types/blocks.go
+++ b/nil/services/synccommittee/internal/types/blocks.go
@@ -97,6 +97,22 @@ func (br *MainBlockRef) ValidateChild(child *jsonrpc.RPCBlock) error {
 	}
 }
 
+func GetMainParentRef(mainBlock *jsonrpc.RPCBlock) (*MainBlockRef, error) {
+	if mainBlock == nil {
+		return nil, errors.New("mainBlock cannot be nil")
+	}
+	if mainBlock.ShardId != types.MainShardId {
+		return nil, fmt.Errorf("mainBlock is not from main shard: %d", mainBlock.ShardId)
+	}
+	if mainBlock.Number == 0 || mainBlock.ParentHash.Empty() {
+		return nil, nil
+	}
+	return &MainBlockRef{
+		Number: mainBlock.Number - 1,
+		Hash:   mainBlock.ParentHash,
+	}, nil
+}
+
 type BlockId struct {
 	ShardId types.ShardId
 	Hash    common.Hash
@@ -108,6 +124,10 @@ func NewBlockId(shardId types.ShardId, hash common.Hash) BlockId {
 
 func IdFromBlock(block *jsonrpc.RPCBlock) BlockId {
 	return BlockId{block.ShardId, block.Hash}
+}
+
+func ParentBlockId(block *jsonrpc.RPCBlock) BlockId {
+	return BlockId{block.ShardId, block.ParentHash}
 }
 
 func ChildBlockIds(mainShardBlock *jsonrpc.RPCBlock) ([]BlockId, error) {

--- a/nil/services/synccommittee/internal/types/errors.go
+++ b/nil/services/synccommittee/internal/types/errors.go
@@ -9,6 +9,7 @@ import (
 )
 
 var (
+	ErrBlockNotFound   = errors.New("block with the specified id is not found")
 	ErrBlockMismatch   = errors.New("block mismatch")
 	ErrBlockProcessing = errors.New("block processing error")
 )


### PR DESCRIPTION
### Sync Committee: Block Storage Reset

As part of the Soft State Reset logic, introduced several changes to the `BlockStorage` type:

* Implemented `BlockStorage.ResetProgress(hash)` method, which performs a state reset starting from the given main block hash (including stored exec shard blocks and the latest fetched refs);

* Added new tests: `Test_ResetProgress_Block_Does_Not_Exists()` and `Test_ResetProgress()` with multiple test cases for block reset logic;

* BlockStorage.getBlockEntry(id) method now accepts an additional `required bool` parameter and returns `scTypes.ErrBlockNotFound` error if the required block is not found;

* Added `scTypes.ErrBlockNotFound` to the list of errors ignored by `badgerRetryRunner`;


#### Blocks reset will be triggered by `taskStateChangeHandler` in a follow-up PR