### PR TITLE
remove docstutorialservice from nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -44,7 +44,6 @@
           uniswap = (pkgs.callPackage ./nix/uniswap.nix { });
           docsaibackend = (pkgs.callPackage ./nix/docsaibackend.nix { });
           l1-contracts = (pkgs.callPackage ./nix/l1-contracts.nix { });
-          docstutorialsservice = (pkgs.callPackage ./nix/docstutorialsservice.nix { });
         };
         checks = rec {
           nil = (pkgs.callPackage ./nix/nil.nix {


### PR DESCRIPTION
file `./nix/docstutorialsservice.nix` was removed in [this pr](https://github.com/NilFoundation/nil/pull/274)