### PR TITLE
[execution] use deterministic time

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,6 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/NilFoundation/badger/v4 v4.0.0-20250130131510-9e58fda915b8 h1:VEswMEp8ifAKT+zpG8GZL4Vr73z4x14Djot/samBt5o=
 github.com/NilFoundation/badger/v4 v4.0.0-20250130131510-9e58fda915b8/go.mod h1:q2blcADYfBlwNmD/GTsBu6pmahdPPPDbfFDKfi+a7JY=
-github.com/NilFoundation/fastssz v0.1.5-0.20241127134502-50c6ef93352f h1:VMmSwezF1VSL0TSe7MBkBhL5cx8gjpwe3iD4Ymsn1Ig=
-github.com/NilFoundation/fastssz v0.1.5-0.20241127134502-50c6ef93352f/go.mod h1:ICVhD5I5Y8/nM5alj6F0YCgp5W6h/E0eNz5djSsq114=
 github.com/NilFoundation/fastssz v0.1.5-0.20250218121538-03800b866858 h1:BbR6F2igm2Q2ymzGVU83O2S74y04/1sP7qQDg63uT/8=
 github.com/NilFoundation/fastssz v0.1.5-0.20250218121538-03800b866858/go.mod h1:ICVhD5I5Y8/nM5alj6F0YCgp5W6h/E0eNz5djSsq114=
 github.com/VictoriaMetrics/fastcache v1.12.2 h1:N0y9ASrJ0F6h0QaC3o6uJb3NIZ9VKLjCM7NQbSmF7WI=

--- a/nil/contracts/solidity/tests/Test.sol
+++ b/nil/contracts/solidity/tests/Test.sol
@@ -9,6 +9,7 @@ contract Test is NilBase {
     event testEvent(uint indexed a, uint indexed b);
 
     uint32 private internalValue = 0;
+    uint256 private timestamp = 0;
 
     constructor() payable {}
 
@@ -125,6 +126,10 @@ contract Test is NilBase {
     }
 
     function bounce(string calldata err) external payable {}
+
+    function saveTime() public {
+        timestamp = block.timestamp;
+    }
 
     // Add output transaction, and then revert if `value` is zero. In that case output transaction should be removed.
     function testFailedAsyncCall(address dst, int32 value) public onlyExternal {

--- a/nil/internal/execution/state.go
+++ b/nil/internal/execution/state.go
@@ -10,7 +10,6 @@ import (
 	"math"
 	"math/big"
 	"sort"
-	"time"
 
 	"github.com/NilFoundation/nil/nil/common"
 	"github.com/NilFoundation/nil/nil/common/assert"
@@ -213,9 +212,13 @@ func NewEVMBlockContext(es *ExecutionState) (*vm.BlockContext, error) {
 
 	currentBlockId := uint64(0)
 	var header *types.Block
+	time := uint64(0)
 	if err == nil {
 		header = data.Block()
 		currentBlockId = header.Id.Uint64() + 1
+		// TODO: we need to use header.Timestamp instead of but it's always zero for now.
+		// Let's return some kind of logical timestamp (monotonic increasing block number).
+		time = header.Id.Uint64()
 	}
 	return &vm.BlockContext{
 		GetHash:     getHashFn(es, header),
@@ -223,7 +226,7 @@ func NewEVMBlockContext(es *ExecutionState) (*vm.BlockContext, error) {
 		Random:      &common.EmptyHash,
 		BaseFee:     big.NewInt(10),
 		BlobBaseFee: big.NewInt(10),
-		Time:        uint64(time.Now().Second()),
+		Time:        time,
 	}, nil
 }
 

--- a/nil/tests/common.go
+++ b/nil/tests/common.go
@@ -154,6 +154,23 @@ func AbiPack(t *testing.T, abi *abi.ABI, name string, args ...any) []byte {
 	return data
 }
 
+func SendTransactionViaSmartAccount(t *testing.T, client client.Client, addrFrom types.Address, addrTo types.Address, key *ecdsa.PrivateKey,
+	calldata []byte,
+) *jsonrpc.RPCReceipt {
+	t.Helper()
+
+	txHash, err := client.SendTransactionViaSmartAccount(t.Context(), addrFrom, calldata, types.NewFeePackFromGas(1_000_000), types.NewZeroValue(),
+		[]types.TokenBalance{}, addrTo, key)
+	require.NoError(t, err)
+
+	receipt := WaitIncludedInMain(t, t.Context(), client, txHash)
+	require.True(t, receipt.Success)
+	require.Equal(t, "Success", receipt.Status)
+	require.Len(t, receipt.OutReceipts, 1)
+
+	return receipt
+}
+
 func SendExternalTransactionNoCheck(t *testing.T, ctx context.Context, client client.Client, bytecode types.Code, contractAddress types.Address) *jsonrpc.RPCReceipt {
 	t.Helper()
 

--- a/nil/tests/regression/regression_test.go
+++ b/nil/tests/regression/regression_test.go
@@ -59,6 +59,8 @@ func (s *SuiteRegression) SetupTest() {
 		RunMode:   nilservice.CollatorsOnlyRunMode,
 		ZeroState: zeroStateConfig,
 	})
+	tests.WaitShardTick(s.T(), s.Context, s.Client, types.MainShardId)
+	tests.WaitShardTick(s.T(), s.Context, s.Client, types.BaseShardId)
 }
 
 func (s *SuiteRegression) TearDownTest() {

--- a/nil/tests/rpc_suite.go
+++ b/nil/tests/rpc_suite.go
@@ -184,17 +184,7 @@ func (s *RpcSuite) SendTransactionViaSmartAccount(addrFrom types.Address, addrTo
 	calldata []byte,
 ) *jsonrpc.RPCReceipt {
 	s.T().Helper()
-
-	txHash, err := s.Client.SendTransactionViaSmartAccount(s.Context, addrFrom, calldata, types.NewFeePackFromGas(1_000_000), types.NewZeroValue(),
-		[]types.TokenBalance{}, addrTo, key)
-	s.Require().NoError(err)
-
-	receipt := s.WaitIncludedInMain(txHash)
-	s.Require().True(receipt.Success)
-	s.Require().Equal("Success", receipt.Status)
-	s.Require().Len(receipt.OutReceipts, 1)
-
-	return receipt
+	return SendTransactionViaSmartAccount(s.T(), s.Client, addrFrom, addrTo, key, calldata)
 }
 
 func (s *RpcSuite) SendExternalTransaction(bytecode types.Code, contractAddress types.Address) *jsonrpc.RPCReceipt {

--- a/smart-contracts/contracts/Faucet.sol
+++ b/smart-contracts/contracts/Faucet.sol
@@ -6,7 +6,7 @@ import "./SmartAccount.sol";
 
 contract Faucet {
     uint256 private constant WITHDRAW_PER_TIMEOUT_LIMIT = 10**16;
-    uint256 private constant TIMEOUT = 1000; // 900s == 15min
+    uint256 private constant TIMEOUT = 200; // 200 blocks
 
     struct LimitInfo {
         uint prevT;


### PR DESCRIPTION
We had problems with consensus. That's because the same EVM input produced different output that led to hash mismatch error. It was pretty hard to debug this issue. It broke consensus on load gen tests because uniswap sometimes operates with a time.

This patch removes using of `time.Now()` that breaks an idea of repeatable blockchain history.

Our block.Timestamp is always zero. So I suggest to use block.Id as a logical time. It also monotonically increases.