### PR TITLE
Fix explorer backend startup sql issue

### DIFF
--- a/explorer_backend/services/tutorials_db.ts
+++ b/explorer_backend/services/tutorials_db.ts
@@ -10,7 +10,7 @@ export interface Tutorial {
 db.exec(
   `
     CREATE TABLE IF NOT EXISTS TUTORIALS (
-      id AUTOINCREMENT PRIMARY KEY ,
+      id INTEGER PRIMARY KEY ,
       text TEXT,
       contracts TEXT,
       stage INTEGER UNIQUE

--- a/nix/nilexplorer.nix
+++ b/nix/nilexplorer.nix
@@ -64,6 +64,21 @@ stdenv.mkDerivation rec {
     echo "Checking explorer backend"
     (cd explorer_backend; npm run lint;)
 
+    echo "Checking if explorer backend starts up without errors"
+    cd explorer_backend
+    npm run start & NPM_PID=$!
+    sleep 7
+
+    if kill -0 $NPM_PID 2>/dev/null; then
+      echo "Explorer backend is running successfully"
+    else
+      echo "Explorer backend startup failed"
+      exit 1
+    fi
+
+    kill $NPM_PID
+    cd -
+
     echo "tests finished successfully"
   '';
 


### PR DESCRIPTION
This diff fixes explorer backend startup by removing `AUTOINCREMENT`, we can do it because SQLite automatically assigns a unique id (without needing `AUTOINCREMENT`).
In addition this patch adds a simple check that command `npm start` does not fail.