### PR TITLE
Sync Committee: BlockStorage Capacity Limit

### DIFF
--- a/nil/services/synccommittee/core/aggregator_test.go
+++ b/nil/services/synccommittee/core/aggregator_test.go
@@ -49,7 +49,7 @@ func (s *AggregatorTestSuite) SetupSuite() {
 	s.db, err = db.NewBadgerDbInMemory()
 	s.Require().NoError(err)
 	timer := common.NewTimer()
-	s.blockStorage = storage.NewBlockStorage(s.db, timer, metricsHandler, logger)
+	s.blockStorage = storage.NewBlockStorage(s.db, storage.DefaultBlockStorageConfig(), timer, metricsHandler, logger)
 	s.taskStorage = storage.NewTaskStorage(s.db, timer, metricsHandler, logger)
 	s.rpcClientMock = &client.ClientMock{}
 

--- a/nil/services/synccommittee/core/block_tasks_integration_test.go
+++ b/nil/services/synccommittee/core/block_tasks_integration_test.go
@@ -49,7 +49,7 @@ func (s *BlockTasksIntegrationTestSuite) SetupSuite() {
 
 	s.timer = testaide.NewTestTimer()
 	s.taskStorage = storage.NewTaskStorage(s.db, s.timer, metricsHandler, logger)
-	s.blockStorage = storage.NewBlockStorage(s.db, s.timer, metricsHandler, logger)
+	s.blockStorage = storage.NewBlockStorage(s.db, storage.DefaultBlockStorageConfig(), s.timer, metricsHandler, logger)
 
 	s.scheduler = scheduler.New(
 		s.taskStorage,

--- a/nil/services/synccommittee/core/proposer_test.go
+++ b/nil/services/synccommittee/core/proposer_test.go
@@ -114,7 +114,7 @@ func (s *ProposerTestSuite) SetupSuite() {
 	s.Require().NoError(err)
 
 	s.timer = testaide.NewTestTimer()
-	s.storage = storage.NewBlockStorage(s.db, s.timer, metricsHandler, logger)
+	s.storage = storage.NewBlockStorage(s.db, storage.DefaultBlockStorageConfig(), s.timer, metricsHandler, logger)
 	s.params = NewDefaultProposerParams()
 	s.testData = testaide.NewProposalData(3, s.timer.NowTime())
 	s.callContractMock = newCallContractMock()

--- a/nil/services/synccommittee/core/service.go
+++ b/nil/services/synccommittee/core/service.go
@@ -38,7 +38,7 @@ func New(cfg *Config, database db.DB, ethClient rollupcontract.EthClient) (*Sync
 	client := nilrpc.NewClient(cfg.RpcEndpoint, logger)
 
 	timer := common.NewTimer()
-	blockStorage := storage.NewBlockStorage(database, timer, metricsHandler, logger)
+	blockStorage := storage.NewBlockStorage(database, storage.DefaultBlockStorageConfig(), timer, metricsHandler, logger)
 	taskStorage := storage.NewTaskStorage(database, timer, metricsHandler, logger)
 
 	// todo: add reset logic to TaskStorage (implement StateResetter interface) and pass it here in https://github.com/NilFoundation/nil/pull/419

--- a/nil/services/synccommittee/core/service_test.go
+++ b/nil/services/synccommittee/core/service_test.go
@@ -53,8 +53,13 @@ func (s *SyncCommitteeTestSuite) SetupSuite() {
 
 	syncCommitteeMetrics, err := metrics.NewSyncCommitteeMetrics()
 	s.Require().NoError(err)
-	s.blockStorage = storage.NewBlockStorage(s.scDb, common.NewTimer(), syncCommitteeMetrics, logging.NewLogger("sync_committee_srv_test"))
-	s.Require().NoError(err)
+	s.blockStorage = storage.NewBlockStorage(
+		s.scDb,
+		storage.DefaultBlockStorageConfig(),
+		common.NewTimer(),
+		syncCommitteeMetrics,
+		logging.NewLogger("sync_committee_srv_test"),
+	)
 }
 
 func (s *SyncCommitteeTestSuite) TearDownSuite() {

--- a/nil/services/synccommittee/internal/storage/badgerRetryRunner.go
+++ b/nil/services/synccommittee/internal/storage/badgerRetryRunner.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/NilFoundation/nil/nil/common"
+	"github.com/dgraph-io/badger/v4"
 	"github.com/rs/zerolog"
 )
 
@@ -18,7 +19,9 @@ func badgerRetryRunner(
 	retryPolicy := common.ComposeRetryPolicies(
 		append(
 			[]common.RetryPolicyFunc{
-				common.DoNotRetryIf(ErrSerializationFailed),
+				common.DoNotRetryIf(
+					ErrSerializationFailed, ErrCapacityLimitReached, badger.ErrTxnTooBig,
+				),
 				common.LimitRetries(badgerDefaultRetryLimit),
 			},
 			additionalPolicies...,

--- a/nil/services/synccommittee/internal/storage/block_storage.go
+++ b/nil/services/synccommittee/internal/storage/block_storage.go
@@ -39,6 +39,10 @@ const (
 	// nextToProposeTable stores parent's hash of the next block to propose (single value).
 	// Key: mainShardKey, Value: common.Hash.
 	nextToProposeTable db.TableName = "next_to_propose_parent_hash"
+
+	// storedBlocksCountTable stores the count of blocks that have been persisted in the database.
+	// Key: mainShardKey, Value: uint32.
+	storedBlocksCountTable db.TableName = "stored_blocks_count"
 )
 
 var mainShardKey = makeShardKey(types.MainShardId)
@@ -62,14 +66,30 @@ type BlockStorageMetrics interface {
 	RecordMainBlockProved(ctx context.Context)
 }
 
+type BlockStorageConfig struct {
+	CapacityLimit uint32
+}
+
+func NewBlockStorageConfig(capacityLimit uint32) BlockStorageConfig {
+	return BlockStorageConfig{
+		CapacityLimit: capacityLimit,
+	}
+}
+
+func DefaultBlockStorageConfig() BlockStorageConfig {
+	return NewBlockStorageConfig(200)
+}
+
 type BlockStorage struct {
 	commonStorage
+	config  BlockStorageConfig
 	timer   common.Timer
 	metrics BlockStorageMetrics
 }
 
 func NewBlockStorage(
 	database db.DB,
+	config BlockStorageConfig,
 	timer common.Timer,
 	metrics BlockStorageMetrics,
 	logger zerolog.Logger,
@@ -80,6 +100,7 @@ func NewBlockStorage(
 			logger,
 			common.DoNotRetryIf(scTypes.ErrBlockMismatch, scTypes.ErrBlockNotFound),
 		),
+		config:  config,
 		timer:   timer,
 		metrics: metrics,
 	}
@@ -172,6 +193,10 @@ func (bs *BlockStorage) setBlockBatchImpl(ctx context.Context, batch *scTypes.Bl
 		return err
 	}
 	defer tx.Rollback()
+
+	if err := bs.addStoredCountTx(tx, int32(batch.BlocksCount())); err != nil {
+		return err
+	}
 
 	currentTime := bs.timer.NowTime()
 	mainEntry := newBlockEntry(batch.MainShardBlock, batch.Id, currentTime)
@@ -656,6 +681,11 @@ func (bs *BlockStorage) deleteMainBlockWithChildren(tx db.RwTx, mainShardEntry *
 		return err
 	}
 
+	blocksCount := int32(len(childIds) + 1)
+	if err := bs.addStoredCountTx(tx, -blocksCount); err != nil {
+		return err
+	}
+
 	for _, childId := range childIds {
 		childEntry, err := bs.getBlockEntry(tx, childId, true)
 		if err != nil {
@@ -732,6 +762,56 @@ func (*BlockStorage) storedBlocksIter(tx db.RoTx) iter.Seq2[*blockEntry, error] 
 			}
 		}
 	}
+}
+
+func (bs *BlockStorage) addStoredCountTx(tx db.RwTx, delta int32) error {
+	currentBlocksCount, err := bs.getBlocksCountTx(tx)
+	if err != nil {
+		return err
+	}
+
+	signed := int32(currentBlocksCount) + delta
+	if signed < 0 {
+		return fmt.Errorf(
+			"blocks count cannot be negative: delta=%d, current blocks count=%d", delta, currentBlocksCount,
+		)
+	}
+
+	newBlocksCount := uint32(signed)
+	if newBlocksCount > bs.config.CapacityLimit {
+		return fmt.Errorf(
+			"%w: batch size is %d, current storage size is %d, capacity limit is %d",
+			ErrCapacityLimitReached, delta, currentBlocksCount, bs.config.CapacityLimit,
+		)
+	}
+
+	return bs.putBlocksCountTx(tx, newBlocksCount)
+}
+
+func (bs *BlockStorage) getBlocksCountTx(tx db.RoTx) (uint32, error) {
+	bytes, err := tx.Get(storedBlocksCountTable, mainShardKey)
+	switch {
+	case err == nil:
+		break
+	case errors.Is(err, db.ErrKeyNotFound):
+		return 0, nil
+	default:
+		return 0, fmt.Errorf("failed to get blocks count: %w", err)
+	}
+
+	count := binary.LittleEndian.Uint32(bytes)
+	return count, nil
+}
+
+func (bs *BlockStorage) putBlocksCountTx(tx db.RwTx, newValue uint32) error {
+	bytes := make([]byte, 4)
+	binary.LittleEndian.PutUint32(bytes, newValue)
+
+	err := tx.Put(storedBlocksCountTable, mainShardKey, bytes)
+	if err != nil {
+		return fmt.Errorf("failed to put blocks count: %w (newValue is %d)", err, newValue)
+	}
+	return nil
 }
 
 func marshallEntry(entry *blockEntry) ([]byte, error) {

--- a/nil/services/synccommittee/internal/storage/errors.go
+++ b/nil/services/synccommittee/internal/storage/errors.go
@@ -3,7 +3,8 @@ package storage
 import "errors"
 
 var (
-	ErrTaskAlreadyExists   = errors.New("task with a given identifier already exists")
-	ErrSerializationFailed = errors.New("failed to serialize/deserialize object")
-	errNilTaskEntry        = errors.New("task entry cannot be nil")
+	ErrTaskAlreadyExists    = errors.New("task with a given identifier already exists")
+	ErrSerializationFailed  = errors.New("failed to serialize/deserialize object")
+	ErrCapacityLimitReached = errors.New("storage capacity limit reached")
+	errNilTaskEntry         = errors.New("task entry cannot be nil")
 )

--- a/nil/services/synccommittee/internal/types/block_batch.go
+++ b/nil/services/synccommittee/internal/types/block_batch.go
@@ -102,6 +102,10 @@ func validateBatch(mainShardBlock *jsonrpc.RPCBlock, childBlocks []*jsonrpc.RPCB
 	return nil
 }
 
+func (b *BlockBatch) BlocksCount() uint32 {
+	return uint32(len(b.ChildBlocks) + 1)
+}
+
 func (b *BlockBatch) AllBlocks() []*jsonrpc.RPCBlock {
 	blocks := make([]*jsonrpc.RPCBlock, 0, len(b.ChildBlocks)+1)
 	blocks = append(blocks, b.MainShardBlock)


### PR DESCRIPTION
### Sync Committee: BlockStorage Capacity Limit

In case if number of blocks stored in the `BlockStorage` increases a certain amount, state reset process failed due to 
violation of Badger transaction size limit: `Txn is too big to fit into one request`

We need to prevent Sync Committee storage from growing indefinitely in case the prover network is down or unresponsive by introducing a capacity limit for the storage:

* Introduced a configurable capacity limit for `BlockStorage` with default settings and validation logic. Stored blocks counted is increased in `SetBlockBatch` and decreased in two scenarios:
a) Once block is proposed and removed from the storage - in `BlockStorage.SetBlockAsProposed(...)` method;
b) During state reset process when `BlockStorage` is fully or partially purged;

TODO: handle `ErrCapacityLimitReached` on the `Aggregator` side