### PR TITLE
Fixed a bug in Handling External Transactions example contract

### DIFF
--- a/explorer_frontend/src/features/code/assets/HandlingExtTxExample.sol
+++ b/explorer_frontend/src/features/code/assets/HandlingExtTxExample.sol
@@ -40,7 +40,7 @@ contract ExternallyAccessible is NilBase {
     }
 
     // dummy function which can only be called with an external transaction
-    function doSth(uint256 data) onlyExternal pure returns (bool) {
+    function doSth(uint256 data) onlyExternal public view returns (bool) {
         return data == 0;
     }
 }

--- a/explorer_frontend/src/features/contracts/init.ts
+++ b/explorer_frontend/src/features/contracts/init.ts
@@ -156,7 +156,7 @@ sample({
             break;
           }
           case input.type.slice(0, 5) === "bytes": {
-            value = input.name && input.name in args ? !!args[input.name] : "";
+            value = input.name && input.name in args ? args[input.name] : "";
             break;
           }
           case input.type.slice(0, 3) === "int": {


### PR DESCRIPTION
This PR fixes issue [392](https://github.com/NilFoundation/nil/issues/392). It changes the state mutability of a function in the contract which would throw compiling error otherwise. This PR also fixes a bug where bytes input types in constructor were incorrectly processed, leading to unexpected behaviour which is it would result in errors such as `t.replace` is not a function . Previously, the bytes case returned true instead of the actual input value due to improper type coercion.