### PR TITLE
Fix ethers.js v6 compatibility and logging cleanup

### DIFF
--- a/l1-contracts/create-wallet-with-funding.ts
+++ b/l1-contracts/create-wallet-with-funding.ts
@@ -53,7 +53,7 @@ async function createAndUseWallet() {
 
     // Step 4: Wait for the transaction to be mined
     const receipt = await tx.wait();
-    console.log("Transaction Mined:", receipt?.hash);
+    console.log("Transaction Mined:", receipt.hash);
 }
 
 createAndUseWallet().catch((error) => {

--- a/l1-contracts/deploy-nilchain.ts
+++ b/l1-contracts/deploy-nilchain.ts
@@ -22,7 +22,7 @@ async function main() {
 
   console.log("Wallet Connected to Provider.");
 
-  const valueInHex = ethers.toQuantity(ethers.parseEther("100"));
+  const valueInHex = ethers.hexlify(ethers.parseEther("100"));
   const walletAddress = process.env.WALLET_ADDRESS as string;
   console.log("Wallet Address:", walletAddress);
 


### PR DESCRIPTION
File: create-wallet-with-funding.ts

Old: console.log("Transaction Mined:", receipt?.hash);
To: console.log("Transaction Mined:", receipt.hash);
Reason: tx.wait() always returns a valid receipt with a hash, so optional chaining (?.) is unnecessary.

File: deploy-nilchain.ts

Old:const valueInHex = ethers.toQuantity(ethers.parseEther("100"));
To:const valueInHex = ethers.hexlify(ethers.parseEther("100"));
Reason: ethers.toQuantity() is deprecated in ethers.js v6. ethers.hexlify() is the correct alternative to ensure compatibility.