### PR TITLE
fixed missing semicolon in box-shadow styles.module.css

### DIFF
--- a/docs/src/components/FloatingAiButton/styles.module.css
+++ b/docs/src/components/FloatingAiButton/styles.module.css
@@ -30,7 +30,7 @@
 [data-theme="dark"] .floatingAiButton {
   background-color: #F1F1f1;
   color: #000;
-  box-shadow: 0 2px 6px rgba(205, 205, 205, 0.3)
+  box-shadow: 0 2px 6px rgba(205, 205, 205, 0.3);
 }
 
 .closeModalButton {


### PR DESCRIPTION
Added a semicolon after the box-shadow property to properly finalize the CSS rule