### PR TITLE
Use eth_getShardIdList to get shards amount in playground

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,5 @@ node_modules
 
 /docs_ai_backend/.next
 /docs_interactive_tutorials_service/.next
+
+openrpc.json

--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ The current RPC is loosely modeled after the Ethereum RPC. The RPC exposes the f
 ### Shards
 
 * `GetShardIdList()`
+* `GetNumShards()`
 
 ### Calls
 

--- a/explorer_frontend/src/features/contracts/components/Deploy/ShardIdInput.tsx
+++ b/explorer_frontend/src/features/contracts/components/Deploy/ShardIdInput.tsx
@@ -11,8 +11,8 @@ import {
 import { useUnit } from "effector-react";
 import type { FC } from "react";
 import { useStyletron } from "styletron-react";
-import { $shardsAmount } from "../../../shards/models/model";
 import { $shardIdIsValid, decrementShardId, incrementShardId } from "../../models/base";
+import { $shardsAmount } from "../../models/shardsAmount";
 
 type ShardIdInputProps = {
   shardId: number | null;

--- a/explorer_frontend/src/features/contracts/init.ts
+++ b/explorer_frontend/src/features/contracts/init.ts
@@ -5,9 +5,8 @@ import { persist } from "effector-storage/local";
 import { debug } from "patronum";
 import type { App } from "../../types";
 import { $rpcUrl, $smartAccount } from "../account-connector/model";
-import { $solidityVersion, compileCodeFx } from "../code/model";
+import { $solidityVersion, compileCodeFx, loadedPlaygroundPage } from "../code/model";
 import { $cometaService } from "../cometa/model";
-import { $shardsAmount } from "../shards/models/model";
 import { getTokenAddressBySymbol } from "../tokens";
 import {
   $activeApp,
@@ -64,6 +63,7 @@ import {
   validateSmartContractAddressFx,
 } from "./models/base";
 import { exportApp, exportAppFx } from "./models/exportApp";
+import { $shardsAmount, getShardsAmountFx } from "./models/shardsAmount";
 
 compileCodeFx.doneData.watch(console.log);
 
@@ -650,4 +650,15 @@ sample({
   source: $activeAppWithState,
   filter: $activeAppWithState.map((app) => !!app && !app.address),
   target: triggerShardIdValidation,
+});
+
+sample({
+  clock: getShardsAmountFx.doneData,
+  target: $shardsAmount,
+});
+
+sample({
+  clock: merge([loadedPlaygroundPage, $rpcUrl.updates]),
+  target: getShardsAmountFx,
+  source: $rpcUrl,
 });

--- a/explorer_frontend/src/features/contracts/models/shardsAmount.ts
+++ b/explorer_frontend/src/features/contracts/models/shardsAmount.ts
@@ -1,0 +1,15 @@
+import { HttpTransport, PublicClient } from "@nilfoundation/niljs";
+import { createDomain } from "effector";
+
+export const shardsAmountDomain = createDomain("shardsAnount");
+
+export const $shardsAmount = shardsAmountDomain.createStore<number>(-1);
+export const getShardsAmountFx = shardsAmountDomain.createEffect<string, number>();
+
+getShardsAmountFx.use(async (rpcUrl) => {
+  const client = new PublicClient({
+    transport: new HttpTransport({ endpoint: rpcUrl }),
+  });
+
+  return (await client.getShardIdList()).length;
+});

--- a/explorer_frontend/src/features/shards/models/model.ts
+++ b/explorer_frontend/src/features/shards/models/model.ts
@@ -9,7 +9,6 @@ const createStore = explorerShardsList.createStore.bind(explorerShardsList);
 const createEffect = explorerShardsList.createEffect.bind(explorerShardsList);
 
 export const $shards = createStore<Shards>([]);
-export const $shardsAmount = $shards.map((shards) => shards.length - 1);
 
 export const fetchShardsFx = createEffect<void, Shards, Error>();
 

--- a/nil/client/client.go
+++ b/nil/client/client.go
@@ -49,6 +49,7 @@ type Client interface {
 	GetBlockTransactionCount(ctx context.Context, shardId types.ShardId, blockId any) (uint64, error)
 	GetBalance(ctx context.Context, address types.Address, blockId any) (types.Value, error)
 	GetShardIdList(ctx context.Context) ([]types.ShardId, error)
+	GetNumShards(ctx context.Context) (uint64, error)
 	GasPrice(ctx context.Context, shardId types.ShardId) (types.Value, error)
 	ChainId(ctx context.Context) (types.ChainId, error)
 

--- a/nil/client/direct_client.go
+++ b/nil/client/direct_client.go
@@ -202,6 +202,10 @@ func (c *DirectClient) GetShardIdList(ctx context.Context) ([]types.ShardId, err
 	return c.ethApi.GetShardIdList(ctx)
 }
 
+func (c *DirectClient) GetNumShards(ctx context.Context) (uint64, error) {
+	return c.ethApi.GetNumShards(ctx)
+}
+
 func (c *DirectClient) DeployContract(
 	ctx context.Context, shardId types.ShardId, smartAccountAddress types.Address, payload types.DeployPayload,
 	value types.Value, fee types.FeePack, pk *ecdsa.PrivateKey,

--- a/nil/client/rpc/client.go
+++ b/nil/client/rpc/client.go
@@ -73,6 +73,7 @@ const (
 	Eth_getBalance                       = "eth_getBalance"
 	Eth_getTokens                        = "eth_getTokens" //nolint:gosec
 	Eth_getShardIdList                   = "eth_getShardIdList"
+	Eth_getNumShards                     = "eth_getNumShards"
 	Eth_gasPrice                         = "eth_gasPrice"
 	Eth_chainId                          = "eth_chainId"
 	Debug_getBlockByHash                 = "debug_getBlockByHash"
@@ -665,6 +666,15 @@ func (c *Client) GetShardIdList(ctx context.Context) ([]types.ShardId, error) {
 		return []types.ShardId{}, err
 	}
 	return shardIdList, nil
+}
+
+func (c *Client) GetNumShards(ctx context.Context) (uint64, error) {
+	res, err := c.call(ctx, Eth_getNumShards)
+	if err != nil {
+		return 0, err
+	}
+
+	return toUint64(res)
 }
 
 func (c *Client) DeployContract(

--- a/nil/services/rpc/jsonrpc/doc.go
+++ b/nil/services/rpc/jsonrpc/doc.go
@@ -27,6 +27,7 @@ package jsonrpc
 // @component FilterChanges filterChanges array "The array of logs, block headers or pending transactions that have occurred since the last poll of the filter."
 // @component FilterLogs filterLogs array "The array of logs that have been recorded since the last poll of the filter."
 // @component ShardIds shardIds array "The array of shard IDs."
+// @component NumShards numShards integer "The number of shards."
 // @component GasShardId shardId integer "The ID of the shard whose gas price is requested."
 // @component BaseFee baseFee integer "The current base fee the given shard."
 // @component GasPrice gasPrice integer "The current gas price in the given shard."

--- a/nil/services/rpc/jsonrpc/eth_api.go
+++ b/nil/services/rpc/jsonrpc/eth_api.go
@@ -247,6 +247,15 @@ type EthAPIRo interface {
 	GetShardIdList(ctx context.Context) ([]types.ShardId, error)
 
 	/*
+		@name GetNumShards
+		@summary Returns the number of shards in the network.
+		@description
+		@tags [Shards]
+		@returns numShards NumShards
+	*/
+	GetNumShards(ctx context.Context) (uint64, error)
+
+	/*
 		@name Call
 		@summary Executes a new transaction call immediately without creating a transaction.
 		@description Implements eth_call.

--- a/nil/services/rpc/jsonrpc/eth_shards.go
+++ b/nil/services/rpc/jsonrpc/eth_shards.go
@@ -9,3 +9,7 @@ import (
 func (api *APIImplRo) GetShardIdList(ctx context.Context) ([]types.ShardId, error) {
 	return api.rawapi.GetShardIdList(ctx)
 }
+
+func (api *APIImplRo) GetNumShards(ctx context.Context) (uint64, error) {
+	return api.rawapi.GetNumShards(ctx)
+}

--- a/nil/services/rpc/rawapi/api.go
+++ b/nil/services/rpc/rawapi/api.go
@@ -33,6 +33,7 @@ type NodeApiRo interface {
 
 	GasPrice(ctx context.Context, shardId types.ShardId) (types.Value, error)
 	GetShardIdList(ctx context.Context) ([]types.ShardId, error)
+	GetNumShards(ctx context.Context) (uint64, error)
 }
 
 type NodeApi interface {
@@ -60,6 +61,7 @@ type ShardApiRo interface {
 
 	GasPrice(ctx context.Context) (types.Value, error)
 	GetShardIdList(ctx context.Context) ([]types.ShardId, error)
+	GetNumShards(ctx context.Context) (uint64, error)
 
 	setAsP2pRequestHandlersIfAllowed(ctx context.Context, networkManager *network.Manager, readonly bool, logger zerolog.Logger) error
 	setNodeApi(nodeApi NodeApi)

--- a/nil/services/rpc/rawapi/client.go
+++ b/nil/services/rpc/rawapi/client.go
@@ -167,6 +167,10 @@ func (api *ShardApiAccessor) GetShardIdList(ctx context.Context) ([]types.ShardI
 	return sendRequestAndGetResponseWithCallerMethodName[[]types.ShardId](ctx, api, "GetShardIdList")
 }
 
+func (api *ShardApiAccessor) GetNumShards(ctx context.Context) (uint64, error) {
+	return sendRequestAndGetResponseWithCallerMethodName[uint64](ctx, api, "GetNumShards")
+}
+
 func (api *ShardApiAccessor) GetTransactionCount(ctx context.Context, address types.Address, blockReference rawapitypes.BlockReference) (uint64, error) {
 	return sendRequestAndGetResponseWithCallerMethodName[uint64](ctx, api, "GetTransactionCount", address, blockReference)
 }

--- a/nil/services/rpc/rawapi/local_system.go
+++ b/nil/services/rpc/rawapi/local_system.go
@@ -49,3 +49,11 @@ func (api *LocalShardApi) GetShardIdList(ctx context.Context) ([]types.ShardId, 
 	treeShards.SetRootHash(block.ChildBlocksRootHash)
 	return treeShards.Keys()
 }
+
+func (api *LocalShardApi) GetNumShards(ctx context.Context) (uint64, error) {
+	shards, err := api.GetShardIdList(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return uint64(len(shards) + 1), nil
+}

--- a/nil/services/rpc/rawapi/node.go
+++ b/nil/services/rpc/rawapi/node.go
@@ -225,6 +225,20 @@ func (api *NodeApiOverShardApis) GetShardIdList(ctx context.Context) ([]types.Sh
 	return result, nil
 }
 
+func (api *NodeApiOverShardApis) GetNumShards(ctx context.Context) (uint64, error) {
+	methodName := methodNameChecked("GetNumShards")
+	shardId := types.MainShardId
+	shardApi, ok := api.Apis[shardId]
+	if !ok {
+		return 0, makeShardNotFoundError(methodName, shardId)
+	}
+	result, err := shardApi.GetNumShards(ctx)
+	if err != nil {
+		return 0, makeCallError(methodName, shardId, err)
+	}
+	return result, nil
+}
+
 func (api *NodeApiOverShardApis) GetTransactionCount(ctx context.Context, address types.Address, blockReference rawapitypes.BlockReference) (uint64, error) {
 	methodName := methodNameChecked("GetTransactionCount")
 	shardId := address.ShardId()

--- a/nil/services/rpc/rawapi/server.go
+++ b/nil/services/rpc/rawapi/server.go
@@ -34,6 +34,7 @@ type NetworkTransportProtocolRo interface {
 
 	GasPrice() pb.GasPriceResponse
 	GetShardIdList() pb.ShardIdListResponse
+	GetNumShards() pb.Uint64Response
 }
 
 // NetworkTransportProtocol is a helper interface for associating the argument and result types of Api methods

--- a/nil/tests/basic/basic_test.go
+++ b/nil/tests/basic/basic_test.go
@@ -88,6 +88,10 @@ func (s *SuiteRpc) TestRpcBasic() {
 	}
 	s.Require().Equal(shardIdListExp, shardIdListRes)
 
+	numShards, err := s.Client.GetNumShards(s.Context)
+	s.Require().NoError(err)
+	s.Require().Equal(uint64(s.ShardsNum), numShards)
+
 	gasPrice, err := s.Client.GasPrice(s.Context, types.BaseShardId)
 	s.Require().NoError(err)
 	s.Require().Equal(types.DefaultGasPrice, gasPrice)

--- a/niljs/src/clients/PublicClient.test.ts
+++ b/niljs/src/clients/PublicClient.test.ts
@@ -239,3 +239,43 @@ test("getTokens", async ({ expect }) => {
     params: [addHexPrefix(defaultAddress), "latest"],
   });
 });
+
+test("getShardIdList", async ({ expect }) => {
+  const fn = vi.fn();
+  fn.mockReturnValue([]);
+
+  const client = new PublicClient({
+    transport: new MockTransport(fn),
+    shardId: 1,
+  });
+
+  const shardIdList = await client.getShardIdList();
+
+  expect(shardIdList).toBeDefined();
+  expect(shardIdList).toBeInstanceOf(Array);
+  expect(fn).toHaveBeenCalledOnce();
+  expect(fn).toHaveBeenLastCalledWith({
+    method: "eth_getShardIdList",
+    params: [],
+  });
+});
+
+test("getNumShards", async ({ expect }) => {
+  const fn = vi.fn();
+  fn.mockReturnValue(1);
+
+  const client = new PublicClient({
+    transport: new MockTransport(fn),
+    shardId: 1,
+  });
+
+  const numShards = await client.getNumShards();
+
+  expect(numShards).toBeDefined();
+  expect(numShards).toBe(1);
+  expect(fn).toHaveBeenCalledOnce();
+  expect(fn).toHaveBeenLastCalledWith({
+    method: "eth_getNumShards",
+    params: [],
+  });
+});

--- a/niljs/src/clients/PublicClient.ts
+++ b/niljs/src/clients/PublicClient.ts
@@ -473,18 +473,46 @@ class PublicClient extends BaseClient {
 
     const params: unknown[] = [sendData, blockNumberOrHash];
 
-    const resStr = await this.request<{ feeCredit: Hex; averagePriorityFee: Hex; maxBaseFee: Hex }>(
-      {
-        method: "eth_estimateFee",
-        params,
-      },
-    );
+    const resStr = await this.request<{
+      feeCredit: Hex;
+      averagePriorityFee: Hex;
+      maxBaseFee: Hex;
+    }>({
+      method: "eth_estimateFee",
+      params,
+    });
 
     const res = {
       feeCredit: BigInt(resStr.feeCredit),
       averagePriorityFee: BigInt(resStr.averagePriorityFee),
       maxBaseFee: BigInt(resStr.maxBaseFee),
     };
+
+    return res;
+  }
+
+  /**
+   * Returns the list of shard IDs.
+   * @returns The list of shard IDs.
+   */
+  public async getShardIdList() {
+    const res = await this.request<number[]>({
+      method: "eth_getShardIdList",
+      params: [],
+    });
+
+    return res;
+  }
+
+  /**
+   * Returns the number of shards.
+   * @returns The number of shards.
+   */
+  public async getNumShards() {
+    const res = await this.request<number>({
+      method: "eth_getNumShards",
+      params: [],
+    });
 
     return res;
   }


### PR DESCRIPTION
This diff adds a new methods to `niljs` client  - `getShardIdList()` and `getNumShards()`. `getNumShards()` returns the amount if shards. We decided to migrate to usage of this rpc method in playground to decrease connectedness between playground and explorer backend.

In addition this diff implements `getNumShards()` on the side of rpc.

It adds `openrpc.json` to `.gitignore` because we don't want to commit auto-generated file accidentally.