### PR TITLE
[network] add custom prefix to network protocols

### DIFF
--- a/nil/internal/collate/block_listener.go
+++ b/nil/internal/collate/block_listener.go
@@ -20,11 +20,11 @@ import (
 const requestTimeout = 10 * time.Second
 
 func topicShardBlocks(shardId types.ShardId) string {
-	return fmt.Sprintf("nil/shard/%s/blocks", shardId)
+	return fmt.Sprintf("/shard/%s/blocks", shardId)
 }
 
 func protocolShardBlock(shardId types.ShardId) network.ProtocolID {
-	return network.ProtocolID(fmt.Sprintf("/nil/shard/%s/block", shardId))
+	return network.ProtocolID(fmt.Sprintf("/shard/%s/block", shardId))
 }
 
 // ListPeers returns a list of peers that may support block exchange protocol.

--- a/nil/internal/network/config.go
+++ b/nil/internal/network/config.go
@@ -10,6 +10,7 @@ type PeerID = peer.ID
 type Config struct {
 	PrivateKey PrivateKey `yaml:"-"`
 
+	Prefix      string `yaml:"prefix,omitempty"`
 	IPV4Address string `yaml:"ipv4,omitempty"`
 	TcpPort     int    `yaml:"tcpPort,omitempty"`
 	QuicPort    int    `yaml:"quicPort,omitempty"`
@@ -22,6 +23,7 @@ type Config struct {
 func NewDefaultConfig() *Config {
 	return &Config{
 		DHTMode: dht.ModeAutoServer,
+		Prefix:  "/nil",
 	}
 }
 

--- a/nil/internal/network/req_resp.go
+++ b/nil/internal/network/req_resp.go
@@ -43,6 +43,7 @@ func (m *Manager) NewStream(ctx context.Context, peerId PeerID, protocolId Proto
 	ctx, cancel := context.WithTimeout(ctx, streamOpenTimeout)
 	defer cancel()
 
+	protocolId = ProtocolID(m.withNetworkPrefix(string(protocolId)))
 	s, err := m.host.NewStream(ctx, peerId, protocolId)
 	if err != nil {
 		return nil, err
@@ -62,6 +63,7 @@ func (m *Manager) NewStream(ctx context.Context, peerId PeerID, protocolId Proto
 func (m *Manager) SetStreamHandler(ctx context.Context, protocolId ProtocolID, handler StreamHandler) {
 	m.logger.Debug().Msgf("Setting stream handler for protocol %s", protocolId)
 
+	protocolId = ProtocolID(m.withNetworkPrefix(string(protocolId)))
 	m.host.SetStreamHandler(protocolId, func(stream Stream) {
 		defer stream.Close()
 

--- a/nil/internal/network/testaide.go
+++ b/nil/internal/network/testaide.go
@@ -102,6 +102,7 @@ func GenerateConfig(t *testing.T, port int) (*Config, AddrInfo) {
 		PrivateKey: key,
 		TcpPort:    port,
 		DHTEnabled: true,
+		Prefix:     t.Name(),
 	}, AddrInfo(*address)
 }
 

--- a/nil/services/txnpool/txn_exchange.go
+++ b/nil/services/txnpool/txn_exchange.go
@@ -9,7 +9,7 @@ import (
 )
 
 func topicPendingTransactions(shardId types.ShardId) string {
-	return fmt.Sprintf("nil/shard/%s/pending-transactions", shardId)
+	return fmt.Sprintf("/shard/%s/pending-transactions", shardId)
 }
 
 func PublishPendingTransaction(ctx context.Context, networkManager *network.Manager, shardId types.ShardId, txn *metaTxn) error {


### PR DESCRIPTION
Seems we have a conflict for archive node test. Exact reason why messages signed by different validators are accepted is a seprate task. But to make test more stable let's add custom prefix to our network protocols.

By default it's `/nil`.