### PR TITLE
Fix playground deploy button position in modal

### DIFF
--- a/explorer_frontend/src/features/contracts/components/Deploy/DeployContractModal.tsx
+++ b/explorer_frontend/src/features/contracts/components/Deploy/DeployContractModal.tsx
@@ -29,13 +29,13 @@ export const DeployContractModal: FC<DeployContractModalProps> = ({ onClose, isO
     deploySmartContractFx.pending,
     importSmartContractFx.pending,
   ]);
-  const tabsDisabled = deployPending || importExistingPending;
+  const disabled = deployPending || importExistingPending;
 
   return (
     <Modal
-      autoFocus={false}
       isOpen={isOpen}
       onClose={onClose}
+      closeable={!disabled}
       size="min(770px, 80vw)"
       overrides={{
         Dialog: {
@@ -49,10 +49,10 @@ export const DeployContractModal: FC<DeployContractModalProps> = ({ onClose, isO
       <ModalHeader>
         <LabelLarge>{name}</LabelLarge>
       </ModalHeader>
-
       <div
         style={{
           overflow: "auto",
+          overscrollBehavior: "contain",
           height: "462px",
           paddingRight: "24px",
           paddingLeft: "5px",
@@ -63,7 +63,8 @@ export const DeployContractModal: FC<DeployContractModalProps> = ({ onClose, isO
             activeKey={activeComponent}
             overrides={tabsOverrides}
             onChange={({ activeKey }) => setActiveComponent(activeKey as ActiveComponent)}
-            disabled={tabsDisabled}
+            disabled={disabled}
+            renderAll
           >
             <Tab
               title="Deploy"

--- a/explorer_frontend/src/features/contracts/components/Deploy/DeployTab.tsx
+++ b/explorer_frontend/src/features/contracts/components/Deploy/DeployTab.tsx
@@ -72,7 +72,6 @@ export const DeployTab = () => {
               paddingTop: "16px",
               borderTop: `1px solid ${COLORS.gray800}`,
               borderBottom: `1px solid ${COLORS.gray800}`,
-              maxHeight: "30vh",
               marginBottom: "24px",
             })}
           >


### PR DESCRIPTION
This diff fixes #377 by adjusting height of the container.
In addition, it makes deploy modal non-closable when deploy or import of a contract is pending to provide smoother ux.