### PR TITLE
[loadgen] main-keys-path parameter removed

### DIFF
--- a/nil/cmd/nil_load_generator/main.go
+++ b/nil/cmd/nil_load_generator/main.go
@@ -30,7 +30,6 @@ func main() {
 	rootCmd.Flags().StringVar(&cfg.ThresholdAmount, "threshold-amount", "3000000000", "threshold amount")
 	rootCmd.Flags().StringVar(&cfg.SwapAmount, "swap-amount", "1000", "swap amount")
 	rootCmd.Flags().StringVar(&cfg.RpcSwapLimit, "rpc-swap-limit", "10000000", "rpc swap limit")
-	rootCmd.Flags().StringVar(&cfg.MainKeysPath, "main-keys-path", "keys.yaml", "path to keys.yaml")
 	rootCmd.Flags().Uint32Var(&cfg.UniswapAccounts, "rpc-uniswap-accounts", 5, "number of uniswap accounts")
 	rootCmd.Flags().StringVar(&cfg.LogLevel, "log-level", "info", "log level: trace|debug|info|warn|error|fatal|panic")
 

--- a/nil/services/nil_load_generator/service.go
+++ b/nil/services/nil_load_generator/service.go
@@ -12,7 +12,6 @@ import (
 	rpc_client "github.com/NilFoundation/nil/nil/client/rpc"
 	"github.com/NilFoundation/nil/nil/common/logging"
 	"github.com/NilFoundation/nil/nil/internal/contracts"
-	"github.com/NilFoundation/nil/nil/internal/execution"
 	"github.com/NilFoundation/nil/nil/internal/types"
 	"github.com/NilFoundation/nil/nil/services/cliservice"
 	"github.com/NilFoundation/nil/nil/services/faucet"
@@ -39,7 +38,6 @@ type Config struct {
 	SwapAmount       string
 	UniswapAccounts  uint32
 	ThresholdAmount  string
-	MainKeysPath     string
 }
 
 var (
@@ -311,13 +309,7 @@ func Run(ctx context.Context, cfg Config, logger zerolog.Logger) error {
 		return err
 	}
 
-	mainPrivateKey, err := execution.LoadMainKeys(cfg.MainKeysPath)
-	if err != nil {
-		handler.RecordError(ctx)
-		return err
-	}
-
-	service := cliservice.NewService(ctx, client, mainPrivateKey, faucet)
+	service := cliservice.NewService(ctx, client, nil, faucet)
 	shardIdList, err := client.GetShardIdList(ctx)
 	if err != nil {
 		handler.RecordError(ctx)

--- a/nil/tests/nil_load_generator_service/nil_load_generator_test.go
+++ b/nil/tests/nil_load_generator_service/nil_load_generator_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/NilFoundation/nil/nil/common/logging"
-	"github.com/NilFoundation/nil/nil/internal/execution"
 	"github.com/NilFoundation/nil/nil/internal/types"
 	"github.com/NilFoundation/nil/nil/services/faucet"
 	"github.com/NilFoundation/nil/nil/services/nil_load_generator"
@@ -36,14 +35,23 @@ func (s *NilLoadGeneratorRpc) SetupTest() {
 	s.faucetClient, faucetEndpoint = tests.StartFaucetService(s.T(), s.Context, &s.Wg, s.Client)
 	time.Sleep(time.Second)
 
-	keyFile := s.T().TempDir() + "/key.yaml"
-	s.Require().NoError(execution.DumpMainKeys(keyFile, execution.MainPrivateKey))
-
 	s.runErrCh = make(chan error, 1)
 	s.Wg.Add(1)
 	go func() {
 		defer s.Wg.Done()
-		if err := nil_load_generator.Run(s.Context, nil_load_generator.Config{OwnEndpoint: nilLoadGeneratorSockPath, Endpoint: sockPath, FaucetEndpoint: faucetEndpoint, SwapPerIteration: 1, RpcSwapLimit: "10000000", MintTokenAmount0: "3000000", MintTokenAmount1: "10000", ThresholdAmount: "3000000000", SwapAmount: "1000", MainKeysPath: keyFile},
+		if err := nil_load_generator.Run(
+			s.Context,
+			nil_load_generator.Config{
+				OwnEndpoint:      nilLoadGeneratorSockPath,
+				Endpoint:         sockPath,
+				FaucetEndpoint:   faucetEndpoint,
+				SwapPerIteration: 1,
+				RpcSwapLimit:     "10000000",
+				MintTokenAmount0: "3000000",
+				MintTokenAmount1: "10000",
+				ThresholdAmount:  "3000000000",
+				SwapAmount:       "1000",
+			},
 			logging.NewLogger("test_nil_load_generator")); err != nil {
 			s.runErrCh <- err
 		} else {


### PR DESCRIPTION
`cliservice.NewService` accepts the private key of the smart account, with which the corresponding smart account management commands will work. We don't use `MainSmartAccount` for anything in the load generator, so we don't need credentials from it. Instead, we use `Faucet`, which does not require authentication.

At the same time, the presence of the flag introduces an inconvenience for local debugging. Since `MainPrivateKey` is now only saved to the filesystem when using `nil gen-configs`, we can't just do a `nil run` and then direct the load generator to that instance, we have nowhere to get the `MainPrivateKey` file. I think this adds an inconvenience that is not necessary at all in this case. Let our tools require as much bodywork as possible for a minimally working setup.

N.B. Also need to roll back the corresponding [PR](https://github.com/NilFoundation/infra/pull/586) in `infra`