### PR TITLE
[cleanup] Remove misleading func PubkeyBytesToAddress

### DIFF
--- a/nil/internal/types/address.go
+++ b/nil/internal/types/address.go
@@ -204,14 +204,6 @@ func (a *Address) Type() string {
 	return "Address"
 }
 
-func PubkeyBytesToAddress(shardId ShardId, pubBytes []byte) Address {
-	raw := make([]byte, ShardIdSize, AddrSize)
-	raw = setShardId(raw, shardId)
-	offset := common.HashSize - AddrSize + ShardIdSize
-	raw = append(raw, common.PoseidonHash(pubBytes).Bytes()[offset:]...)
-	return BytesToAddress(raw)
-}
-
 func createAddress(shardId ShardId, deployPayload []byte) Address {
 	raw := make([]byte, ShardIdSize, AddrSize)
 	raw = setShardId(raw, shardId)

--- a/nil/internal/types/address_test.go
+++ b/nil/internal/types/address_test.go
@@ -1,25 +1,12 @@
 package types
 
 import (
-	"encoding/hex"
 	"fmt"
 	"testing"
 
 	"github.com/NilFoundation/nil/nil/common"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
-
-func TestPubKeyAddressShardId(t *testing.T) {
-	t.Parallel()
-
-	shardId := ShardId(7)
-	pubkey, err := hex.DecodeString("0255d1e56a49f7115b913cbd23cd68c5f471375e74a53eabeb9ca81c64a464d19f")
-	require.NoError(t, err)
-
-	addr := PubkeyBytesToAddress(shardId, pubkey)
-	assert.Equal(t, shardId, addr.ShardId())
-}
 
 func TestCreateAddressShardId(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
That's not the way we calculate addresses, so this func is misleading.
Reported by Amir in a Slack thread.