### PR TITLE
[docs] removal of hardcoded tokens

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -63,13 +63,13 @@ file=path/to/test start=START_COMMENT end=END_COMMENT
 Before running tests, launch `nild`, `faucet` and `cometa`. Then:
 
 ```bash
-npm run test:useNilD
+npm run test
 ```
 
 To run an individual test:
 
 ```bash
-npm run test:useNilD path/to/test
+npm run test path/to/test
 ```
 
 ## License

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,7 +12,6 @@
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "test": "vitest",
-    "test:useNilD": "USE_NILD=true vitest",
     "generate-cli-docs": "npx tsx nil/scripts/cliRefGenerator.ts",
     "build": "npm run generate-cli-docs && docusaurus build",
     "lint": "biome check .",

--- a/docs/run_tests.sh
+++ b/docs/run_tests.sh
@@ -25,7 +25,7 @@ nild run --http-port 8529 --collator-tick-ms=100 >nild.log 2>&1 &
 NILD_PID=$!
 sleep 2
 
-if CI=true npm run test:useNilD; then
+if CI=true npm run test; then
     exit 0
 else
     STATUS=$?

--- a/docs/tests/globals.js
+++ b/docs/tests/globals.js
@@ -1,11 +1,5 @@
-export const RPC_GLOBAL = process.env.USE_NILD
-  ? "http://127.0.0.1:8529"
-  : "https://api.devnet.nil.foundation/api/nil_user/TEK83KSDZH58AIK9PCYSNU4G86DU55I9/";
-export const COMETA_GLOBAL = process.env.USE_NILD
-  ? "http://127.0.0.1:8529"
-  : "https://api.devnet.nil.foundation/api/nil_user/TEK83KSDZH58AIK9PCYSNU4G86DU55I9/";
-export const FAUCET_GLOBAL = process.env.USE_NILD
-  ? "http://127.0.0.1:8529"
-  : "https://api.devnet.nil.foundation/api/nil_user/TEK83KSDZH58AIK9PCYSNU4G86DU55I9/";
+export const RPC_GLOBAL = "http://127.0.0.1:8529";
+export const COMETA_GLOBAL = "http://127.0.0.1:8529";
+export const FAUCET_GLOBAL = "http://127.0.0.1:8529";
 export const NIL_GLOBAL = "nil";
 export const NODE_MODULES = "--include-path ../node_modules/ --base-path ../ ";


### PR DESCRIPTION
This diff removes hardcoded RPC URL from docs' tests. It was there previously when the repo was still closed but now it's been exposed to the public. 