### PR TITLE
[docs] miscellaneous fixes

### DIFF
--- a/docs/nil/hardhat/getting-started.mdx
+++ b/docs/nil/hardhat/getting-started.mdx
@@ -12,7 +12,7 @@ Clone the repo:
 git clone https://github.com/NilFoundation/nil.git
 ```
 
-Build deps which configured in repo npm workspaces settings
+Build all dependencies for the NPM workspaces in the repo:
 
 ```bash
 cd ./nil

--- a/docs/nil/nild.mdx
+++ b/docs/nil/nild.mdx
@@ -15,6 +15,8 @@ Cometa and faucet are provided by separate daemons in a production setting.
 
 ## Generating `nild`
 
+First, [**install Nix**](./prerequisites.mdx#dependencies).
+
 To create the `nild` binary:
 
 ```
@@ -47,7 +49,7 @@ If an incompatible old database is found in the specified `db-path`, `nild` will
 ## Complete devnet with 2 validators, an archive node and an RPC node
 
 To start a devnet with multiple validators, said validators need to be assigned with identities. This process involves generating cryptographic keys and bootstrap the network by informing validators
-about each other. This can be achieved using the devnet generator, available through the `nild devnet` subcommand.
+about each other.
 
 Write the devnet spec as a YAML file:
 
@@ -84,10 +86,10 @@ $ nild gen-configs myDevnet.yaml --basedir myDevnet/var
 The configuration files will be created in `myDevnet/conf`. Start the services by running:
 
 ```bash
-$ nild run --config myDevnet/conf/nil-0  # start first validator
-$ nild run --config myDevnet/conf/nil-1  # start second validator
-$ nild archive --config myDevnet/conf/nil-archive-0  # start archive node
-$ nild rpc --config myDevnet/conf/nil-rpc-0  # start RPC node
+$ nild run --config myDevnet/conf/nil-0/nild.yaml  # start first validator
+$ nild run --config myDevnet/conf/nil-1/nild.yaml  # start second validator
+$ nild archive --config myDevnet/conf/nil-archive-0/nild.yaml  # start archive node
+$ nild rpc --config myDevnet/conf/nil-rpc-0/nild.yaml  # start RPC node
 ```
 
 This setup does not launch the faucet service or the Cometa service. They have to be configured

--- a/docs/nil/niljs/tokens.mdx
+++ b/docs/nil/niljs/tokens.mdx
@@ -1,5 +1,13 @@
 # `Nil.js`: working with tokens
 
+:::tip[Specifying values]
+
+When specifying values for minting, sending or burning tokens, use exact numbers with no decimals.
+
+For example, when sending 50 million tokens, specify their amount as `50_000_000n`.
+
+:::
+
 ## Basic example
 
 To create a new token and withdraw it:
@@ -64,5 +72,7 @@ await faucetClient.topUpAndWaitUntilCompletion({
   smartAccountAddress: SMART_ACCOUNT_ADDRESS,
   faucetAddress: FAUCET_ADDRESS,
   amount: AMOUNT,
-});
+  },
+  client
+); 
 ```

--- a/docs/nil/smart-contracts/tokens.mdx
+++ b/docs/nil/smart-contracts/tokens.mdx
@@ -2,6 +2,8 @@ import PGButton from '@theme/PGButton';
 
 # `smart-contracts`: working with tokens
 
+## Overview
+
 The `NilTokenBase.sol` contract allows for creating new custom tokens to be deployed on =nil;
 
 To do so, simply inherit a new smart contract from `NilTokenBase.sol` and deploy it. 
@@ -12,7 +14,16 @@ import "@nilfoundation/smart-contracts/contracts/NilTokenBase.sol";
 contract NewToken is NilTokenBase {}
 ```
 
-`NilTokenBase.sol` provides internal methods for burning, minting and sending tokens, as well as [**`onlyExternal` wrappers**](./func-modifiers.mdx) over these methods. 
+`NilTokenBase.sol` provides internal methods for burning, minting and sending tokens, as well as [**`onlyExternal` wrappers**](./func-modifiers.mdx) over these methods.
+
+## FT example
+
+It is possible to implement a simple fungible token contract by inheriting from `NilTokenBase.sol`:
+
+```solidity showLineNumbers file=../../tests/FT.sol start=startContract end=endContract
+```
+
+## NFT example
 
 Here is a basic implementation of an NFT contract inheriting from `NilTokenBase.sol`:
 

--- a/docs/sidebar-nil.js
+++ b/docs/sidebar-nil.js
@@ -168,11 +168,6 @@ export default {
         },
         {
           type: "doc",
-          label: "Reading and writing info",
-          id: "nilcli/reading-writing-info",
-        },
-        {
-          type: "doc",
           label: "Working with tokens",
           id: "nilcli/tokens",
         },
@@ -193,6 +188,11 @@ export default {
               id: "nilcli/calling-smart-contract",
             },
           ],
+        },
+        {
+          type: "doc",
+          label: "Error handling",
+          id: "nilcli/error-handling",
         },
       ],
     },

--- a/docs/tests/FT.sol
+++ b/docs/tests/FT.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+//startContract
+pragma solidity ^0.8.0;
+
+import "@nilfoundation/smart-contracts/contracts/Nil.sol";
+import "@nilfoundation/smart-contracts/contracts/NilTokenBase.sol";
+
+/**
+ * @title FT
+ * @author =nil; Foundation
+ * @notice The contract represents a simple fungible token.
+ */
+contract FT is NilTokenBase {
+    /**
+     * @notice A public 'wrapper' over mintTokenInternal().
+     */
+    function mintFT(uint256 amount) public {
+        mintTokenInternal(amount);
+    }
+
+    /**
+     * @notice The function sends the FT to the provided address.
+     * @param dst The address to which the FT must be sent.
+     */
+    function sendFT(address dst, uint256 amount) public {
+        uint currentBalance = getTokenTotalSupply();
+        require(amount <= currentBalance, "Insufficient balance");
+        Nil.Token[] memory ft = new Nil.Token[](1);
+        ft[0].id = getTokenId();
+        ft[0].amount = amount;
+        Nil.asyncCallWithTokens(
+            dst,
+            msg.sender,
+            msg.sender,
+            0,
+            Nil.FORWARD_REMAINING,
+            0,
+            ft,
+            ""
+        );
+    }
+
+    /**
+     *
+     * @notice The empty override ensures that the FT can only be minted via mintFT().
+     */
+    function mintToken(uint256 amount) public override onlyExternal {}
+}
+//endContract

--- a/docs/tests/compilationCommands.js
+++ b/docs/tests/compilationCommands.js
@@ -41,3 +41,5 @@ export const NFT_COMPILATION_COMMAND = `solc -o ./tests/NFT --abi --bin ./tests/
 export const AUCTION_COMPILATION_COMMAND = `solc -o ./tests/EnglishAuction --abi --bin ./tests/EnglishAuction.sol --overwrite ${NODE_MODULES}`;
 
 export const CLONE_FACTORY_COMPILATION_COMMAND = `solc -o ./tests/CloneFactory --abi --bin ./tests/CloneFactory.sol --overwrite ${NODE_MODULES}`;
+
+export const FT_COMPILATION_COMMAND = `solc -o ./tests/FT --abi --bin ./tests/FT.sol --overwrite ${NODE_MODULES}`;

--- a/docs/tests/multi-tokens-support.test.mjs
+++ b/docs/tests/multi-tokens-support.test.mjs
@@ -7,6 +7,8 @@ import {
   waitTillCompleted,
 } from "@nilfoundation/niljs";
 
+import { FT_COMPILATION_COMMAND } from "./compilationCommands";
+
 import TestHelper from "./TestHelper";
 
 import { CREATED_TOKEN_PATTERN, SMART_ACCOUNT_ADDRESS_PATTERN, TOKEN_PATTERN } from "./patterns";
@@ -43,6 +45,13 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await exec(`rm -rf ${CONFIG_FILE_NAME}`);
+});
+
+describe.sequential("FT contract tests", () => {
+  test.sequential("The FT contract is compiled", async () => {
+    const { stdout, stderr } = await exec(FT_COMPILATION_COMMAND);
+    expect(stdout).toBeDefined();
+  });
 });
 
 describe.skip.sequential("initial usage CLI tests", () => {

--- a/docs/tests/working-with-smart-contracts-niljs.test.mjs
+++ b/docs/tests/working-with-smart-contracts-niljs.test.mjs
@@ -260,7 +260,7 @@ describe.sequential("Nil.js deployment tests", async () => {
         decodeFunctionResult({
           abi: MANUFACTURER_ABI,
           functionName: "getProducts",
-          data: resultsCall,
+          data: resultsCall.data,
         }),
       );
       //endRetailerRetrievesTheResult

--- a/explorer_frontend/README.md
+++ b/explorer_frontend/README.md
@@ -25,7 +25,7 @@ cd ./nil/explorer_frontend
 Install dependencies:
 
 ```bash
-npm штыефдд
+npm install
 ```
 
 ## Development


### PR DESCRIPTION
This diff closes several minor GitHub issues and addresses comments received in other channels.

* Closes #351 by amending links to config files when running `nild`
* Closes #291 by adding a simple FT example to docs
* Improves the description of `npm run build` in the Hardhat tutorial
* Adjusts Nil.js snippets in several tutorial
* Fixes =nil; CLI sidebar by removing the duplicate section and restoring 'Error handling' 