### PR TITLE
[archive node] Drop on version change

### DIFF
--- a/nil/cmd/nild/devnet.go
+++ b/nil/cmd/nild/devnet.go
@@ -325,6 +325,7 @@ func (devnet *devnet) writeServerConfig(instanceId int, srv server, only string)
 	spec := devnet.spec
 	cfg.NShards = spec.NShards
 	inst := srv.nodeSpec
+	cfg.AllowDbDrop = spec.NilWipeOnUpdate
 	cfg.MyShards = inst.Shards
 	cfg.SplitShards = inst.SplitShards
 	cfg.BootstrapPeers = getPeers(devnet.validators, inst.BootstrapPeersIdx)
@@ -332,7 +333,6 @@ func (devnet *devnet) writeServerConfig(instanceId int, srv server, only string)
 	cfg.LogClientRpcEvents = srv.logClientEvents
 	cfg.DB = db.NewDefaultBadgerDBOptions()
 	cfg.DB.Path = srv.workDir + "/database"
-	cfg.DB.AllowDrop = spec.NilWipeOnUpdate
 	cfg.Network.DHTEnabled = true
 	cfg.Network.DHTBootstrapPeers = getPeers(devnet.validators, inst.DHTBootstrapPeersIdx)
 

--- a/nil/cmd/nild/main.go
+++ b/nil/cmd/nild/main.go
@@ -38,7 +38,7 @@ func main() {
 
 	profiling.Start(cfg.PprofPort)
 
-	database, err := openDb(cfg.DB.Path, cfg.DB.AllowDrop, logger)
+	database, err := openDb(cfg.DB.Path, cfg.AllowDbDrop, logger)
 	check.PanicIfErr(err)
 
 	if len(cfg.ReadThrough.SourceAddr) != 0 {
@@ -109,7 +109,7 @@ func addTelemetryFlags(fset *pflag.FlagSet, cfg *nildconfig.Config) {
 }
 
 func addAllowDbClearFlag(fset *pflag.FlagSet, cfg *nildconfig.Config) {
-	fset.BoolVar(&cfg.DB.AllowDrop, "allow-db-clear", cfg.DB.AllowDrop, "allow to clear database in case of outdated version")
+	fset.BoolVar(&cfg.AllowDbDrop, "allow-db-clear", cfg.AllowDbDrop, "allow to clear database in case of outdated version")
 }
 
 func addRpcNodeFlags(fset *pflag.FlagSet, cfg *nildconfig.Config) {
@@ -227,6 +227,12 @@ func parseArgs() *nildconfig.Config {
 
 	logging.SetupGlobalLogger(*logLevel)
 	check.PanicIfErr(logging.SetLibp2pLogLevel(*libp2pLogLevel))
+
+	// todo: remove it when we remove the old flag
+	// Support old flag for backward compatibility
+	if cfg.DB.AllowDrop {
+		cfg.Config.AllowDbDrop = cfg.DB.AllowDrop
+	}
 
 	if cfg.Replay.BlockIdLast == 0 {
 		cfg.Replay.BlockIdLast = cfg.Replay.BlockIdFirst

--- a/nil/internal/db/badger.go
+++ b/nil/internal/db/badger.go
@@ -25,7 +25,9 @@ type BadgerDBOptions struct {
 	Path         string        `yaml:"path"`
 	DiscardRatio float64       `yaml:"gcDiscardRatio,omitempty"`
 	GcFrequency  time.Duration `yaml:"gcFrequency,omitempty"`
-	AllowDrop    bool          `yaml:"allowDrop,omitempty"`
+
+	// deprecated
+	AllowDrop bool `yaml:"allowDrop,omitempty"`
 }
 
 func NewDefaultBadgerDBOptions() *BadgerDBOptions {
@@ -62,10 +64,6 @@ var (
 
 func MakeKey(table TableName, key []byte) []byte {
 	return append([]byte(table+":"), key...)
-}
-
-func IsKeyFromTable(table TableName, fullKey []byte) bool {
-	return bytes.HasPrefix(fullKey, []byte(table+":"))
 }
 
 func NewBadgerDb(pathToDb string) (*badgerDB, error) {
@@ -134,7 +132,7 @@ func (db *badgerDB) CreateRwTx(ctx context.Context) (RwTx, error) {
 }
 
 func (db *badgerDB) Stream(
-	ctx context.Context, keyFilter func([]byte) bool, writer io.Writer,
+	_ context.Context, keyFilter func([]byte) bool, writer io.Writer,
 ) error {
 	stream := db.db.NewStream()
 	stream.NumGo = 4

--- a/nil/internal/network/pubsub.go
+++ b/nil/internal/network/pubsub.go
@@ -127,11 +127,6 @@ func (ps *PubSub) Publish(ctx context.Context, topic string, data []byte) error 
 
 // Subscribe subscribes to the given topic. The subscription must be closed after use.
 func (ps *PubSub) Subscribe(topic string) (*Subscription, error) {
-	logger := ps.logger.With().
-		Str(logging.FieldComponent, "sub").
-		Str(logging.FieldTopic, topic).
-		Logger()
-
 	t, err := ps.getTopic(topic)
 	if err != nil {
 		return nil, err
@@ -151,6 +146,10 @@ func (ps *PubSub) Subscribe(topic string) (*Subscription, error) {
 		return nil, err
 	}
 
+	logger := ps.logger.With().
+		Str(logging.FieldComponent, "sub").
+		Str(logging.FieldTopic, t.String()).
+		Logger()
 	logger.Debug().Msg("Subscribed to topic")
 	return &Subscription{
 		impl:         impl,

--- a/nil/internal/network/req_resp.go
+++ b/nil/internal/network/req_resp.go
@@ -61,9 +61,9 @@ func (m *Manager) NewStream(ctx context.Context, peerId PeerID, protocolId Proto
 }
 
 func (m *Manager) SetStreamHandler(ctx context.Context, protocolId ProtocolID, handler StreamHandler) {
+	protocolId = ProtocolID(m.withNetworkPrefix(string(protocolId)))
 	m.logger.Debug().Msgf("Setting stream handler for protocol %s", protocolId)
 
-	protocolId = ProtocolID(m.withNetworkPrefix(string(protocolId)))
 	m.host.SetStreamHandler(protocolId, func(stream Stream) {
 		defer stream.Close()
 
@@ -103,9 +103,7 @@ func (m *Manager) SendRequestAndGetResponse(ctx context.Context, peerId PeerID, 
 }
 
 func (m *Manager) SetRequestHandler(ctx context.Context, protocolId ProtocolID, handler RequestHandler) {
-	logger := m.logger.With().Str(logging.FieldProtocolID, string(protocolId)).Logger()
-
-	logger.Debug().Msg("Setting request handler...")
+	logger := m.logger.With().Str(logging.FieldProtocolID, m.withNetworkPrefix(string(protocolId))).Logger()
 
 	m.SetStreamHandler(ctx, protocolId, func(stream Stream) {
 		ctx, cancel := context.WithTimeout(ctx, responseTimeout)

--- a/nil/internal/network/testaide.go
+++ b/nil/internal/network/testaide.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -37,12 +38,6 @@ func NewTestManagerWithBaseConfig(t *testing.T, ctx context.Context, conf *Confi
 	m, err := NewManager(ctx, conf)
 	require.NoError(t, err)
 	return m
-}
-
-func NewTestManager(t *testing.T, ctx context.Context) *Manager {
-	t.Helper()
-
-	return NewTestManagerWithBaseConfig(t, ctx, &Config{})
 }
 
 func NewTestManagers(t *testing.T, ctx context.Context, initialTcpPort int, n int) []*Manager {
@@ -86,6 +81,14 @@ func WaitForPeer(t *testing.T, m *Manager, id PeerID) {
 	}, 10*time.Second, 100*time.Millisecond)
 }
 
+// topLevelTestName returns the top-level test name for a given test.
+// It is used to generate unique (among parallel tests) prefixes for topic and protocol names.
+func topLevelTestName(t *testing.T) string {
+	t.Helper()
+
+	return strings.Split(t.Name(), "/")[0]
+}
+
 func GenerateConfig(t *testing.T, port int) (*Config, AddrInfo) {
 	t.Helper()
 
@@ -102,7 +105,7 @@ func GenerateConfig(t *testing.T, port int) (*Config, AddrInfo) {
 		PrivateKey: key,
 		TcpPort:    port,
 		DHTEnabled: true,
-		Prefix:     t.Name(),
+		Prefix:     topLevelTestName(t),
 	}, AddrInfo(*address)
 }
 

--- a/nil/services/nilservice/config.go
+++ b/nil/services/nilservice/config.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"slices"
 
-	"github.com/NilFoundation/nil/nil/common/logging"
 	"github.com/NilFoundation/nil/nil/internal/collate"
 	"github.com/NilFoundation/nil/nil/internal/config"
 	"github.com/NilFoundation/nil/nil/internal/crypto/bls"
@@ -17,8 +16,6 @@ import (
 	"github.com/NilFoundation/nil/nil/services/cometa"
 	"github.com/NilFoundation/nil/nil/services/rollup"
 )
-
-var Logger = logging.NewLogger("config")
 
 type RunMode int
 
@@ -48,6 +45,7 @@ type Config struct {
 
 	// Admin
 	AdminSocketPath string `yaml:"adminSocket,omitempty"`
+	AllowDbDrop     bool   `yaml:"allowDbDrop,omitempty"`
 
 	// RPC events log
 	LogClientRpcEvents bool `yaml:"logClientRpcEvents,omitempty"`

--- a/nil/tests/archive_node/archive_node_test.go
+++ b/nil/tests/archive_node/archive_node_test.go
@@ -1,55 +1,128 @@
 package tests
 
 import (
+	"context"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/NilFoundation/nil/nil/internal/db"
 	"github.com/NilFoundation/nil/nil/internal/types"
 	"github.com/NilFoundation/nil/nil/services/nilservice"
 	"github.com/NilFoundation/nil/nil/tests"
 	"github.com/stretchr/testify/suite"
 )
 
+type dbWrapper struct {
+	db.DB
+
+	Dropped bool
+}
+
+func (d *dbWrapper) Close() {
+}
+
+func (d *dbWrapper) DropAll() error {
+	d.Dropped = true
+	return d.DB.DropAll()
+}
+
 type SuiteArchiveNode struct {
 	tests.ShardedSuite
 
+	reusedDb *dbWrapper
+	cancel   func()
+	wg       sync.WaitGroup
+
+	nShards            uint32
 	withBootstrapPeers bool
 	port               int
 }
 
-func (s *SuiteArchiveNode) SetupTest() {
-	nshards := uint32(3)
+func (s *SuiteArchiveNode) SetupSuite() {
+	s.nShards = 3
 
-	s.Start(&nilservice.Config{
-		NShards:              nshards,
-		CollatorTickPeriodMs: 200,
-	}, s.port)
+	reusedDb, err := db.NewBadgerDbInMemory()
+	s.Require().NoError(err)
+	s.reusedDb = &dbWrapper{DB: reusedDb}
 
+	s.startCluster()
+
+	s.startArchiveNode()
+}
+
+func (s *SuiteArchiveNode) startArchiveNode() {
+	s.DbInit = func() db.DB {
+		return s.reusedDb
+	}
+
+	ctx, cancel := context.WithCancel(s.Context)
+	s.cancel = cancel
 	s.DefaultClient, _ = s.StartArchiveNode(&tests.ArchiveNodeConfig{
-		Port:               s.port + int(nshards),
+		Ctx:                ctx,
+		Wg:                 &s.wg,
+		AllowDbDrop:        true,
+		Port:               s.port + int(s.nShards),
 		WithBootstrapPeers: s.withBootstrapPeers,
 	})
 }
 
-func (s *SuiteArchiveNode) TearDownTest() {
-	s.Cancel()
+func (s *SuiteArchiveNode) stopArchiveNode() {
+	s.cancel()
+	s.wg.Wait()
 }
 
-func (s *SuiteArchiveNode) TestGetDebugBlock() {
-	for shardId := range s.GetNShards() {
-		debugBlock, err := s.DefaultClient.GetDebugBlock(s.Context, types.ShardId(shardId), "latest", true)
-		s.Require().NoError(err)
-		s.NotNil(debugBlock)
+func (s *SuiteArchiveNode) startCluster() {
+	s.DbInit = nil
+	s.Start(&nilservice.Config{
+		NShards:              s.nShards,
+		CollatorTickPeriodMs: 200,
+	}, s.port)
+}
 
-		b, err := debugBlock.DecodeSSZ()
-		s.Require().NoError(err)
-
-		s.Require().Eventually(func() bool {
-			nextBlock, err := s.DefaultClient.GetDebugBlock(s.Context, types.ShardId(shardId), b.Block.Id.Uint64()+1, true)
+func (s *SuiteArchiveNode) TestRestarts() {
+	check := func() {
+		for shardId := range s.GetNShards() {
+			b, err := s.DefaultClient.GetDebugBlock(s.Context, types.ShardId(shardId), 0, true)
 			s.Require().NoError(err)
-			return nextBlock != nil
-		}, 5*time.Second, 100*time.Millisecond)
+			s.NotNil(b)
+		}
+
+		for shardId := range s.GetNShards() {
+			s.Require().Eventually(func() bool {
+				b, err := s.DefaultClient.GetDebugBlock(s.Context, types.ShardId(shardId), 1, true)
+				s.Require().NoError(err)
+				return b != nil
+			}, 5*time.Second, 100*time.Millisecond)
+		}
 	}
+
+	s.Run("Before", check)
+
+	s.Run("Restart", func() {
+		s.stopArchiveNode()
+		s.startArchiveNode()
+
+		s.False(s.reusedDb.Dropped)
+	})
+
+	s.Run("AfterRestart", check)
+
+	if !s.withBootstrapPeers {
+		// Bootstrap peers are required for the node to fetch the version.
+		// todo: fix it
+		return
+	}
+
+	s.Run("ClusterReset", func() {
+		s.Cancel()
+		s.startCluster()
+		s.startArchiveNode()
+
+		s.True(s.reusedDb.Dropped)
+	})
+
+	s.Run("AfterClusterReset", check)
 }
 
 func (s *SuiteArchiveNode) TestGetFaucetBalance() {


### PR DESCRIPTION
On syncer initialization (called only on a single syncer on the node) the version is checked. Main shard genesis block hash serves as the version, as in the case of exporter.
If local and remote versions differ:
- if `--allow-db-clear`, the existing db is dropped and the snapshot is fetched;
- by default, an error is returned.

Added tests that restart the archive node with and without reset.

For now, before this code is on all the nodes, there is no way to fetch a remote version, so an error there is handled stoically.
