### PR TITLE
Correct Return Type for run Method to Improve Type Safety

### DIFF
--- a/clijs/src/commands/keygen/new-p2p.ts
+++ b/clijs/src/commands/keygen/new-p2p.ts
@@ -32,7 +32,7 @@ export default class KeygenNewP2p extends BaseCommand {
 
   static override examples = ["<%= config.bin %> <%= command.id %>"];
 
-  public async run(): Promise<Hex> {
+  public async run(): Promise<void> {
     const { privateKey, publicKey, peerId } = await generateSecp256k1Key();
     if (this.quiet) {
       this.log(privateKey);


### PR DESCRIPTION
Fix Incorrect Return Type

File: src/commands/keygen.ts
Change:
Before: public async run(): Promise<Hex>
After: public async run(): Promise<void>
Reason:
The run method does not return a Hex value explicitly. The method logs values but does not return any usable value. Changing the return type to void correctly reflects that the function does not produce a meaningful return value. This improves code clarity and prevents potential type mismatches.
