### PR TITLE
[otel] fix semconv version

### DIFF
--- a/nil/internal/telemetry/internal/resource.go
+++ b/nil/internal/telemetry/internal/resource.go
@@ -2,7 +2,7 @@ package internal
 
 import (
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.27.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0" // Be sure otelcol support it before update
 )
 
 func NewResource(config *Config) (*resource.Resource, error) {

--- a/nix/nil.nix
+++ b/nix/nil.nix
@@ -49,7 +49,7 @@ buildGo124Module rec {
   ];
 
   # to obtain run `nix build` with vendorHash = "";
-  vendorHash = "sha256-Cqkos2JACh9qV+cFSUanOQ/JHzbftlvUfHXoRZ2VbQQ=";
+  vendorHash = "sha256-b3yEYGngHgencOGoptOD41aBlK2OdVo4Z7LtYCkutd0=";
   hardeningDisable = [ "all" ];
 
   postInstall = ''


### PR DESCRIPTION
To fix following issue on nildev:
```
ERROR=failed to initialize metric provider: conflicting Schema URL: https://opentelemetry.io/schemas/1.26.0 and https://opentelemetry.io/schemas/1.27.0
    JSON={"level":"error","component":"nil","error":"failed to initialize metric provider: conflicting Schema URL: https://opentelemetry.io/schemas/1.26.0 and https://opentelemetry.io/schemas/1.27.0","caller":"github.com/NilFoundation/nil/nil/services/nilservice/service.go:351","time":"2025-03-04T16:59:45Z","message":"Failed to initialize telemetry"}wq
```