### PR TITLE
[proposer] Fix internal txn counting

### DIFF
--- a/nil/internal/collate/proposer_test.go
+++ b/nil/internal/collate/proposer_test.go
@@ -148,6 +148,7 @@ func (s *ProposerTestSuite) TestCollator() {
 
 	// Now process internal transactions by one to test queueing.
 	p.params.MaxInternalTransactionsInBlock = 1
+	pool.Reset()
 
 	s.Run("ProcessInternalTransaction1", func() {
 		generateBlock()
@@ -181,10 +182,10 @@ func (s *ProposerTestSuite) TestCollator() {
 
 		proposal := generateBlock()
 		s.Empty(proposal.ExternalTxns)
-		s.Len(proposal.InternalTxns, 2)
+		s.Empty(proposal.InternalTxns)
 		s.Empty(proposal.ForwardTxns)
 		s.Equal([]common.Hash{m1.Hash(), m2.Hash()}, pool.LastDiscarded)
-		s.Equal(txnpool.DuplicateHash, pool.LastReason)
+		s.Equal(txnpool.Unverified, pool.LastReason)
 	})
 
 	s.Run("Deploy", func() {


### PR DESCRIPTION
Removed redundant check on duplicates (the seqno is checked within external validation, which is a more general check than full duplicates).

And also found a problem with the latest proposer fix: if it stops collecting txns when the block is full, it fails to increment its position. Only when all internal txns are processed, the proposer position is updated correctly.
This lead to duplicating internal txns in the test.
The fix is moving `checkLimits()` to the loop condition.