### PR TITLE
Add a "governance" system contract that will be able to initiate rollbacks

### DIFF
--- a/nil/contracts/solidity/system/Governance.sol
+++ b/nil/contracts/solidity/system/Governance.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import "../lib/Nil.sol";
+
+contract Governance is NilBase {
+    address public constant SELF_ADDRESS =
+        address(0x777777777777777777777777777777777777);
+
+    function rollback(
+        uint32 version,
+        uint32 counter,
+        uint32 patchLevel,
+        uint64 mainBlockId,
+        uint32 /*replayDepth*/,
+        uint32 /*searchDepth*/
+    ) external onlyExternal {
+        Nil.rollback(
+            version,
+            counter,
+            patchLevel,
+            mainBlockId /*,
+            replayDepth,
+            searchDepth */
+        );
+    }
+
+    bytes pubkey;
+
+    constructor(bytes memory _pubkey) payable {
+        pubkey = _pubkey;
+    }
+
+    function verifyExternal(
+        uint256 hash,
+        bytes memory authData
+    ) external view returns (bool) {
+        return Nil.validateSignature(pubkey, hash, authData);
+    }
+}

--- a/nil/internal/config/generate.go
+++ b/nil/internal/config/generate.go
@@ -1,3 +1,3 @@
 package config
 
-//go:generate go run github.com/NilFoundation/fastssz/sszgen --path params.go -include ../types/address.go,../types/uint256.go,../types/transaction.go,../../common/hash.go,../../common/length.go --objs ListValidators,ParamValidators,ValidatorInfo,ParamGasPrice,ParamFees,ParamL1BlockInfo,WorkaroundToImportTypes
+//go:generate go run github.com/NilFoundation/fastssz/sszgen --path params.go -include ../types/address.go,../types/uint256.go,../types/transaction.go,../../common/hash.go,../../common/length.go --objs ListValidators,ParamValidators,ValidatorInfo,ParamGasPrice,ParamFees,ParamL1BlockInfo,ParamSudoKey,WorkaroundToImportTypes

--- a/nil/internal/contracts/contract.go
+++ b/nil/internal/contracts/contract.go
@@ -20,6 +20,7 @@ const (
 	NameNilBounceable = "NilBounceable"
 	NameNilConfigAbi  = "NilConfigAbi"
 	NameL1BlockInfo   = "system/L1BlockInfo"
+	NameGovernance    = "system/Governance"
 )
 
 var (

--- a/nil/internal/crypto/secp256k1.go
+++ b/nil/internal/crypto/secp256k1.go
@@ -1,6 +1,7 @@
 package crypto
 
 import (
+	"github.com/NilFoundation/nil/nil/common"
 	"github.com/holiman/uint256"
 )
 
@@ -14,7 +15,7 @@ func TransactionSignatureIsValid(v byte, r, s *uint256.Int) bool {
 }
 
 func TransactionSignatureIsValidBytes(sign []byte) bool {
-	if len(sign) != 65 {
+	if len(sign) != common.SignatureSize {
 		return false
 	}
 

--- a/nil/internal/execution/block_generator.go
+++ b/nil/internal/execution/block_generator.go
@@ -222,6 +222,8 @@ func (g *BlockGenerator) prepareExecutionState(proposal *Proposal, gasPrices []t
 	}
 
 	g.executionState.MainChainHash = proposal.MainChainHash
+	g.executionState.PatchLevel = proposal.PatchLevel
+	g.executionState.RollbackCounter = proposal.RollbackCounter
 
 	for _, txn := range proposal.InternalTxns {
 		if err := g.handleTxn(txn); err != nil {

--- a/nil/internal/execution/proposal.go
+++ b/nil/internal/execution/proposal.go
@@ -31,11 +31,13 @@ type InternalTxnReference struct {
 }
 
 type Proposal struct {
-	PrevBlockId   types.BlockNumber   `json:"prevBlockId"`
-	PrevBlockHash common.Hash         `json:"prevBlockHash"`
-	CollatorState types.CollatorState `json:"collatorState"`
-	MainChainHash common.Hash         `json:"mainChainHash"`
-	ShardHashes   []common.Hash       `json:"shardHashes"`
+	PrevBlockId     types.BlockNumber   `json:"prevBlockId"`
+	PrevBlockHash   common.Hash         `json:"prevBlockHash"`
+	PatchLevel      uint32              `json:"patchLevel"`
+	RollbackCounter uint32              `json:"rollbackCounter"`
+	CollatorState   types.CollatorState `json:"collatorState"`
+	MainChainHash   common.Hash         `json:"mainChainHash"`
+	ShardHashes     []common.Hash       `json:"shardHashes"`
 
 	InternalTxns []*types.Transaction `json:"internalTxns"`
 	ExternalTxns []*types.Transaction `json:"externalTxns"`
@@ -45,6 +47,10 @@ type Proposal struct {
 type ProposalSSZ struct {
 	PrevBlockId   types.BlockNumber
 	PrevBlockHash common.Hash
+
+	PatchLevel      uint32
+	RollbackCounter uint32
+
 	CollatorState types.CollatorState
 	MainChainHash common.Hash
 	ShardHashes   []common.Hash `ssz-max:"4096"`
@@ -154,11 +160,13 @@ func ConvertProposal(proposal *ProposalSSZ) (*Proposal, error) {
 	}
 
 	return &Proposal{
-		PrevBlockId:   proposal.PrevBlockId,
-		PrevBlockHash: proposal.PrevBlockHash,
-		CollatorState: proposal.CollatorState,
-		MainChainHash: proposal.MainChainHash,
-		ShardHashes:   proposal.ShardHashes,
+		PrevBlockId:     proposal.PrevBlockId,
+		PrevBlockHash:   proposal.PrevBlockHash,
+		PatchLevel:      proposal.PatchLevel,
+		RollbackCounter: proposal.RollbackCounter,
+		CollatorState:   proposal.CollatorState,
+		MainChainHash:   proposal.MainChainHash,
+		ShardHashes:     proposal.ShardHashes,
 
 		// todo: special txns should be validated
 		InternalTxns: append(proposal.SpecialTxns, internalTxns...),

--- a/nil/internal/execution/zerostate.go
+++ b/nil/internal/execution/zerostate.go
@@ -62,6 +62,7 @@ func CreateDefaultZeroStateConfig(mainPublicKey []byte) (*ZeroStateConfig, error
 			{Name: "BtcFaucet", Contract: "FaucetToken", Address: types.BtcFaucetAddress, Value: tokenValue},
 			{Name: "UsdcFaucet", Contract: "FaucetToken", Address: types.UsdcFaucetAddress, Value: tokenValue},
 			{Name: "L1BlockInfo", Contract: "system/L1BlockInfo", Address: types.L1BlockInfoAddress, Value: types.Value0},
+			{Name: "Governance", Contract: "system/Governance", Address: types.GovernanceAddress, Value: smartAccountValue, CtorArgs: []any{hexutil.Encode(mainPublicKey)}},
 		},
 	}
 	return zeroStateConfig, nil

--- a/nil/internal/types/address.go
+++ b/nil/internal/types/address.go
@@ -31,6 +31,7 @@ var (
 	BtcFaucetAddress        = ShardAndHexToAddress(BaseShardId, "111111111111111111111111111111111114")
 	UsdcFaucetAddress       = ShardAndHexToAddress(BaseShardId, "111111111111111111111111111111111115")
 	L1BlockInfoAddress      = ShardAndHexToAddress(MainShardId, "222222222222222222222222222222222222")
+	GovernanceAddress       = ShardAndHexToAddress(MainShardId, "777777777777777777777777777777777777")
 )
 
 func GetTokenName(addr TokenId) string {
@@ -96,16 +97,6 @@ func ShardAndHexToAddress(shardId ShardId, s string) Address {
 	}
 	setShardId(addr[:], shardId)
 	return addr
-}
-
-// IsHexAddress verifies whether a string can represent a valid hex-encoded
-// Ethereum address or not.
-func IsHexAddress(s string) bool {
-	if len(s) >= 2 && s[0] == '0' && (s[1] == 'x' || s[1] == 'X') {
-		s = s[2:]
-	}
-	_, err := hex.DecodeString(s)
-	return err == nil
 }
 
 // Bytes gets the string representation of the underlying address.

--- a/nil/internal/types/block.go
+++ b/nil/internal/types/block.go
@@ -50,6 +50,12 @@ type BlockData struct {
 	BaseFee             Value            `json:"gasPrice" ch:"gas_price"`
 	GasUsed             Gas              `json:"gasUsed" ch:"gas_used"`
 	L1BlockNumber       uint64           `json:"l1BlockNumber" ch:"l1_block_number"`
+
+	// Incremented after every rollback, used to prevent rollback replay attacks
+	RollbackCounter uint32 `json:"rollbackCounter" ch:"rollback_counter"`
+	// Required validator patchLevel, incremented if validator updates
+	// are required to mitigate an issue
+	PatchLevel uint32 `json:"patchLevel" ch:"patch_level"`
 }
 
 type ConsensusParams struct {

--- a/nil/internal/types/exec_errors.go
+++ b/nil/internal/types/exec_errors.go
@@ -148,8 +148,14 @@ const (
 	// ErrorPrecompileStateDbReturnedError is an internal error indicating that the Execution returned an error
 	ErrorPrecompileStateDbReturnedError
 	// ErrorOnlyMainShardContractsCanChangeConfig is returned when a contract from a shard other than the main one tries
-	// to change on-cahin config
+	// to change on-chain config
 	ErrorOnlyMainShardContractsCanChangeConfig
+	// ErrorPrecompileWrongCaller is returned when the caller of the precompile is not the expected one
+	ErrorPrecompileWrongCaller
+	// ErrorPrecompileWrongVersion is returned when the version of the precompile is not the expected one
+	ErrorPrecompileWrongVersion
+	// ErrorPrecompileBadArgument is returned when the precompile receives an invalid argument
+	ErrorPrecompileBadArgument
 	// ErrorPrecompileConfigSetParamFailed is returned when the precompile fails to set the config parameter
 	ErrorPrecompileConfigSetParamFailed
 	// ErrorPrecompileConfigGetParamFailed is returned when the precompile fails to get the config parameter

--- a/nil/internal/types/ssz_test.go
+++ b/nil/internal/types/ssz_test.go
@@ -36,7 +36,7 @@ func TestSszBlock(t *testing.T) {
 	h, err := common.PoseidonSSZ(&block2)
 	require.NoError(t, err)
 
-	h2, err := hex.DecodeString("19590a5f03cbb70db36b7cafa77b91e997d3e31fb344572cbad2afd31b90fce6")
+	h2, err := hex.DecodeString("305b9ab7546ad01a500dd57f29935bc43648d3f428b8b3a8869ab33c543940db")
 	require.NoError(t, err)
 
 	require.Equal(t, common.BytesToHash(h2), common.BytesToHash(h[:]))

--- a/nil/internal/vm/evm.go
+++ b/nil/internal/vm/evm.go
@@ -38,6 +38,8 @@ type BlockContext struct {
 	BaseFee     *big.Int      // Provides information for BASEFEE (0 if vm runs with NoBaseFee flag and 0 gas price)
 	BlobBaseFee *big.Int      // Provides information for BLOBBASEFEE (0 if vm runs with NoBaseFee flag and 0 blob gas price)
 	Random      *common.Hash  // Provides information for PREVRANDAO
+
+	RollbackCounter uint32 // Provides information for rollback handling
 }
 
 // TxContext provides the EVM with information about a transaction.

--- a/nil/internal/vm/interface.go
+++ b/nil/internal/vm/interface.go
@@ -105,6 +105,8 @@ type StateDB interface {
 	SaveVmState(state *types.EvmState, continuationGasCredit types.Gas) error
 
 	GetConfigAccessor() config.ConfigAccessor
+
+	Rollback(counter, patchLevel uint32, mainBlock uint64) error
 }
 
 // CallContext provides a basic interface for the EVM calling conventions. The EVM

--- a/nil/services/cliservice/block_format_test.go
+++ b/nil/services/cliservice/block_format_test.go
@@ -147,7 +147,7 @@ func TestDebugBlockToText(t *testing.T) {
 		text, err := s.debugBlockToText(types.ShardId(13), block, false, false)
 		require.NoError(t, err)
 
-		expectedText := `Block #100500 [0x000d9bb830d574ddf2973a367f2fe9d899c7c523afb809a1a7d2480ab9bcd4cf] @ 13 shard
+		expectedText := `Block #100500 [0x000dad995dc84952f5631bfba6237a9a77520053aa6f282a6471dd1ea1af6a89] @ 13 shard
   PrevBlock: 0x00000000000000000000000000000000000000000000000000000000deadbeef
   ChildBlocksRootHash: 0x00000000000000000000000000000000000000000000000000000000deadbabe
   ChildBlocks:

--- a/nil/services/rpc/jsonrpc/types.go
+++ b/nil/services/rpc/jsonrpc/types.go
@@ -73,6 +73,8 @@ type RPCBlock struct {
 	Number              types.BlockNumber   `json:"number"`
 	Hash                common.Hash         `json:"hash"`
 	ParentHash          common.Hash         `json:"parentHash"`
+	PatchLevel          uint32              `json:"patchLevel"`
+	RollbackCounter     uint32              `json:"rollbackCounter"`
 	InTransactionsRoot  common.Hash         `json:"inTransactionsRoot"`
 	ReceiptsRoot        common.Hash         `json:"receiptsRoot"`
 	ChildBlocksRootHash common.Hash         `json:"childBlocksRootHash"`
@@ -379,6 +381,8 @@ func NewRPCBlock(shardId types.ShardId, data *BlockWithEntities, fullTx bool) (*
 		Number:              blockId,
 		Hash:                blockHash,
 		ParentHash:          block.PrevBlock,
+		PatchLevel:          block.PatchLevel,
+		RollbackCounter:     block.RollbackCounter,
 		InTransactionsRoot:  block.InTransactionsRoot,
 		ReceiptsRoot:        block.ReceiptsRoot,
 		ChildBlocksRootHash: block.ChildBlocksRootHash,

--- a/nil/services/synccommittee/prover/tracer/state_db.go
+++ b/nil/services/synccommittee/prover/tracer/state_db.go
@@ -667,6 +667,10 @@ func (tsdb *TracerStateDB) Selfdestruct6780(types.Address) error {
 	return errors.New("not implemented")
 }
 
+func (tsdb *TracerStateDB) Rollback(_, _ uint32, _ uint64) error {
+	return errors.New("not implemented")
+}
+
 // Exist reports whether the given account exists in state.
 // Notably this should also return true for self-destructed accounts.
 func (tsdb *TracerStateDB) Exists(address types.Address) (bool, error) {

--- a/nil/tests/governance/rollback_test.go
+++ b/nil/tests/governance/rollback_test.go
@@ -1,0 +1,62 @@
+package governance
+
+import (
+	"testing"
+
+	"github.com/NilFoundation/nil/nil/internal/collate"
+	"github.com/NilFoundation/nil/nil/internal/execution"
+	"github.com/NilFoundation/nil/nil/internal/types"
+	"github.com/NilFoundation/nil/nil/services/nilservice"
+	"github.com/NilFoundation/nil/nil/services/rpc"
+	"github.com/NilFoundation/nil/nil/services/rpc/transport"
+	"github.com/NilFoundation/nil/nil/tests"
+	"github.com/stretchr/testify/suite"
+)
+
+const numShards = 4
+
+type RollbackSuite struct {
+	tests.RpcSuite
+}
+
+func (s *RollbackSuite) SetupTest() {
+	s.Start(&nilservice.Config{
+		NShards:              numShards,
+		HttpUrl:              rpc.GetSockPath(s.T()),
+		CollatorTickPeriodMs: 300,
+		RunMode:              nilservice.CollatorsOnlyRunMode,
+	})
+}
+
+func (s *RollbackSuite) TearDownTest() {
+	s.Cancel()
+}
+
+func (s *RollbackSuite) TestSendRollbackTx() {
+	params := &execution.RollbackParams{
+		Version:     1,
+		Counter:     0,
+		PatchLevel:  1,
+		MainBlockId: 2,
+		ReplayDepth: 3,
+		SearchDepth: 4,
+	}
+
+	calldata, err := collate.CreateRollbackCalldata(params)
+	s.Require().NoError(err)
+
+	receipt := s.SendExternalTransaction(calldata, types.GovernanceAddress)
+	s.Require().NotNil(receipt)
+	s.True(receipt.Success)
+
+	// Check that the patchLevel has been updated
+	block, err := s.Client.GetBlock(s.Context, types.MainShardId, transport.BlockNumber(receipt.BlockNumber), false)
+	s.Require().NoError(err)
+	s.Equal(uint32(1), block.PatchLevel)
+}
+
+func TestRollback(t *testing.T) {
+	t.Parallel()
+
+	suite.Run(t, &RollbackSuite{})
+}

--- a/nil/tests/rpc_suite.go
+++ b/nil/tests/rpc_suite.go
@@ -227,13 +227,6 @@ func (s *RpcSuite) SendTransactionViaSmartAccountNoCheck(addrSmartAccount types.
 	return receipt
 }
 
-func (s *RpcSuite) SendRawTransaction(data []byte) *jsonrpc.RPCReceipt {
-	txHash, err := s.Client.SendRawTransaction(s.Context, data)
-	s.Require().NoError(err)
-	receipt := s.WaitIncludedInMain(txHash)
-	return receipt
-}
-
 func (s *RpcSuite) CallGetter(addr types.Address, calldata []byte, blockId any, overrides *jsonrpc.StateOverrides) []byte {
 	s.T().Helper()
 	return CallGetter(s.T(), s.Context, s.Client, addr, calldata, blockId, overrides)

--- a/smart-contracts/contracts/Nil.sol
+++ b/smart-contracts/contracts/Nil.sol
@@ -29,6 +29,7 @@ library Nil {
     address private constant SEND_REQUEST = address(0xd8);
     address public constant IS_RESPONSE_TRANSACTION = address(0xd9);
     address public constant LOG = address(0xda);
+    address public constant GOVERNANCE = address(0xdb);
 
     // The following constants specify from where and how the gas should be taken during async call.
     // Forwarding values are calculated in the following order: FORWARD_VALUE, FORWARD_PERCENTAGE, FORWARD_REMAINING.
@@ -374,6 +375,22 @@ library Nil {
     }
 
     /**
+     * @dev Initiates a rollback
+     *
+     * Unused parameters are temporarily commented out.
+     */
+    function rollback(
+        uint32 version,
+        uint32 counter,
+        uint32 patchLevel,
+        uint64 mainBlockId /*,
+        uint32 replayDepth,
+        uint32 searchDepth */
+    ) internal {
+        __Precompile__(GOVERNANCE).precompileRollback(version, counter, patchLevel, mainBlockId /*, replayDepth, searchDepth */);
+    }
+
+    /**
      * @dev Sets a configuration parameter.
      * @param name Name of the parameter.
      * @param data Data of the parameter.
@@ -508,6 +525,7 @@ contract __Precompile__ {
     function precompileGetPoseidonHash(bytes memory data) public returns(uint256) {}
     function precompileConfigParam(bool isSet, string calldata name, bytes calldata data) public returns(bytes memory) {}
     function precompileLog(string memory transaction, int[] memory data) public returns(bool) {}
+    function precompileRollback(uint32, uint32, uint32, uint64 /*, uint32, uint32*/) public returns(bool) {}
 }
 
 contract NilConfigAbi {

--- a/smart-contracts/contracts/SmartAccount.sol
+++ b/smart-contracts/contracts/SmartAccount.sol
@@ -6,9 +6,11 @@ import "./NilTokenBase.sol";
 
 /**
  * @title SmartAccount
- * @dev Basic Smart Account contract which provides functional for calling another contracts and sending tokens.
- * It also supports multi-token functionality providing methods for minting and sending token.
- * NilTokenBase class implements functional for managing own token(where `tokenId = address(this)`).
+ * @dev Basic Smart Account contract that provides functionality for interacting
+ * with other contracts and sending tokens.  It also supports multi-token
+ * functionality, including methods for minting and sending tokens.
+ * The NilTokenBase class implements functionality for managing the contract's own
+ * token (where `tokenId = address(this)`).
  */
 contract SmartAccount is NilTokenBase {
     bytes pubkey;


### PR DESCRIPTION
During network launch, we may encounter misconfigurations, vulnerabilities or bugs in the validators or the provers that may result in malicious or breaking changes to the state of the blockchain. One way to deal with them at early stages of the mainnet is "rolling back" to a known good state when an authority decides to do so.

This patch adds a "governance" system contract on the main shard and a corresponding precompile, accepting rollback transactions signed by a "sudo key" (currently the same as the "main key" of the built-in system smart account). The rollback functionality itself will be implemented by following patches.