### PR TITLE
Fix multiple inputs in playground sc management

### DIFF
--- a/explorer_frontend/src/features/code/init.ts
+++ b/explorer_frontend/src/features/code/init.ts
@@ -235,3 +235,5 @@ sample({
     };
   },
 });
+
+$error.reset(compileCodeFx.doneData);

--- a/explorer_frontend/src/features/contracts/components/Management/MethodInput.tsx
+++ b/explorer_frontend/src/features/contracts/components/Management/MethodInput.tsx
@@ -71,7 +71,7 @@ const MethodInput: FC<MethodInputProps> = ({
       ) : (
         <FormControl label={name} caption={type}>
           <Input
-            value={params ? `${params[paramName]}` || "" : ""}
+            value={params?.[paramName] ? String(params[paramName]) : ""}
             onChange={(e) => {
               const value = e.target.value;
               paramsHandler({ functionName: methodName, paramName, value });


### PR DESCRIPTION
This diff fixes the issue with initial values in multiple inputs displayed as `undefined`.


https://github.com/user-attachments/assets/0e68e06e-966e-4480-a426-ccf2d14f6c77



Also, it resets `$error` on successful compilation of the code. We use this `$error` to display error in code editor, and previously we used to remove error only on code change, but successful compilation can happen for instance after changing compiler version without any changes to the code. This is the reason to reset `$error` on successful compilation as well.