### PR TITLE
[collate] fix tx stucking when it reaches block gas limit

### DIFF
--- a/nil/internal/collate/proposer_test.go
+++ b/nil/internal/collate/proposer_test.go
@@ -181,7 +181,7 @@ func (s *ProposerTestSuite) TestCollator() {
 
 		proposal := generateBlock()
 		s.Empty(proposal.ExternalTxns)
-		s.Empty(proposal.InternalTxns)
+		s.Len(proposal.InternalTxns, 2)
 		s.Empty(proposal.ForwardTxns)
 		s.Equal([]common.Hash{m1.Hash(), m2.Hash()}, pool.LastDiscarded)
 		s.Equal(txnpool.DuplicateHash, pool.LastReason)

--- a/nil/tests/contracts/GasBurner.sol
+++ b/nil/tests/contracts/GasBurner.sol
@@ -1,0 +1,10 @@
+pragma solidity ^0.8.0;
+
+contract GasBurner {
+    uint256[] public data;
+
+    function burnGas() public payable {
+        data = new uint256[](2**24);
+        require(false, "Intentional failure");
+    }
+}

--- a/nil/tests/regression/regression_test.go
+++ b/nil/tests/regression/regression_test.go
@@ -94,6 +94,28 @@ func (s *SuiteRegression) TestEmptyError() {
 	s.Require().False(receipt.Success)
 }
 
+func (s *SuiteRegression) TestProposerOutOfGas() {
+	contractCode, abi := s.LoadContract(common.GetAbsolutePath("../contracts/GasBurner.sol"), "GasBurner")
+	deployPayload := s.PrepareDefaultDeployPayload(abi, contractCode)
+
+	addr, receipt := s.DeployContractViaMainSmartAccount(3, deployPayload, types.Value0)
+	s.Require().True(receipt.OutReceipts[0].Success)
+
+	calldata, err := abi.Pack("burnGas")
+	s.Require().NoError(err)
+
+	txHash, err := s.Client.SendTransactionViaSmartAccount(s.T().Context(),
+		types.MainSmartAccountAddress, calldata, types.NewFeePackFromGas(100_000_000_000), types.Value0,
+		[]types.TokenBalance{}, addr, execution.MainPrivateKey)
+	s.Require().NoError(err)
+
+	receipt = s.WaitIncludedInMain(txHash)
+	s.Require().True(receipt.Success)
+	s.Require().Equal("Success", receipt.Status)
+	s.Require().Len(receipt.OutReceipts, 1)
+	s.Require().Equal("OutOfGasDynamic", receipt.OutReceipts[0].Status)
+}
+
 func TestRegression(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
If a transaction consumed more gas than the block allowed, it just got stuck in the neighbor out tx tree. That prevented the execution of other transactions. This patch should fix it.

See also https://github.com/NilFoundation/nil/issues/79