### PR TITLE
Remove generation from yaml

### DIFF
--- a/nil/cmd/nild/devnet.go
+++ b/nil/cmd/nild/devnet.go
@@ -18,6 +18,7 @@ import (
 	"github.com/NilFoundation/nil/nil/internal/network"
 	"github.com/NilFoundation/nil/nil/internal/telemetry"
 	"github.com/NilFoundation/nil/nil/services/nilservice"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
@@ -131,17 +132,19 @@ func (devnet devnet) generateZeroState(nShards uint32, servers []server) (*execu
 		}
 	}
 	mainKeyPath := devnet.spec.NildCredentialsDir + "/keys.yaml"
-	_, mainPublicKey, err := execution.LoadMainKeys(mainKeyPath)
+	mainPrivateKey, err := execution.LoadMainKeys(mainKeyPath)
+	mainPublicKey := crypto.CompressPubkey(&mainPrivateKey.PublicKey)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return nil, err
 	}
 	if err != nil {
 		var mainPrivateKey *ecdsa.PrivateKey
+
 		mainPrivateKey, mainPublicKey, err = nilcrypto.GenerateKeyPair()
 		if err != nil {
 			return nil, err
 		}
-		if err := execution.DumpMainKeys(mainKeyPath, mainPrivateKey, mainPublicKey); err != nil {
+		if err := execution.DumpMainKeys(mainKeyPath, mainPrivateKey); err != nil {
 			return nil, err
 		}
 	}

--- a/nil/internal/execution/execution_state_test.go
+++ b/nil/internal/execution/execution_state_test.go
@@ -644,17 +644,11 @@ func BenchmarkBlockGeneration(b *testing.B) {
 	address, err := contracts.CalculateAddress(contracts.NameCounter, 1, nil)
 	require.NoError(b, err)
 
-	zerostateCfg := fmt.Sprintf(`
-contracts:
-- name: Counter
-  address: %s
-  value: 10000000
-  contract: tests/Counter
-`, address.Hex())
-
-	zeroState, err := ParseZeroStateConfig(zerostateCfg)
-	require.NoError(b, err)
-	zeroState.MainPublicKey = MainPublicKey
+	zeroState := &ZeroStateConfig{
+		Contracts: []*ContractDescr{
+			{Name: "Counter", Contract: "tests/Counter", Address: address, Value: types.NewValueFromUint64(10000000)},
+		},
+	}
 
 	params := NewBlockGeneratorParams(1, 2)
 

--- a/nil/services/cliservice/block_format_test.go
+++ b/nil/services/cliservice/block_format_test.go
@@ -54,7 +54,7 @@ func TestDebugBlockToText(t *testing.T) {
 		From:      types.BytesToAddress(hexutil.FromHex("0x0100")),
 		RefundTo:  types.BytesToAddress(hexutil.FromHex("0x0300")),
 		BounceTo:  types.BytesToAddress(hexutil.FromHex("0x0400")),
-		Value:     types.NewValueFromUint64(0),
+		Value:     types.Value0,
 		Token:     nil,
 		Signature: []byte("Signature"),
 	}

--- a/nil/services/nil_load_generator/service.go
+++ b/nil/services/nil_load_generator/service.go
@@ -301,7 +301,7 @@ func Run(ctx context.Context, cfg Config, logger zerolog.Logger) error {
 		return err
 	}
 
-	mainPrivateKey, _, err := execution.LoadMainKeys(cfg.MainKeysPath)
+	mainPrivateKey, err := execution.LoadMainKeys(cfg.MainKeysPath)
 	if err != nil {
 		return err
 	}

--- a/nil/tests/config/config_test.go
+++ b/nil/tests/config/config_test.go
@@ -98,18 +98,17 @@ func (s *SuiteConfigParams) TestConfigReadWriteGasPrice() {
 		Contracts: []*execution.ContractDescr{
 			{
 				Name:     "TestConfig",
-				Address:  &s.testAddressMain,
+				Address:  s.testAddressMain,
 				Value:    types.GasToValue(10_000_000_000),
 				Contract: contracts.NameConfigTest,
 			},
 			{
 				Name:     "TestConfig",
-				Address:  &s.testAddress,
+				Address:  s.testAddress,
 				Value:    types.GasToValue(10_000_000_000),
 				Contract: contracts.NameConfigTest,
 			},
 		},
-		MainPublicKey: execution.MainPublicKey,
 	}
 
 	// Manually set gas price for all shards. It is necessary because the initial prices are set only during the first

--- a/nil/tests/modifiers/rpc_modifiers_test.go
+++ b/nil/tests/modifiers/rpc_modifiers_test.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"crypto/ecdsa"
-	"fmt"
 	"testing"
 
 	"github.com/NilFoundation/nil/nil/common/hexutil"
@@ -41,22 +40,12 @@ func (s *SuiteModifiersRpc) SetupSuite() {
 	s.abi, err = contracts.GetAbi(contracts.NameTransactionCheck)
 	s.Require().NoError(err)
 
-	zerostateYaml := fmt.Sprintf(`
-contracts:
-- name: SmartAccount
-  address: %s
-  value: 100000000000000000
-  contract: SmartAccount
-  ctorArgs: [%s]
-- name: TransactionCheck
-  address: %s
-  value: 100000000000000000
-  contract: tests/TransactionCheck
-`, s.smartAccountAddr.Hex(), hexutil.Encode(s.smartAccountPublicKey), s.testAddr)
-
-	zeroState, err := execution.ParseZeroStateConfig(zerostateYaml)
-	s.Require().NoError(err)
-	zeroState.MainPublicKey = execution.MainPublicKey
+	zeroState := &execution.ZeroStateConfig{
+		Contracts: []*execution.ContractDescr{
+			{Name: "SmartAccount", Contract: "SmartAccount", Address: s.smartAccountAddr, Value: types.NewValueFromUint64(100000000000000000), CtorArgs: []interface{}{hexutil.Encode(s.smartAccountPublicKey)}},
+			{Name: "TransactionCheck", Contract: "tests/TransactionCheck", Address: s.testAddr, Value: types.NewValueFromUint64(100000000000000000)},
+		},
+	}
 
 	s.Start(&nilservice.Config{
 		NShards:   4,

--- a/nil/tests/nil_load_generator_service/nil_load_generator_test.go
+++ b/nil/tests/nil_load_generator_service/nil_load_generator_test.go
@@ -37,7 +37,7 @@ func (s *NilLoadGeneratorRpc) SetupTest() {
 	time.Sleep(time.Second)
 
 	keyFile := s.T().TempDir() + "/key.yaml"
-	s.Require().NoError(execution.DumpMainKeys(keyFile, execution.MainPrivateKey, execution.MainPublicKey))
+	s.Require().NoError(execution.DumpMainKeys(keyFile, execution.MainPrivateKey))
 
 	s.runErrCh = make(chan error, 1)
 	s.Wg.Add(1)

--- a/nil/tests/sharded_suite.go
+++ b/nil/tests/sharded_suite.go
@@ -77,8 +77,7 @@ func newZeroState(oldZeroState *execution.ZeroStateConfig, validators []config.L
 				Validators: validators,
 			},
 		},
-		Contracts:     oldZeroState.Contracts,
-		MainPublicKey: oldZeroState.MainPublicKey,
+		Contracts: oldZeroState.Contracts,
 	}
 }
 


### PR DESCRIPTION
We don't need to set zeroStateConfig as Yaml string and later parse it to ZeroStateConfig structure. 