### PR TITLE
[explorer] Refactoring for the future introduction of versioning

### DIFF
--- a/nil/cmd/exporter/internal/cfg.go
+++ b/nil/cmd/exporter/internal/cfg.go
@@ -9,6 +9,7 @@ import (
 type Cfg struct {
 	ExporterDriver ExportDriver
 	Client         client.Client
+	AllowDbDrop    bool
 	BlocksChan     chan *BlockWithShardId
 	exportRound    atomic.Uint32
 }

--- a/nil/cmd/exporter/internal/clickhouse/reflection.go
+++ b/nil/cmd/exporter/internal/clickhouse/reflection.go
@@ -159,14 +159,8 @@ func (s reflectedScheme) Fields() string {
 	return strings.Join(fields, ", ")
 }
 
-func (s reflectedScheme) CreateTableQuery(tableName, engine string, primaryKeys []string, orderKeys []string) string {
-	query := fmt.Sprintf(`
-		CREATE TABLE IF NOT EXISTS %s
-						(%s)
-		 ENGINE = %s
-		PRIMARY KEY (%s)
-		order by (%s)
-`, tableName, s.Fields(), engine, strings.Join(primaryKeys, ", "), strings.Join(orderKeys, ", "))
+func (s reflectedScheme) CreateTableQuery(tableName, engine string, primaryKeys, orderKeys []string) string {
+	query := createTableQuery(tableName, s.Fields(), engine, primaryKeys, orderKeys)
 	logger.Debug().Msgf("CreateTableQuery: %s", query)
 	return query
 }

--- a/nil/cmd/exporter/internal/clickhouse/scheme.go
+++ b/nil/cmd/exporter/internal/clickhouse/scheme.go
@@ -1,0 +1,89 @@
+package clickhouse
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/NilFoundation/nil/nil/common/check"
+)
+
+var tableSchemeCache map[string]reflectedScheme = nil
+
+func initSchemeCache() map[string]reflectedScheme {
+	tableScheme := make(map[string]reflectedScheme)
+
+	blockScheme, err := reflectSchemeToClickhouse(&BlockWithBinary{})
+	check.PanicIfErr(err)
+
+	tableScheme["blocks"] = blockScheme
+	transactionScheme, err := reflectSchemeToClickhouse(&TransactionWithBinary{})
+	check.PanicIfErr(err)
+
+	tableScheme["transactions"] = transactionScheme
+	logScheme, err := reflectSchemeToClickhouse(&LogWithBinary{})
+	check.PanicIfErr(err)
+
+	tableScheme["logs"] = logScheme
+
+	return tableScheme
+}
+
+func getTableScheme() map[string]reflectedScheme {
+	if tableSchemeCache == nil {
+		tableSchemeCache = initSchemeCache()
+	}
+
+	return tableSchemeCache
+}
+
+func setupScheme(ctx context.Context, conn driver.Conn, tableName string, keys []string) error {
+	tableScheme := getTableScheme()
+	scheme, ok := tableScheme[tableName]
+	if !ok {
+		return fmt.Errorf("scheme for %s not found", tableName)
+	}
+
+	if err := conn.Exec(ctx, scheme.CreateTableQuery(
+		tableName,
+		"ReplacingMergeTree",
+		keys,
+		keys,
+	)); err != nil {
+		return fmt.Errorf("failed to create table %s: %w", tableName, err)
+	}
+
+	return nil
+}
+
+func setupSchemes(ctx context.Context, conn driver.Conn) error {
+	if err := setupScheme(ctx, conn,
+		"blocks", []string{"shard_id", "hash"}); err != nil {
+		return err
+	}
+
+	if err := setupScheme(ctx, conn,
+		"transactions", []string{"hash", "outgoing"}); err != nil {
+		return err
+	}
+
+	if err := setupScheme(ctx, conn,
+		"logs", []string{"transaction_hash"}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func createTableQuery(tableName, fields, engine string, primaryKeys, orderKeys []string) string {
+	query := fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s
+		(%s)
+		ENGINE = %s
+		PRIMARY KEY (%s)
+		order by (%s)
+`, tableName, fields, engine, strings.Join(primaryKeys, ", "), strings.Join(orderKeys, ", "))
+	logger.Debug().Msgf("CreateTableQuery: %s", query)
+	return query
+}

--- a/nil/cmd/exporter/internal/export_driver.go
+++ b/nil/cmd/exporter/internal/export_driver.go
@@ -12,7 +12,7 @@ type BlockWithShardId struct {
 }
 
 type ExportDriver interface {
-	SetupScheme(context.Context) error
+	SetupScheme(ctx context.Context) error
 	ExportBlocks(context.Context, []*BlockWithShardId) error
 	FetchBlock(context.Context, types.ShardId, types.BlockNumber) (*types.Block, bool, error)
 	FetchLatestProcessedBlock(context.Context, types.ShardId) (*types.Block, bool, error)

--- a/nil/cmd/exporter/internal/exporter.go
+++ b/nil/cmd/exporter/internal/exporter.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/NilFoundation/nil/nil/common/concurrent"
@@ -13,21 +14,14 @@ import (
 const (
 	BlockBufferSize     = 10000
 	InitialRoundsAmount = 1000
-	LongSleepTimeout    = 3 * time.Second
 )
 
 func StartExporter(ctx context.Context, cfg *Cfg) error {
 	logger.Info().Msg("Starting exporter...")
 
-	var shards []types.ShardId
-	for {
-		var err error
-		shards, err = setupExporter(ctx, cfg)
-		if err == nil {
-			break
-		}
-		logger.Error().Err(err).Msgf("Failed to setup exporter. Retrying in %s...", LongSleepTimeout)
-		time.Sleep(LongSleepTimeout)
+	shards, err := setupExporter(ctx, cfg)
+	if err != nil {
+		return fmt.Errorf("failed to setup exporter: %w", err)
 	}
 
 	workers := make([]concurrent.Func, 0, 2*len(shards)+1)


### PR DESCRIPTION
1. Removed `only-scheme-init` option.
2. Added `allow-db-clear` option (not yet implemented).
3. Moved scheme related stuff to a new file.
4. Simplified boilerplate in scheme code.
5. Removed restarts of setup (the service is automatically restarted on failure anyway).

The new code (in an upcoming PR) will be wiping the database on version change.