### PR TITLE
[nild] support changing log level of libp2p

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 	github.com/hashicorp/go-metrics v0.5.4
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/icza/bitio v1.1.0
+	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/klauspost/compress v1.18.0
 	github.com/shopspring/decimal v1.4.0
 	github.com/spf13/viper v1.19.0
@@ -133,7 +134,6 @@ require (
 	github.com/ipfs/go-cid v0.5.0 // indirect
 	github.com/ipfs/go-datastore v0.8.1 // indirect
 	github.com/ipfs/go-log v1.0.5 // indirect
-	github.com/ipfs/go-log/v2 v2.5.1 // indirect
 	github.com/ipld/go-ipld-prime v0.21.0 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
 	github.com/jbenet/go-temp-err-catcher v0.1.0 // indirect

--- a/nil/cmd/nild/main.go
+++ b/nil/cmd/nild/main.go
@@ -134,6 +134,7 @@ func parseArgs() *nildconfig.Config {
 	}
 
 	logLevel := rootCmd.PersistentFlags().StringP("log-level", "l", "info", "log level: trace|debug|info|warn|error|fatal|panic")
+	libp2pLogLevel := rootCmd.PersistentFlags().String("libp2p-log-level", "", "log level: debug|info|warn|error|fatal|dpanic|panic")
 	rootCmd.PersistentFlags().StringP("config", "c", "", "config file (none by default)")
 
 	rootCmd.PersistentFlags().StringVar(&cfg.DB.Path, "db-path", cfg.DB.Path, "path to database")
@@ -225,6 +226,7 @@ func parseArgs() *nildconfig.Config {
 	check.PanicIfErr(rootCmd.Execute())
 
 	logging.SetupGlobalLogger(*logLevel)
+	check.PanicIfErr(logging.SetLibp2pLogLevel(*libp2pLogLevel))
 
 	if cfg.Replay.BlockIdLast == 0 {
 		cfg.Replay.BlockIdLast = cfg.Replay.BlockIdFirst

--- a/nil/common/logging/libp2p_logger.go
+++ b/nil/common/logging/libp2p_logger.go
@@ -1,0 +1,13 @@
+package logging
+
+import (
+	libp2plog "github.com/ipfs/go-log/v2"
+)
+
+func SetLibp2pLogLevel(level string) error {
+	if level == "" {
+		return nil
+	}
+
+	return libp2plog.SetLogLevel("*", level)
+}


### PR DESCRIPTION
Libp2p internally logs some events but it's disabled by default. This patch gives a way to enable it. It can be done via cmd args or via our admin API.