### PR TITLE
Temporary disable tutorials explorer backend generation

### DIFF
--- a/explorer_backend/start.ts
+++ b/explorer_backend/start.ts
@@ -39,7 +39,7 @@ app.use("/api", async (req, res) => {
     path: endpoint,
   });
 
-  await generateTutorials();
+  //await generateTutorials();
 });
 
 const start = async () => {


### PR DESCRIPTION
This diff temporary disables generation of tutorials in explorer backend. We need to fix some issue with it before running in production.