### PR TITLE
[optimization] Reduce block and txn hashing via reuse

### DIFF
--- a/nil/internal/collate/scheduler.go
+++ b/nil/internal/collate/scheduler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/NilFoundation/nil/nil/common"
 	"github.com/NilFoundation/nil/nil/common/logging"
 	"github.com/NilFoundation/nil/nil/internal/db"
 	"github.com/NilFoundation/nil/nil/internal/execution"
@@ -15,8 +16,8 @@ import (
 )
 
 type TxnPool interface {
-	Peek(ctx context.Context, n int) ([]*types.Transaction, error)
-	Discard(ctx context.Context, txns []*types.Transaction, reason txnpool.DiscardReason) error
+	Peek(ctx context.Context, n int) ([]*types.TxnWithHash, error)
+	Discard(ctx context.Context, txns []common.Hash, reason txnpool.DiscardReason) error
 	OnCommitted(ctx context.Context, committed []*types.Transaction) error
 }
 

--- a/nil/internal/collate/testaide.go
+++ b/nil/internal/collate/testaide.go
@@ -4,34 +4,38 @@ package collate
 
 import (
 	"context"
+	"slices"
 
+	"github.com/NilFoundation/nil/nil/common"
 	"github.com/NilFoundation/nil/nil/internal/types"
 	"github.com/NilFoundation/nil/nil/services/txnpool"
 )
 
 type MockTxnPool struct {
-	Txns []*types.Transaction
+	Txns     []*types.Transaction
+	MetaTxns []*types.TxnWithHash
 
-	LastDiscarded []*types.Transaction
+	LastDiscarded []common.Hash
 	LastReason    txnpool.DiscardReason
 }
 
 var _ TxnPool = (*MockTxnPool)(nil)
 
 func (m *MockTxnPool) Reset() {
-	m.Txns = nil
+	m.Txns = m.Txns[:0]
+	m.MetaTxns = m.MetaTxns[:0]
 	m.LastDiscarded = nil
 	m.LastReason = 0
 }
 
-func (m *MockTxnPool) Peek(_ context.Context, n int) ([]*types.Transaction, error) {
+func (m *MockTxnPool) Peek(_ context.Context, n int) ([]*types.TxnWithHash, error) {
 	if n > len(m.Txns) {
-		return m.Txns, nil
+		return m.MetaTxns, nil
 	}
-	return m.Txns[:n], nil
+	return m.MetaTxns[:n], nil
 }
 
-func (m *MockTxnPool) Discard(_ context.Context, txns []*types.Transaction, reason txnpool.DiscardReason) error {
+func (m *MockTxnPool) Discard(_ context.Context, txns []common.Hash, reason txnpool.DiscardReason) error {
 	m.LastDiscarded = txns
 	m.LastReason = reason
 	return nil
@@ -39,4 +43,13 @@ func (m *MockTxnPool) Discard(_ context.Context, txns []*types.Transaction, reas
 
 func (m *MockTxnPool) OnCommitted(context.Context, []*types.Transaction) error {
 	return nil
+}
+
+func (m *MockTxnPool) Add(txns ...*types.Transaction) {
+	m.Txns = append(m.Txns, txns...)
+
+	m.MetaTxns = slices.Grow(m.MetaTxns, len(m.Txns))
+	for _, txn := range txns {
+		m.MetaTxns = append(m.MetaTxns, types.NewTxnWithHash(txn))
+	}
 }

--- a/nil/internal/types/transaction.go
+++ b/nil/internal/types/transaction.go
@@ -176,7 +176,8 @@ type Transaction struct {
 
 type OutboundTransaction struct {
 	*Transaction
-	ForwardKind ForwardKind `json:"forwardFee,omitempty" ch:"forward_kind"`
+	TxnHash     common.Hash `json:"txnHash" ch:"txn_hash"`
+	ForwardKind ForwardKind `json:"forwardKind,omitempty" ch:"forward_kind"`
 }
 
 type ExternalTransaction struct {
@@ -579,3 +580,19 @@ func (m TransactionFlags) IsResponse() bool {
 }
 
 //go:generate go run github.com/NilFoundation/fastssz/sszgen --path transaction.go -include ../../common/length.go,address.go,gas.go,value.go,code.go,shard.go,bloom.go,log.go,../../common/hash.go,signature.go,account.go,bitflags.go --objs Transaction,ExternalTransaction,InternalTransactionPayload,TransactionDigest,TransactionFlags,EvmState,AsyncContext,AsyncResponsePayload
+
+type TxnWithHash struct {
+	*Transaction
+	hash common.Hash
+}
+
+func NewTxnWithHash(txn *Transaction) *TxnWithHash {
+	return &TxnWithHash{
+		Transaction: txn,
+		hash:        txn.Hash(),
+	}
+}
+
+func (m *TxnWithHash) Hash() common.Hash {
+	return m.hash
+}

--- a/nil/services/rpc/jsonrpc/test_block.go
+++ b/nil/services/rpc/jsonrpc/test_block.go
@@ -31,7 +31,24 @@ func writeTestBlock(t *testing.T, tx db.RwTx, shardId types.ShardId, blockNumber
 	}
 	hash := block.Hash(types.BaseShardId)
 	require.NoError(t, db.WriteBlock(tx, types.BaseShardId, hash, &block))
-	return &execution.BlockGenerationResult{BlockHash: hash, Block: &block}
+
+	require.Equal(t, len(transactions), len(receipts))
+	inTxnHashes := make([]common.Hash, len(transactions))
+	for i, r := range receipts {
+		inTxnHashes[i] = r.TxnHash
+	}
+	outTxnHashes := make([]common.Hash, len(outTransactions))
+	for i, txn := range outTransactions {
+		outTxnHashes[i] = txn.Hash()
+	}
+	return &execution.BlockGenerationResult{
+		BlockHash:    hash,
+		Block:        &block,
+		InTxns:       transactions,
+		InTxnHashes:  inTxnHashes,
+		OutTxns:      outTransactions,
+		OutTxnHashes: outTxnHashes,
+	}
 }
 
 func writeTransactions(t *testing.T, tx db.RwTx, shardId types.ShardId, transactions []*types.Transaction) *execution.TransactionTrie {

--- a/nil/services/rpc/jsonrpc/types.go
+++ b/nil/services/rpc/jsonrpc/types.go
@@ -509,9 +509,10 @@ func toOutTransactions(input []*rpctypes.OutTransaction) ([]*OutTransaction, err
 			Transaction: &types.Transaction{},
 			ForwardKind: txn.ForwardKind,
 		}
-		if err := decoded.UnmarshalSSZ(txn.TransactionSSZ); err != nil {
+		if err := decoded.Transaction.UnmarshalSSZ(txn.TransactionSSZ); err != nil {
 			return nil, err
 		}
+		decoded.TxnHash = decoded.Transaction.Hash()
 
 		output[i] = &OutTransaction{
 			Transaction:     decoded,

--- a/nil/services/txnpool/queue.go
+++ b/nil/services/txnpool/queue.go
@@ -1,5 +1,7 @@
 package txnpool
 
+import "github.com/NilFoundation/nil/nil/internal/types"
+
 type TxnQueue struct {
 	data []*metaTxn
 }
@@ -23,7 +25,7 @@ func (q *TxnQueue) Size() int {
 	return len(q.data)
 }
 
-func (q *TxnQueue) Remove(txn *metaTxn) bool {
+func (q *TxnQueue) Remove(txn *types.TxnWithHash) bool {
 	for i, elem := range q.data {
 		if elem.Seqno == txn.Seqno && elem.From.Equal(txn.From) {
 			q.data = append(q.data[:i], q.data[i+1:]...)

--- a/nil/services/txnpool/tree.go
+++ b/nil/services/txnpool/tree.go
@@ -36,7 +36,7 @@ func sortBySeqnoLess(a, b *metaTxn) bool {
 func NewBySenderAndSeqno(logger zerolog.Logger) *ByReceiverAndSeqno {
 	return &ByReceiverAndSeqno{
 		tree:       btree.NewG(32, sortBySeqnoLess),
-		search:     &metaTxn{Transaction: &types.Transaction{}},
+		search:     &metaTxn{TxnWithHash: &types.TxnWithHash{Transaction: &types.Transaction{}}},
 		toTxnCount: map[types.Address]int{},
 		logger:     logger,
 	}
@@ -104,7 +104,7 @@ func (b *ByReceiverAndSeqno) has(mt *metaTxn) bool { //nolint:unused
 
 func (b *ByReceiverAndSeqno) logTrace(txn *metaTxn, format string, args ...any) {
 	b.logger.Trace().
-		Stringer(logging.FieldTransactionHash, txn.hash).
+		Stringer(logging.FieldTransactionHash, txn.Hash()).
 		Stringer(logging.FieldTransactionTo, txn.To).
 		Uint64(logging.FieldTransactionSeqno, txn.Seqno.Uint64()).
 		Msgf(format, args...)

--- a/nil/services/txnpool/txnpool_test.go
+++ b/nil/services/txnpool/txnpool_test.go
@@ -228,7 +228,7 @@ func (s *SuiteTxnPool) TestOnNewBlock() {
 	transactions, err := s.pool.Peek(s.ctx, 10)
 	s.Require().NoError(err)
 	s.Require().Len(transactions, 1)
-	s.Equal(txn22, transactions[0])
+	s.Equal(types.NewTxnWithHash(txn22), transactions[0])
 	s.Equal(1, s.pool.TransactionCount())
 }
 


### PR DESCRIPTION
Reduced the calls to the expensive `Hash()` method of `Block` and `Transaction` to more or less necessary amount.

While looking at ways to implement https://github.com/NilFoundation/nil/issues/97, I decided to optimize the code, since there aren't many places where blocks and txns are hashed.
Now transaction hashes are calculated at the following places in validators:
1. Pool: all added txns.
2. Proposer: all incoming internal txns (not forwarded; external txn hashes are taken from the pool).
3. Proposal validation: block execution.
4. Proposal commit: block execution.
5. Block execution: all incoming and outgoing (generated during execution) txns.

Changes made:
1. Proposer fetches txns from the pool along with their hashes (`MetaTxn`).
2. Pool discards txns by hash.
3. `BlockGenerationResult` obtained in and out txn hashes. Users of this struct (e.g. `BlocksTracer`) now don't calculate these hashes themselves. For that, `OutboundTransaction` obtained a hash field. Also, fixed tests that produced their own mock `BlockGenerationResult` without txns.
4. Postropessing part that writes `txn hash -> (block hash, txn num)` map uses transactions from `BlockGenerationResult` instead of parsing the trie.
5. Unnecessary hashing in logs: removed or replaced with already calculated hash.
6. Each n-th block is reported at info level by a syncher along with its hash. This is done so that archive nodes show some activity in info logs, but also because logging of the block's hash was removed from the debug log.
