### PR TITLE
Fix conversion of amount during top-up

### DIFF
--- a/explorer_frontend/src/features/account-connector/init.ts
+++ b/explorer_frontend/src/features/account-connector/init.ts
@@ -100,7 +100,7 @@ createSmartAccountFx.use(async ({ privateKey, rpcUrl }) => {
       {
         smartAccountAddress: smartAccount.address,
         faucetAddress: faucets.NIL,
-        amount: BigInt(1e18),
+        amount: convertEthToWei(0.1),
       },
       client,
     );
@@ -271,7 +271,7 @@ topupSmartAccountTokenFx.use(async ({ smartAccount, topupInput, faucets, rpcUrl 
     {
       smartAccountAddress: smartAccount.address,
       faucetAddress: tokenFaucetAddress,
-      amount: Number(amount),
+      amount: tokenFaucetAddress === faucets.NIL ? convertEthToWei(Number(amount)) : BigInt(amount),
     },
     publicClient,
   );


### PR DESCRIPTION
Currently, the conversion of amount for topping up is not parsed correctly, as NIL token and other tokens have different decimals. This PR fixes the conversion of the amount to bigint and number respectively for topping up of NIL and other tokens. 