### PR TITLE
[GH-420] Example of checklocks analyzer integration

### DIFF
--- a/.github/workflows/build_artifacts.yml
+++ b/.github/workflows/build_artifacts.yml
@@ -34,21 +34,8 @@ jobs:
       - name: golangci-lint
         run: nix develop -c golangci-lint run
 
-      - name: Find directories with .go files
-        id: find-go-dirs
-        # TODO: change DIRS to $(find ./nil -type f -name "*.go" | xargs -I {} dirname {} | sort -u) when all checks have passed
-        run: |
-          DIRS=(./nil/internal/network)
-          echo "Found directories:"
-          echo "$DIRS"
-          echo "dirs=$DIRS" >> $GITHUB_OUTPUT
-
       - name: Run checklocks
-        run: |
-          for dir in ${{ steps.find-go-dirs.outputs.dirs }}; do
-            echo "  >> Checking locks correctness in $dir"
-            nix develop -c sh -c "GOFLAGS=\"\$GOFLAGS -tags=test\" go run gvisor.dev/gvisor/tools/checklocks/cmd/checklocks $dir"
-          done
+        run: nix develop -c make checklocks
 
       - name: build
         run: nix build -L

--- a/.github/workflows/build_artifacts.yml
+++ b/.github/workflows/build_artifacts.yml
@@ -34,6 +34,22 @@ jobs:
       - name: golangci-lint
         run: nix develop -c golangci-lint run
 
+      - name: Find directories with .go files
+        id: find-go-dirs
+        # TODO: change DIRS to $(find ./nil -type f -name "*.go" | xargs -I {} dirname {} | sort -u) when all checks have passed
+        run: |
+          DIRS=(./nil/internal/network)
+          echo "Found directories:"
+          echo "$DIRS"
+          echo "dirs=$DIRS" >> $GITHUB_OUTPUT
+
+      - name: Run checklocks
+        run: |
+          for dir in ${{ steps.find-go-dirs.outputs.dirs }}; do
+            echo "  >> Checking locks correctness in $dir"
+            nix develop -c sh -c "GOFLAGS=\"\$GOFLAGS -tags=test\" go run gvisor.dev/gvisor/tools/checklocks/cmd/checklocks $dir"
+          done
+
       - name: build
         run: nix build -L
 

--- a/Makefile
+++ b/Makefile
@@ -67,9 +67,12 @@ lint: generated
 	gofumpt -l -w .
 	gci write . --skip-generated --skip-vendor
 	golangci-lint run
-	@for dir in $(CHECK_LOCKS_DIRECTORIES); do \
-		echo "  >> Checking locks correctness in $$dir"; \
-		GOFLAGS="-tags=test" go run gvisor.dev/gvisor/tools/checklocks/cmd/checklocks "$$dir" || exit 1; \
+
+checklocks: generated
+	@export GOFLAGS="$$GOFLAGS -tags=test"; \
+	for dir in $(CHECK_LOCKS_DIRECTORIES); do \
+		echo ">> Checking locks correctness in $$dir"; \
+		go run gvisor.dev/gvisor/tools/checklocks/cmd/checklocks "$$dir" || exit 1; \
 	done
 
 rpcspec:

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,9 @@ pb: pb_rawapi pb_ibft pb_synccommittee
 
 SOL_FILES := $(wildcard nil/contracts/solidity/tests/*.sol nil/contracts/solidity/*.sol)
 BIN_FILES := $(patsubst nil/contracts/solidity/%.sol, contracts/compiled/%.bin, $(SOL_FILES))
+CHECK_LOCKS_DIRECTORIES := ./nil/internal/network
+# TODO: Uncomment the line below when all checks have passed to run checklocks across all directories
+# CHECK_LOCKS_DIRECTORIES := $(shell find ./nil -type f -name "*.go" | xargs -I {} dirname {} | sort -u)
 
 .PHONY: compile-bins
 compile-bins:
@@ -64,6 +67,10 @@ lint: generated
 	gofumpt -l -w .
 	gci write . --skip-generated --skip-vendor
 	golangci-lint run
+	@for dir in $(CHECK_LOCKS_DIRECTORIES); do \
+		echo "  >> Checking locks correctness in $$dir"; \
+		GOFLAGS="-tags=test" go run gvisor.dev/gvisor/tools/checklocks/cmd/checklocks "$$dir" || exit 1; \
+	done
 
 rpcspec:
 	go run nil/cmd/spec_generator/spec_generator.go

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/rs/zerolog v1.33.0
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/crypto v0.33.0
-
+	gvisor.dev/gvisor v0.0.0-20250225225209-86abc85f37d5
 )
 
 require (
@@ -242,7 +242,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/mod v0.23.0 // indirect
-	golang.org/x/time v0.5.0 // indirect
+	golang.org/x/time v0.7.0 // indirect
 	golang.org/x/tools v0.30.0 // indirect
 	gonum.org/v1/gonum v0.15.1 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250115164207-1a7da9e5054f // indirect

--- a/go.sum
+++ b/go.sum
@@ -958,8 +958,8 @@ golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20201208040808-7e3f01d25324/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
-golang.org/x/time v0.5.0 h1:o7cqy6amK/52YcAKIPlM3a+Fpj35zvRj2TP+e1xFSfk=
-golang.org/x/time v0.5.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
+golang.org/x/time v0.7.0 h1:ntUhktv3OPE6TgYxXWv9vKvUSJyIFJlyohwbkEwPrKQ=
+golang.org/x/time v0.7.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181030000716-a0a13e073c7b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
@@ -1047,6 +1047,8 @@ gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 grpc.go4.org v0.0.0-20170609214715-11d0a25b4919/go.mod h1:77eQGdRu53HpSqPFJFmuJdjuHRquDANNeA4x7B8WQ9o=
+gvisor.dev/gvisor v0.0.0-20250225225209-86abc85f37d5 h1:zujTtH23qWqR10N5deCpxaY6D22+WQlX82TxNnU3ccs=
+gvisor.dev/gvisor v0.0.0-20250225225209-86abc85f37d5/go.mod h1:5DMfjtclAbTIjbXqO1qCe2K5GKKxWz2JHvCChuTcJEM=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/nil/internal/network/pubsub.go
+++ b/nil/internal/network/pubsub.go
@@ -16,11 +16,11 @@ import (
 const subscriptionChannelSize = 100
 
 type PubSub struct {
-	impl   *pubsub.PubSub
+	impl   *pubsub.PubSub // +checklocksignore: mu is not required, it just happens to be held always.
 	prefix string
 
 	mu     sync.Mutex
-	topics map[string]*pubsub.Topic
+	topics map[string]*pubsub.Topic // +checklocks:mu
 	self   PeerID
 
 	meter         telemetry.Meter

--- a/nil/tools/tools.go
+++ b/nil/tools/tools.go
@@ -7,4 +7,5 @@ import (
 	_ "github.com/NilFoundation/fastssz/sszgen"
 	_ "github.com/ethereum/go-ethereum/cmd/abigen"
 	_ "github.com/matryer/moq"
+	_ "gvisor.dev/gvisor/tools/checklocks/cmd/checklocks"
 )

--- a/nix/nil.nix
+++ b/nix/nil.nix
@@ -49,7 +49,7 @@ buildGo124Module rec {
   ];
 
   # to obtain run `nix build` with vendorHash = "";
-  vendorHash = "sha256-X0zXLB7qCl9f9tcZ3p48fERdL/mu1hZJl84sGT27TyM=";
+  vendorHash = "sha256-X7eLWC27qd5hqwLHsaVQ7WzEj6D3kRwGiUgZg+TuInU=";
   hardeningDisable = [ "all" ];
 
   postInstall = ''


### PR DESCRIPTION
See #420

We will need to deal with all the warnings that are now generated before enabling it for the whole project.

<details>
<summary>Analysis of the entire project</summary>

```
$ find ./nil -type f -name "*.go" \
  | xargs -I {} dirname {} \
  | sort -u \
  | xargs -I {} sh -c 'echo ">> Checking {}" && GOFLAGS="-tags=test" go run gvisor.dev/gvisor/tools/checklocks/cmd/checklocks {}'
>> Checking ./nil/client
>> Checking ./nil/client/rpc
>> Checking ./nil/cmd/cometa
>> Checking ./nil/cmd/exporter
>> Checking ./nil/cmd/exporter/internal
>> Checking ./nil/cmd/exporter/internal/clickhouse
>> Checking ./nil/cmd/faucet
>> Checking ./nil/cmd/journald_forwarder
>> Checking ./nil/cmd/nil
>> Checking ./nil/cmd/nil_block_generator
>> Checking ./nil/cmd/nil_block_generator/internal/commands
>> Checking ./nil/cmd/nil/common
>> Checking ./nil/cmd/nild
>> Checking ./nil/cmd/nild/nildconfig
>> Checking ./nil/cmd/nil/internal/abi
>> Checking ./nil/cmd/nil/internal/block
>> Checking ./nil/cmd/nil/internal/cometa
>> Checking ./nil/cmd/nil/internal/config
>> Checking ./nil/cmd/nil/internal/contract
>> Checking ./nil/cmd/nil/internal/debug
>> Checking ./nil/cmd/nil/internal/keygen
>> Checking ./nil/cmd/nil/internal/minter
>> Checking ./nil/cmd/nil/internal/receipt
>> Checking ./nil/cmd/nil/internal/smartaccount
>> Checking ./nil/cmd/nil/internal/system
>> Checking ./nil/cmd/nil/internal/transaction
>> Checking ./nil/cmd/nil/internal/version
>> Checking ./nil/cmd/nil_load_generator
>> Checking ./nil/cmd/proof_provider
>> Checking ./nil/cmd/prover
>> Checking ./nil/cmd/spec_generator
>> Checking ./nil/cmd/sync_committee
>> Checking ./nil/cmd/sync_committee_cli
>> Checking ./nil/cmd/sync_committee_cli/internal/commands
>> Checking ./nil/cmd/sync_committee_cli/internal/flags
>> Checking ./nil/common
>> Checking ./nil/common/assert
>> Checking ./nil/common/check
>> Checking ./nil/common/concurrent
/home/un1or/projects/nil/nil-public/nil/common/concurrent/map.go:9:2: may require checklocks annotation for mu, used with lock held 100% of the time
exit status 3
>> Checking ./nil/common/hexutil
>> Checking ./nil/common/logging
/home/un1or/projects/nil/nil-public/nil/common/logging/logger.go:20:2: may require checklocks annotation for lock, used with lock held 100% of the time
/home/un1or/projects/nil/nil-public/nil/common/logging/logger.go:21:2: may require checklocks annotation for lock, used with lock held 100% of the time
exit status 3
>> Checking ./nil/common/math
>> Checking ./nil/common/sszx
>> Checking ./nil/common/version
/home/un1or/projects/nil/nil-public/nil/common/version/version.go:27:2: may require checklocks annotation for versionInfoCacheMutex, used with lock held 100% of the time
/home/un1or/projects/nil/nil-public/nil/common/version/version.go:26:2: may require checklocks annotation for versionInfoCacheMutex, used with lock held 100% of the time
exit status 3
>> Checking ./nil/contracts
>> Checking ./nil/go-ibft/core
/home/un1or/projects/nil/nil-public/nil/go-ibft/core/state.go:45:2: may require checklocks annotation for RWMutex, used with lock held 100% of the time
/home/un1or/projects/nil/nil-public/nil/go-ibft/core/validator_manager.go:29:2: may require checklocks annotation for vpLock, used with lock held 100% of the time
/home/un1or/projects/nil/nil-public/nil/go-ibft/core/validator_manager.go:25:2: may require checklocks annotation for vpLock, used with lock held 100% of the time
/home/un1or/projects/nil/nil-public/nil/go-ibft/core/state.go:38:2: may require checklocks annotation for RWMutex, used with lock held 100% of the time
/home/un1or/projects/nil/nil-public/nil/go-ibft/core/state.go:51:2: may require checklocks annotation for RWMutex, used with lock held 100% of the time
/home/un1or/projects/nil/nil-public/nil/go-ibft/core/state.go:54:2: may require checklocks annotation for RWMutex, used with lock held 100% of the time
/home/un1or/projects/nil/nil-public/nil/go-ibft/core/state.go:56:2: may require checklocks annotation for RWMutex, used with lock held 100% of the time
/home/un1or/projects/nil/nil-public/nil/go-ibft/core/state.go:48:2: may require checklocks annotation for RWMutex, used with lock held 100% of the time
/home/un1or/projects/nil/nil-public/nil/go-ibft/core/state.go:41:2: may require checklocks annotation for RWMutex, used with lock held 100% of the time
/home/un1or/projects/nil/nil-public/nil/go-ibft/core/validator_manager.go:12:5: may require checklocks annotation for vpLock, used with lock held 100% of the time
/home/un1or/projects/nil/nil-public/nil/go-ibft/core/mock_test.go:457:17: unexpected call to atomic function
/home/un1or/projects/nil/nil-public/nil/go-ibft/core/mock_test.go:462:25: unexpected call to atomic function
/home/un1or/projects/nil/nil-public/nil/go-ibft/core/mock_test.go:466:19: unexpected call to atomic function
/home/un1or/projects/nil/nil-public/nil/go-ibft/core/rapid_test.go:107:2: may require checklocks annotation for Mutex, used with lock held 100% of the time
/home/un1or/projects/nil/nil-public/nil/go-ibft/core/rapid_test.go:108:2: may require checklocks annotation for Mutex, used with lock held 100% of the time
/home/un1or/projects/nil/nil-public/nil/go-ibft/core/rapid_test.go:30:2: may require checklocks annotation for Mutex, used with lock held 100% of the time
exit status 3
>> Checking ./nil/go-ibft/messages
/home/un1or/projects/nil/nil-public/nil/go-ibft/messages/event_manager.go:76:17: unexpected call to atomic function
/home/un1or/projects/nil/nil-public/nil/go-ibft/messages/event_manager.go:92:18: unexpected call to atomic function
/home/un1or/projects/nil/nil-public/nil/go-ibft/messages/event_manager.go:105:19: unexpected call to atomic function
/home/un1or/projects/nil/nil-public/nil/go-ibft/messages/event_manager.go:113:21: unexpected call to atomic function
/home/un1or/projects/nil/nil-public/nil/go-ibft/messages/event_manager.go:13:2: may require checklocks annotation for subscriptionsLock, used with lock held 100% of the time
exit status 3
>> Checking ./nil/go-ibft/messages/proto
>> Checking ./nil/internal/abi
>> Checking ./nil/internal/collate
/home/un1or/projects/nil/nil-public/nil/internal/collate/syncer.go:56:2: may require checklocks annotation for subsMutex, used with lock held 100% of the time
/home/un1or/projects/nil/nil-public/nil/internal/collate/syncer.go:55:2: may require checklocks annotation for subsMutex, used with lock held 100% of the time
exit status 3
>> Checking ./nil/internal/config
>> Checking ./nil/internal/consensus/ibft
>> Checking ./nil/internal/contracts
>> Checking ./nil/internal/crypto
>> Checking ./nil/internal/crypto/bls
>> Checking ./nil/internal/crypto/bls/common
>> Checking ./nil/internal/crypto/bls/kyber
>> Checking ./nil/internal/db
>> Checking ./nil/internal/execution
/home/un1or/projects/nil/nil-public/nil/internal/execution/fee.go:41:2: may require checklocks annotation for lock, used with lock held 100% of the time
exit status 3
>> Checking ./nil/internal/keys
>> Checking ./nil/internal/mpt
>> Checking ./nil/internal/network
>> Checking ./nil/internal/network/internal
>> Checking ./nil/internal/params
>> Checking ./nil/internal/profiling
>> Checking ./nil/internal/readthroughdb
>> Checking ./nil/internal/signer
>> Checking ./nil/internal/telemetry
>> Checking ./nil/internal/telemetry/internal
>> Checking ./nil/internal/telemetry/telattr
>> Checking ./nil/internal/tracing
>> Checking ./nil/internal/types
>> Checking ./nil/internal/vm
>> Checking ./nil/services/admin
>> Checking ./nil/services/cliservice
>> Checking ./nil/services/cometa
>> Checking ./nil/services/faucet
>> Checking ./nil/services/journald_forwarder
>> Checking ./nil/services/nil_load_generator
>> Checking ./nil/services/nil_load_generator/contracts
>> Checking ./nil/services/nil_load_generator/metrics
>> Checking ./nil/services/nilservice
>> Checking ./nil/services/rollup
/home/un1or/projects/nil/nil-public/nil/services/rollup/l1_fetcher.go:27:2: may require checklocks annotation for lock, used with lock held 100% of the time
/home/un1or/projects/nil/nil-public/nil/services/rollup/l1_fetcher_generated_mock.go:36:2: may require checklocks annotation for lockGetLastBlockInfo, used with lock held 100% of the time
exit status 3
>> Checking ./nil/services/rpc
>> Checking ./nil/services/rpc/filters
/home/un1or/projects/nil/nil-public/nil/services/rpc/filters/filters.go:69:2: may require checklocks annotation for mutex, used with lock held 100% of the time
exit status 3
>> Checking ./nil/services/rpc/httpcfg
>> Checking ./nil/services/rpc/internal/http
/home/un1or/projects/nil/nil-public/nil/services/rpc/internal/http/stack.go:42:2: may require checklocks annotation for mu, used with lock held 100% of the time
/home/un1or/projects/nil/nil-public/nil/services/rpc/internal/http/stack.go:57:2: may require checklocks annotation for mu, used with lock held 100% of the time
exit status 3
>> Checking ./nil/services/rpc/jsonrpc
>> Checking ./nil/services/rpc/rawapi
>> Checking ./nil/services/rpc/rawapi/pb
>> Checking ./nil/services/rpc/rawapi/types
>> Checking ./nil/services/rpc/transport
/home/un1or/projects/nil/nil-public/nil/services/rpc/transport/server.go:113:21: unexpected call to atomic function
/home/un1or/projects/nil/nil-public/nil/services/rpc/transport/server.go:146:31: unexpected call to atomic function
/home/un1or/projects/nil/nil-public/nil/services/rpc/transport/json.go:127:2: may require checklocks annotation for encMu, used with lock held 100% of the time
/home/un1or/projects/nil/nil-public/nil/services/rpc/transport/service.go:27:2: may require checklocks annotation for mu, used with lock held 100% of the time
exit status 3
>> Checking ./nil/services/rpc/transport/rpccfg
>> Checking ./nil/services/rpc/types
>> Checking ./nil/services/synccommittee/core
>> Checking ./nil/services/synccommittee/core/batches
>> Checking ./nil/services/synccommittee/core/batches/blob
>> Checking ./nil/services/synccommittee/core/batches/encode
>> Checking ./nil/services/synccommittee/core/batches/encode/v1
>> Checking ./nil/services/synccommittee/debug
>> Checking ./nil/services/synccommittee/internal/api
/home/un1or/projects/nil/nil-public/nil/services/synccommittee/internal/api/task_handler_generated_mock.go:38:2: may require checklocks annotation for lockHandle, used with lock held 100% of the time
/home/un1or/projects/nil/nil-public/nil/services/synccommittee/internal/api/task_state_change_handler_generated_mock.go:38:2: may require checklocks annotation for lockOnTaskTerminated, used with lock held 100% of the time
exit status 3
>> Checking ./nil/services/synccommittee/internal/executor
>> Checking ./nil/services/synccommittee/internal/log
>> Checking ./nil/services/synccommittee/internal/metrics
>> Checking ./nil/services/synccommittee/internal/rollupcontract
>> Checking ./nil/services/synccommittee/internal/rpc
>> Checking ./nil/services/synccommittee/internal/scheduler
>> Checking ./nil/services/synccommittee/internal/scheduler/heap
>> Checking ./nil/services/synccommittee/internal/srv
>> Checking ./nil/services/synccommittee/internal/storage
>> Checking ./nil/services/synccommittee/internal/testaide
>> Checking ./nil/services/synccommittee/internal/types
>> Checking ./nil/services/synccommittee/internal/types/proto
>> Checking ./nil/services/synccommittee/proofprovider
>> Checking ./nil/services/synccommittee/prover
>> Checking ./nil/services/synccommittee/prover/commands
>> Checking ./nil/services/synccommittee/prover/internal/constants
>> Checking ./nil/services/synccommittee/prover/proto
>> Checking ./nil/services/synccommittee/prover/tracer
>> Checking ./nil/services/synccommittee/prover/tracer/api
>> Checking ./nil/services/synccommittee/prover/tracer/internal/constants
>> Checking ./nil/services/synccommittee/prover/tracer/internal/mpttracer
>> Checking ./nil/services/synccommittee/prover/tracer/internal/testutils
>> Checking ./nil/services/synccommittee/public
>> Checking ./nil/services/txnpool
>> Checking ./nil/tests
>> Checking ./nil/tests/archive_node
>> Checking ./nil/tests/async_await
>> Checking ./nil/tests/basic
>> Checking ./nil/tests/block_replay
>> Checking ./nil/tests/cli
>> Checking ./nil/tests/cli_call
>> Checking ./nil/tests/cometa
>> Checking ./nil/tests/config
>> Checking ./nil/tests/consensus
>> Checking ./nil/tests/deploy
>> Checking ./nil/tests/economy
>> Checking ./nil/tests/faucet
>> Checking ./nil/tests/faucet_service
>> Checking ./nil/tests/journald_forwarder
>> Checking ./nil/tests/l1info
>> Checking ./nil/tests/modifiers
>> Checking ./nil/tests/multitoken
>> Checking ./nil/tests/nil_load_generator_service
>> Checking ./nil/tests/opcodes
>> Checking ./nil/tests/read_through
>> Checking ./nil/tests/regression
>> Checking ./nil/tests/rpc_node
>> Checking ./nil/tests/shard
>> Checking ./nil/tests/smart-account
>> Checking ./nil/tools
-: build constraints exclude all Go files in /home/un1or/projects/nil/nil-public/nil/tools
buildssa: analysis skipped due to errors in package
checklocks: failed prerequisites: buildssa@github.com/NilFoundation/nil/nil/tools
exit status 1
>> Checking ./nil/tools/solc
>> Checking ./nil/tools/solc/bin
```
</details>