### PR TITLE
Sync Committee: Parent-child batch linking

### DIFF
--- a/nil/common/concurrent/suspendable_test.go
+++ b/nil/common/concurrent/suspendable_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	testTimeout        = 5 * time.Second
+	testTimeout        = 10 * time.Second
 	testActionInterval = 10 * time.Millisecond
 )
 

--- a/nil/services/synccommittee/core/aggregator.go
+++ b/nil/services/synccommittee/core/aggregator.go
@@ -36,6 +36,7 @@ type AggregatorTaskStorage interface {
 type AggregatorBlockStorage interface {
 	TryGetLatestFetched(ctx context.Context) (*types.MainBlockRef, error)
 	TryGetProvedStateRoot(ctx context.Context) (*common.Hash, error)
+	TryGetLatestBatchId(ctx context.Context) (*types.BatchId, error)
 	SetBlockBatch(ctx context.Context, batch *types.BlockBatch) error
 }
 
@@ -296,7 +297,12 @@ func (agg *aggregator) createBlockBatch(ctx context.Context, mainShardBlock *jso
 		childBlocks = append(childBlocks, childBlock)
 	}
 
-	return types.NewBlockBatch(mainShardBlock, childBlocks)
+	latestBatchId, err := agg.blockStorage.TryGetLatestBatchId(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error reading latest batch id: %w", err)
+	}
+
+	return types.NewBlockBatch(latestBatchId, mainShardBlock, childBlocks)
 }
 
 // handleBlockBatch checks the validity of a block and stores it if valid.

--- a/nil/services/synccommittee/core/block_batch_test.go
+++ b/nil/services/synccommittee/core/block_batch_test.go
@@ -100,7 +100,8 @@ func (s *BlockBatchTestSuite) TestNewBlockBatch() {
 
 	for _, testCase := range testCases {
 		s.Run(testCase.name, func() {
-			batch, err := types.NewBlockBatch(testCase.mainShardBlock, testCase.childBlocks)
+			parentBatchId := types.NewBatchId()
+			batch, err := types.NewBlockBatch(&parentBatchId, testCase.mainShardBlock, testCase.childBlocks)
 			testCase.errPredicate(err)
 
 			if err != nil {

--- a/nil/services/synccommittee/internal/testaide/blocks.go
+++ b/nil/services/synccommittee/internal/testaide/blocks.go
@@ -75,9 +75,10 @@ func NewBatchesSequence(batchesCount int) []*scTypes.BlockBatch {
 			nextBatch.MainShardBlock.Number = 0
 			nextBatch.MainShardBlock.ParentHash = common.EmptyHash
 		} else {
-			prevMainBlock := batches[len(batches)-1].MainShardBlock
-			nextBatch.MainShardBlock.ParentHash = prevMainBlock.Hash
-			nextBatch.MainShardBlock.Number = prevMainBlock.Number + 1
+			prevBatch := batches[len(batches)-1]
+			nextBatch.MainShardBlock.ParentHash = prevBatch.MainShardBlock.Hash
+			nextBatch.MainShardBlock.Number = prevBatch.MainShardBlock.Number + 1
+			nextBatch.ParentId = &prevBatch.Id
 		}
 		batches = append(batches, nextBatch)
 	}
@@ -96,7 +97,7 @@ func NewBlockBatch(childBlocksCount int) *scTypes.BlockBatch {
 		mainBlock.ChildBlocks = append(mainBlock.ChildBlocks, block.Hash)
 	}
 
-	batch, err := scTypes.NewBlockBatch(mainBlock, childBlocks)
+	batch, err := scTypes.NewBlockBatch(nil, mainBlock, childBlocks)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
### Sync Committee: Parent-child batch linking

* Introduced parent-child links between block batches (`BlockBatch.ParentId` field). First batch generated by SyncCommittee is expected to have `nil` parent;

* Introduced functionality to track the latest batch ID in `BlockStorage` and link block batches through parent batch IDs;

Links between batches created by SC are required to restore batches sequence during task cancellation process