### PR TITLE
Sync Committee: Soft State Reset

### DIFF
--- a/nil/common/concurrent/suspendable.go
+++ b/nil/common/concurrent/suspendable.go
@@ -89,10 +89,14 @@ func (s *Suspendable) onStateChange(ticker *time.Ticker, currentState *workerSta
 	req.response <- true
 }
 
+// Pause halts the periodic execution of the action, transitioning the worker to a paused state.
+// Returns true if the state was changed, false if already paused or an error occurred.
 func (s *Suspendable) Pause(ctx context.Context) (paused bool, err error) {
 	return s.pushAndWait(ctx, workerStatePaused)
 }
 
+// Resume resumes periodic action execution, transitioning the worker to a running state,
+// Returns true if the state was changed, false if already running or an error occurred.
 func (s *Suspendable) Resume(ctx context.Context) (resumed bool, err error) {
 	return s.pushAndWait(ctx, workerStateRunning)
 }

--- a/nil/services/synccommittee/core/block_tasks_integration_test.go
+++ b/nil/services/synccommittee/core/block_tasks_integration_test.go
@@ -53,7 +53,7 @@ func (s *BlockTasksIntegrationTestSuite) SetupSuite() {
 
 	s.scheduler = scheduler.New(
 		s.taskStorage,
-		newTaskStateChangeHandler(s.blockStorage, logger),
+		newTaskStateChangeHandler(s.blockStorage, &noopStateResetLauncher{}, logger),
 		metricsHandler,
 		logger,
 	)
@@ -182,4 +182,10 @@ func newTestSuccessProviderResult(taskToExecute *types.Task, executorId types.Ta
 		types.TaskOutputArtifacts{},
 		types.TaskResultData{},
 	)
+}
+
+type noopStateResetLauncher struct{}
+
+func (l *noopStateResetLauncher) LaunchPartialResetWithSuspension(_ context.Context, _ common.Hash) error {
+	return nil
 }

--- a/nil/services/synccommittee/core/reset/resetter.go
+++ b/nil/services/synccommittee/core/reset/resetter.go
@@ -1,0 +1,61 @@
+package reset
+
+import (
+	"context"
+
+	"github.com/NilFoundation/nil/nil/common"
+	"github.com/NilFoundation/nil/nil/common/logging"
+	"github.com/rs/zerolog"
+)
+
+type StateResetter interface {
+	// ResetProgressPartial resets Sync Committee's block processing progress
+	// to a point preceding main shard block with the specified hash.
+	ResetProgressPartial(ctx context.Context, firstMainHashToPurge common.Hash) error
+
+	// ResetProgressNotProved resets Sync Committee's progress for all not yet proven blocks.
+	ResetProgressNotProved(ctx context.Context) error
+}
+
+func NewStateResetter(logger zerolog.Logger, resetters ...StateResetter) StateResetter {
+	return &compositeStateResetter{
+		resetters: resetters,
+		logger:    logger,
+	}
+}
+
+type compositeStateResetter struct {
+	resetters []StateResetter
+	logger    zerolog.Logger
+}
+
+func (r *compositeStateResetter) ResetProgressPartial(ctx context.Context, firstMainHashToPurge common.Hash) error {
+	r.logger.Info().
+		Stringer(logging.FieldBlockMainChainHash, firstMainHashToPurge).
+		Msg("Started partial progress reset")
+
+	for _, resetter := range r.resetters {
+		if err := resetter.ResetProgressPartial(ctx, firstMainHashToPurge); err != nil {
+			return err
+		}
+	}
+
+	r.logger.Info().
+		Stringer(logging.FieldBlockMainChainHash, firstMainHashToPurge).
+		Msg("Finished partial progress reset")
+
+	return nil
+}
+
+func (r *compositeStateResetter) ResetProgressNotProved(ctx context.Context) error {
+	r.logger.Info().Msg("Started not proven progress reset")
+
+	for _, resetter := range r.resetters {
+		if err := resetter.ResetProgressNotProved(ctx); err != nil {
+			return err
+		}
+	}
+
+	r.logger.Info().Msg("Finished not proven progress reset")
+	return nil
+}

--- a/nil/services/synccommittee/core/reset/state_reset_launcher.go
+++ b/nil/services/synccommittee/core/reset/state_reset_launcher.go
@@ -1,0 +1,102 @@
+package reset
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/NilFoundation/nil/nil/common"
+	"github.com/NilFoundation/nil/nil/common/logging"
+	"github.com/rs/zerolog"
+)
+
+const (
+	fetchResumeDelay        = 10 * time.Minute
+	fetchResumeTimeout      = time.Minute
+	gracefulShutdownTimeout = 5 * time.Minute
+)
+
+type BlockFetcher interface {
+	Pause(ctx context.Context) error
+	Resume(ctx context.Context) error
+}
+
+type Service interface {
+	Stop() (stopped <-chan struct{})
+}
+
+type stateResetLauncher struct {
+	blockFetcher BlockFetcher
+	resetter     StateResetter
+	service      Service
+	logger       zerolog.Logger
+}
+
+func NewResetLauncher(
+	blockFetcher BlockFetcher,
+	resetter StateResetter,
+	service Service,
+	logger zerolog.Logger,
+) *stateResetLauncher {
+	return &stateResetLauncher{
+		blockFetcher: blockFetcher,
+		resetter:     resetter,
+		service:      service,
+		logger:       logger,
+	}
+}
+
+func (l *stateResetLauncher) LaunchPartialResetWithSuspension(ctx context.Context, firstMainHashToPurge common.Hash) error {
+	l.logger.Info().
+		Stringer(logging.FieldBlockMainChainHash, firstMainHashToPurge).
+		Msg("Launching state reset process")
+
+	if err := l.blockFetcher.Pause(ctx); err != nil {
+		return fmt.Errorf("failed to pause block fetching: %w", err)
+	}
+
+	if err := l.resetter.ResetProgressPartial(ctx, firstMainHashToPurge); err != nil {
+		l.onResetError(ctx, err, firstMainHashToPurge)
+		return nil
+	}
+
+	l.logger.Info().
+		Stringer(logging.FieldBlockMainChainHash, firstMainHashToPurge).
+		Msgf("State reset completed, block fetching will be resumed after %s", fetchResumeDelay)
+
+	detachedCtx := context.WithoutCancel(ctx)
+	time.AfterFunc(fetchResumeDelay, func() {
+		l.resumeBlockFetching(detachedCtx)
+	})
+	return nil
+}
+
+func (l *stateResetLauncher) onResetError(
+	ctx context.Context, resetErr error, failedMainBlockHash common.Hash,
+) {
+	l.logger.Error().Err(resetErr).Stringer(logging.FieldBlockMainChainHash, failedMainBlockHash).Send()
+	l.resumeBlockFetching(ctx)
+}
+
+func (l *stateResetLauncher) resumeBlockFetching(ctx context.Context) {
+	ctx, cancel := context.WithTimeout(ctx, fetchResumeTimeout)
+	defer cancel()
+
+	l.logger.Info().Msg("Resuming block fetching")
+	err := l.blockFetcher.Resume(ctx)
+
+	if err == nil {
+		l.logger.Info().Msg("Block fetching successfully resumed")
+		return
+	}
+
+	l.logger.Error().Err(err).Msg("Failed to resume block fetching, service will be terminated")
+
+	stopped := l.service.Stop()
+
+	select {
+	case <-time.After(gracefulShutdownTimeout):
+		l.logger.Fatal().Err(err).Msgf("Service did not stop after %s, force termination", gracefulShutdownTimeout)
+	case <-stopped:
+	}
+}

--- a/nil/services/synccommittee/core/task_state_change_handler.go
+++ b/nil/services/synccommittee/core/task_state_change_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/NilFoundation/nil/nil/common"
 	"github.com/NilFoundation/nil/nil/common/logging"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/api"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/log"
@@ -15,33 +16,51 @@ type ProvedBlockSetter interface {
 	SetBlockAsProved(ctx context.Context, blockId types.BlockId) error
 }
 
+type StateResetLauncher interface {
+	LaunchPartialResetWithSuspension(ctx context.Context, failedMainBlockHash common.Hash) error
+}
+
 type taskStateChangeHandler struct {
-	blockSetter ProvedBlockSetter
-	logger      zerolog.Logger
+	blockSetter        ProvedBlockSetter
+	stateResetLauncher StateResetLauncher
+	logger             zerolog.Logger
 }
 
 func newTaskStateChangeHandler(
 	blockSetter ProvedBlockSetter,
+	stateResetLauncher StateResetLauncher,
 	logger zerolog.Logger,
 ) api.TaskStateChangeHandler {
 	return &taskStateChangeHandler{
-		blockSetter: blockSetter,
-		logger:      logger,
+		blockSetter:        blockSetter,
+		stateResetLauncher: stateResetLauncher,
+		logger:             logger,
 	}
 }
 
-func (h taskStateChangeHandler) OnTaskTerminated(ctx context.Context, task *types.Task, result *types.TaskResult) error {
+func (h *taskStateChangeHandler) OnTaskTerminated(ctx context.Context, task *types.Task, result *types.TaskResult) error {
+	switch {
+	case result.IsSuccess():
+		log.NewTaskResultEvent(h.logger, zerolog.InfoLevel, result).
+			Msg("received successful task result")
+		return h.onTaskSuccess(ctx, task, result)
+
+	case result.HasRetryableError():
+		log.NewTaskResultEvent(h.logger, zerolog.WarnLevel, result).
+			Msg("task execution failed with retryable error")
+		return nil
+
+	default:
+		log.NewTaskResultEvent(h.logger, zerolog.WarnLevel, result).
+			Msg("task execution failed with critical error, state will be reset")
+		return h.stateResetLauncher.LaunchPartialResetWithSuspension(ctx, task.BlockHash)
+	}
+}
+
+func (h *taskStateChangeHandler) onTaskSuccess(ctx context.Context, task *types.Task, result *types.TaskResult) error {
 	if task.TaskType != types.AggregateProofs {
 		log.NewTaskEvent(h.logger, zerolog.DebugLevel, task).
 			Msgf("task has type %s, just update pending dependency", task.TaskType)
-		return nil
-	}
-
-	if !result.IsSuccess() {
-		// TODO: handle critical errors here
-
-		log.NewTaskResultEvent(h.logger, zerolog.WarnLevel, result).
-			Msg("block proof task has failed, data won't be sent to the L1")
 		return nil
 	}
 

--- a/nil/services/synccommittee/internal/types/blocks.go
+++ b/nil/services/synccommittee/internal/types/blocks.go
@@ -39,24 +39,28 @@ type BlocksRange struct {
 	End   types.BlockNumber
 }
 
-func GetBlocksFetchingRange(latestFetched *MainBlockRef, actualLatest MainBlockRef) (*BlocksRange, error) {
+// GetBlocksFetchingRange determines the range of blocks to fetch between the latest handled block and the actual latest block.
+// latestHandled can be equal to:
+// a) The latest block fetched from the cluster, or
+// b) The latest proved state root, if `latestFetched` is nil.
+func GetBlocksFetchingRange(latestHandled *MainBlockRef, actualLatest MainBlockRef) (*BlocksRange, error) {
 	switch {
-	case latestFetched == nil:
+	case latestHandled == nil:
 		return &BlocksRange{actualLatest.Number, actualLatest.Number}, nil
 
-	case latestFetched.Number < actualLatest.Number:
-		return &BlocksRange{latestFetched.Number + 1, actualLatest.Number}, nil
+	case latestHandled.Number < actualLatest.Number:
+		return &BlocksRange{latestHandled.Number + 1, actualLatest.Number}, nil
 
-	case latestFetched.Number == actualLatest.Number && latestFetched.Hash != actualLatest.Hash:
+	case latestHandled.Number == actualLatest.Number && latestHandled.Hash != actualLatest.Hash:
 		return nil, fmt.Errorf(
 			"%w: latest blocks have same number %d, but hashes are different: %s != %s",
-			ErrBlockMismatch, actualLatest.Number, latestFetched.Hash, actualLatest.Hash,
+			ErrBlockMismatch, actualLatest.Number, latestHandled.Hash, actualLatest.Hash,
 		)
 
-	case latestFetched.Number > actualLatest.Number:
+	case latestHandled.Number > actualLatest.Number:
 		return nil, fmt.Errorf(
 			"%w: latest fetched block is higher than actual latest block: %d > %d",
-			ErrBlockMismatch, latestFetched.Number, actualLatest.Number,
+			ErrBlockMismatch, latestHandled.Number, actualLatest.Number,
 		)
 
 	default:


### PR DESCRIPTION
## Sync Committee: Soft State Reset

As a reaction to one of the following events, the Sync Committee should perform a partial state reset and re-fetch blocks starting from a well-known point in the past:
a) Critical task execution error
b) Block mismatch detection

### Changes Introduced:
- Introduced `StateResetLauncher`, which performs a state reset by suspending and resuming the `Aggregator`.
- Declared the `StateResetter` interface with two methods: `ResetProgressPartial(hash)` and `ResetProgressNotProved()`.
- Implemented the `BlockStorage.ResetProgressNotProved()` method, which purges all non-proven blocks and resets the `latestFetched` value to `nil`.

### `TaskStateChangeHandler (Sync Committee)`
- Integrated `StateResetLauncher`, triggered in case of a critical task execution error.

### `Aggregator`
- Integrated `StateResetter`, triggered when a block mismatch is detected.
- Implemented `getLatestHandledBlockRef`, which retrieves the latest handled block reference (`latestFetched` or `latestProvedStateRoot`).

Linked PRs: #307 #364 #388 #419 