### PR TITLE
relax block gen unix socket permissions

### DIFF
--- a/nil/cmd/nil_block_generator/internal/commands/config.go
+++ b/nil/cmd/nil_block_generator/internal/commands/config.go
@@ -13,6 +13,7 @@ const (
 	configFilePath = "config.json"
 	nilDBPath      = "test.db"
 	fileMode       = 0o666
+	directoryMode  = 0o744
 )
 
 type Contract struct {
@@ -167,7 +168,7 @@ func ShowCalls(writer io.StringWriter) error {
 }
 
 func GetSockPath() (string, error) {
-	err := os.Mkdir(socketDir, fileMode)
+	err := os.Mkdir(socketDir, directoryMode)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
0o666 is too strict mode which makes impossible to operate on the domain socket after nil_block_generator finishes its work. Relaxing it to owner RW priveleges