### PR TITLE
[collate] prevent "Transaction conflict" error because of syncer/consensus race

### DIFF
--- a/nil/internal/collate/proposer.go
+++ b/nil/internal/collate/proposer.go
@@ -29,7 +29,7 @@ const (
 )
 
 type proposer struct {
-	params Params
+	params *Params
 
 	topology ShardTopology
 	pool     TxnPool
@@ -44,7 +44,7 @@ type proposer struct {
 	l1BlockFetcher rollup.L1BlockFetcher
 }
 
-func newProposer(params Params, topology ShardTopology, pool TxnPool, logger zerolog.Logger) *proposer {
+func newProposer(params *Params, topology ShardTopology, pool TxnPool, logger zerolog.Logger) *proposer {
 	if params.MaxGasInBlock == 0 {
 		params.MaxGasInBlock = defaultMaxGasInBlock
 	}

--- a/nil/internal/collate/proposer_test.go
+++ b/nil/internal/collate/proposer_test.go
@@ -34,13 +34,13 @@ func (s *ProposerTestSuite) TearDownTest() {
 	s.db.Close()
 }
 
-func (s *ProposerTestSuite) newParams() Params {
-	return Params{
+func (s *ProposerTestSuite) newParams() *Params {
+	return &Params{
 		BlockGeneratorParams: execution.NewBlockGeneratorParams(s.shardId, 2),
 	}
 }
 
-func newTestProposer(params Params, pool TxnPool) *proposer {
+func newTestProposer(params *Params, pool TxnPool) *proposer {
 	return newProposer(params, new(TrivialShardTopology), pool, logging.NewLogger("proposer"))
 }
 

--- a/nil/internal/collate/validator.go
+++ b/nil/internal/collate/validator.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/NilFoundation/nil/nil/common"
 	"github.com/NilFoundation/nil/nil/common/check"
@@ -33,6 +34,7 @@ type Validator struct {
 	networkManager *network.Manager
 	blockVerifier  *signer.BlockVerifier
 
+	mutex  sync.Mutex
 	logger zerolog.Logger
 }
 
@@ -97,6 +99,9 @@ func (s *Validator) VerifyProposal(ctx context.Context, proposal *execution.Prop
 }
 
 func (s *Validator) InsertProposal(ctx context.Context, proposal *execution.Proposal, params *types.ConsensusParams) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
 	if err := s.validateProposal(ctx, proposal); err != nil {
 		return err
 	}
@@ -206,6 +211,9 @@ func (s *Validator) validateProposal(ctx context.Context, proposal *execution.Pr
 }
 
 func (s *Validator) ReplayBlock(ctx context.Context, block *types.BlockWithExtractedData) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
 	prevBlock, err := s.getBlock(ctx, block.Block.PrevBlock)
 	if err != nil {
 		return err

--- a/nil/internal/consensus/ibft/validators.go
+++ b/nil/internal/consensus/ibft/validators.go
@@ -33,11 +33,9 @@ func (i *backendIBFT) calcProposer(height, round uint64, prevValidator *uint64) 
 }
 
 type validatorsMap struct {
+	shardId  types.ShardId
 	txFabtic db.DB
-
-	shardId types.ShardId
-
-	m sync.Map
+	m        sync.Map
 }
 
 func newValidatorsMap(txFabric db.DB, shardId types.ShardId) *validatorsMap {

--- a/nil/internal/consensus/ibft/verifier.go
+++ b/nil/internal/consensus/ibft/verifier.go
@@ -7,8 +7,6 @@ import (
 	"github.com/NilFoundation/nil/nil/go-ibft/messages"
 	protoIBFT "github.com/NilFoundation/nil/nil/go-ibft/messages/proto"
 	"github.com/NilFoundation/nil/nil/internal/config"
-	"github.com/NilFoundation/nil/nil/internal/db"
-	"github.com/NilFoundation/nil/nil/internal/types"
 )
 
 func (i *backendIBFT) IsValidProposal(rawProposal []byte) bool {
@@ -74,13 +72,7 @@ func (i *backendIBFT) getPrevProposer(height uint64) *uint64 {
 		return nil
 	}
 
-	tx, err := i.db.CreateRoTx(i.ctx)
-	if err != nil {
-		return nil
-	}
-	defer tx.Rollback()
-
-	block, err := db.ReadBlockByNumber(tx, i.shardId, types.BlockNumber(height-1))
+	block, _, err := i.validator.GetLastBlock(i.ctx)
 	if err != nil {
 		return nil
 	}

--- a/nil/tests/sharded_suite.go
+++ b/nil/tests/sharded_suite.go
@@ -285,6 +285,8 @@ func (s *ShardedSuite) StartArchiveNode(params *ArchiveNodeConfig) (client.Clien
 		DisableConsensus: params.DisableConsensus,
 	}
 
+	PatchConfigWithTestDefaults(cfg)
+
 	cfg.MyShards = slices.Collect(common.Range(0, uint(cfg.NShards)))
 	netCfg.DHTBootstrapPeers = slices.Collect(common.Transform(slices.Values(s.Instances), getShardAddress))
 	if params.WithBootstrapPeers {


### PR DESCRIPTION
The main idea is to make validator as an entry point for proposal insertion.
We insert proposal in two cases: consensus and block replay.

Sometimes we had an error "Transaction conflict" caused by race between
that two modules. So it seems reasonable to add a lock here to
avoid confusing error messages and execution transaction two times.