### PR TITLE
Sync Committee: In-storage task cancellation

### DIFF
--- a/nil/services/synccommittee/internal/types/block_batch.go
+++ b/nil/services/synccommittee/internal/types/block_batch.go
@@ -125,11 +125,11 @@ func (b *BlockBatch) AllBlocks() []*jsonrpc.RPCBlock {
 func (b *BlockBatch) CreateProofTasks(currentTime time.Time) ([]*TaskEntry, error) {
 	taskEntries := make([]*TaskEntry, 0, len(b.ChildBlocks)+1)
 
-	aggregateProofsTask := NewAggregateProofsTaskEntry(b.Id, b.MainShardBlock, currentTime)
+	aggregateProofsTask := NewAggregateProofsTaskEntry(b.Id, b.ParentId, b.MainShardBlock, currentTime)
 	taskEntries = append(taskEntries, aggregateProofsTask)
 
 	for _, childBlock := range b.ChildBlocks {
-		blockProofTask, err := NewBlockProofTaskEntry(b.Id, aggregateProofsTask, childBlock, currentTime)
+		blockProofTask, err := NewBlockProofTaskEntry(b.Id, b.ParentId, aggregateProofsTask, childBlock, currentTime)
 		if err != nil {
 			return nil, err
 		}

--- a/nil/services/synccommittee/internal/types/errors.go
+++ b/nil/services/synccommittee/internal/types/errors.go
@@ -15,6 +15,7 @@ var (
 )
 
 var (
+	ErrTaskNotFound      = errors.New("task with the specified id is not found")
 	ErrTaskInvalidStatus = errors.New("task has invalid status")
 	ErrTaskWrongExecutor = errors.New("task belongs to another executor")
 )
@@ -44,6 +45,9 @@ const (
 
 	// TaskErrTerminated indicates that the task was explicitly terminated prior to completion.
 	TaskErrTerminated
+
+	// TaskErrCancelled indicates that task execution was cancelled before starting/completion.
+	TaskErrCancelled
 
 	// TaskErrNotSupportedType indicates that an unsupported or unrecognized type was encountered by the executor.
 	TaskErrNotSupportedType

--- a/nil/services/synccommittee/internal/types/task_status.go
+++ b/nil/services/synccommittee/internal/types/task_status.go
@@ -15,6 +15,7 @@ const (
 	Running
 	Failed
 	Completed
+	Cancelled
 )
 
 var TaskStatuses = map[string]TaskStatus{
@@ -22,6 +23,7 @@ var TaskStatuses = map[string]TaskStatus{
 	"WaitingForExecutor": WaitingForExecutor,
 	"Running":            Running,
 	"Failed":             Failed,
+	"Cancelled":          Cancelled,
 }
 
 func (t *TaskStatus) Set(str string) error {

--- a/nil/services/synccommittee/proofprovider/task_handler_test.go
+++ b/nil/services/synccommittee/proofprovider/task_handler_test.go
@@ -87,7 +87,7 @@ func (s *TaskHandlerTestSuite) TestHandleAggregateProofsTask() {
 	now := s.timer.NowTime()
 	executorId := testaide.RandomExecutorId()
 	mainBlock := testaide.NewMainShardBlock()
-	taskEntry := types.NewAggregateProofsTaskEntry(types.NewBatchId(), mainBlock, now)
+	taskEntry := types.NewAggregateProofsTaskEntry(types.NewBatchId(), nil, mainBlock, now)
 	aggProofsTask := taskEntry.Task
 
 	err := s.taskHandler.Handle(s.context, executorId, &taskEntry.Task)
@@ -111,8 +111,8 @@ func (s *TaskHandlerTestSuite) TestHandleBlockProofTask() {
 	now := s.timer.NowTime()
 	executorId := testaide.RandomExecutorId()
 	execBlock := testaide.NewExecutionShardBlock()
-	aggregateProofsEntry := types.NewAggregateProofsTaskEntry(types.NewBatchId(), execBlock, now)
-	taskEntry, err := types.NewBlockProofTaskEntry(types.NewBatchId(), aggregateProofsEntry, execBlock, now)
+	aggregateProofsEntry := types.NewAggregateProofsTaskEntry(types.NewBatchId(), nil, execBlock, now)
+	taskEntry, err := types.NewBlockProofTaskEntry(types.NewBatchId(), nil, aggregateProofsEntry, execBlock, now)
 	s.Require().NoError(err)
 
 	err = s.taskHandler.Handle(s.context, executorId, &taskEntry.Task)

--- a/nil/services/synccommittee/prover/commands/commands.go
+++ b/nil/services/synccommittee/prover/commands/commands.go
@@ -42,7 +42,7 @@ func makeCmdCommon(config CommandConfig) cmdCommon {
 
 func circuitTypeToArg(ct types.CircuitType) string {
 	switch ct {
-	case types.None:
+	case types.CircuitNone:
 		return "none"
 	case types.CircuitBytecode:
 		return "bytecode"


### PR DESCRIPTION
### Sync Committee: In-storage task cancellation

During the Sync Committee state reset process (in the case of a critical failure or if cluster rollback/hard reset is detected), all proof generation tasks that follow the failed task should be canceled.

To achieve this, several changes have been introduced in the `TaskStorage` logic:

* Implemented task cancellation logic, including new statuses, error types, and functions for terminating dependent tasks upon critical failures;

* Added batch task indexing for parent-child relationships, improving task management and enabling BFS-style traversal for batch tasks;

* Refactored constructor functions for prover tasks: all of them now accept `providerTask` as a parameter;

⚠️ TODO: add new tests for `TaskStorage.ProcessTaskResult(...)` method covering cancellation logic