### PR TITLE
Added simple metrics for loadgen

### DIFF
--- a/nil/services/nil_load_generator/metrics/metrics_handler.go
+++ b/nil/services/nil_load_generator/metrics/metrics_handler.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/NilFoundation/nil/nil/internal/telemetry"
-	"github.com/NilFoundation/nil/nil/internal/types"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )
@@ -14,12 +13,8 @@ type MetricsHandler struct {
 	attributes metric.MeasurementOption
 
 	// Counters
-	totalFromToCalls                 metric.Int64Counter
-	totalErrorsEncountered           metric.Int64Counter
-	currentApproxSmartAccountBalance metric.Int64UpDownCounter
-
-	// Gauges
-	currentSmartAccountBalance metric.Int64Gauge
+	totalFromToCalls       metric.Int64Counter
+	totalErrorsEncountered metric.Int64Counter
 }
 
 func NewMetricsHandler(name string) (*MetricsHandler, error) {
@@ -54,32 +49,13 @@ func (mh *MetricsHandler) initMetrics(name string, meter metric.Meter) error {
 		return err
 	}
 
-	mh.currentApproxSmartAccountBalance, err = meter.Int64UpDownCounter(name + "_current_approx_smart_account_balance")
-	if err != nil {
-		return err
-	}
-
-	// Initialize gauges
-	mh.currentSmartAccountBalance, err = meter.Int64Gauge(name + "_current_smart_account_balance")
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 
-func (mh *MetricsHandler) RecordFromToCall(shardFrom, shardTo int64) {
-	mh.totalFromToCalls.Add(context.Background(), 1, mh.attributes, metric.WithAttributes(attribute.Int64("from", shardFrom), attribute.Int64("to", shardTo)))
+func (mh *MetricsHandler) RecordFromToCall(ctx context.Context, shardFrom, shardTo int64) {
+	mh.totalFromToCalls.Add(ctx, 1, mh.attributes, metric.WithAttributes(attribute.Int64("from", shardFrom), attribute.Int64("to", shardTo)))
 }
 
-func (mh *MetricsHandler) RecordError() {
-	mh.totalErrorsEncountered.Add(context.Background(), 1, mh.attributes)
-}
-
-func (mh *MetricsHandler) SetCurrentSmartAccountBalance(balance uint64, smartAccount types.Address) {
-	mh.currentSmartAccountBalance.Record(context.Background(), int64(balance), mh.attributes, metric.WithAttributes(attribute.Stringer("smart-account", smartAccount)))
-}
-
-func (mh *MetricsHandler) SetCurrentApproxSmartAccountBalance(balance uint64, smartAccount types.Address) {
-	mh.currentApproxSmartAccountBalance.Add(context.Background(), int64(balance), mh.attributes, metric.WithAttributes(attribute.Stringer("smart-account", smartAccount)))
+func (mh *MetricsHandler) RecordError(ctx context.Context) {
+	mh.totalErrorsEncountered.Add(ctx, 1, mh.attributes)
 }


### PR DESCRIPTION
This PR adds simple metrics for the Uniswap load generator service. It helps us gather statistics and analyze the distribution of calls from SmartAccount to Pair.