### PR TITLE
Remove redundant padding declaration in `.socialButton`

### DIFF
--- a/docs/src/theme/Footer/IconLinkItem/styles.module.css
+++ b/docs/src/theme/Footer/IconLinkItem/styles.module.css
@@ -3,7 +3,6 @@
   justify-content: center;
   flex-direction: row;
   align-items: center;
-  padding: 5px;
   width: 80px;
   height: 80px;
   padding: 20px;


### PR DESCRIPTION
The `padding` property in `.socialButton` is duplicated. The first declaration (`padding: 5px;`) is immediately overridden by the second (`padding: 20px;`), making it redundant. Removing the unnecessary declaration improves code readability, reduces confusion, and simplifies future maintenance.
