### PR TITLE
Set GasPrice metrics only after update them

### DIFF
--- a/nil/internal/execution/block_generator.go
+++ b/nil/internal/execution/block_generator.go
@@ -286,13 +286,15 @@ func (g *BlockGenerator) BuildBlock(proposal *Proposal, gasPrices []types.Uint25
 }
 
 func (g *BlockGenerator) GenerateBlock(proposal *Proposal, params *types.ConsensusParams) (*BlockGenerationResult, error) {
-	g.mh.StartProcessingMeasurement(g.ctx, g.executionState.GasPrice, proposal.PrevBlockId+1)
+	g.mh.StartProcessingMeasurement(g.ctx, proposal.PrevBlockId+1)
 	defer func() { g.mh.EndProcessingMeasurement(g.ctx, g.counters) }()
 
 	gasPrices := g.CollectGasPrices(proposal.PrevBlockId)
 	if err := g.prepareExecutionState(proposal, gasPrices); err != nil {
 		return nil, err
 	}
+
+	g.mh.RecordGasPrice(g.ctx, g.executionState.GasPrice)
 
 	if err := db.WriteCollatorState(g.rwTx, g.params.ShardId, proposal.CollatorState); err != nil {
 		return nil, fmt.Errorf("failed to write collator state: %w", err)

--- a/nil/internal/execution/metrics.go
+++ b/nil/internal/execution/metrics.go
@@ -107,9 +107,12 @@ func (mh *MetricsHandler) initMetrics(meter metric.Meter) error {
 	return nil
 }
 
-func (mh *MetricsHandler) StartProcessingMeasurement(ctx context.Context, gasPrice types.Value, blockId types.BlockNumber) {
-	mh.measurer.Restart()
+func (mh *MetricsHandler) RecordGasPrice(ctx context.Context, gasPrice types.Value) {
 	mh.gasPrice.Record(ctx, int64(gasPrice.Uint64()), mh.option)
+}
+
+func (mh *MetricsHandler) StartProcessingMeasurement(ctx context.Context, blockId types.BlockNumber) {
+	mh.measurer.Restart()
 	mh.blockId.Record(ctx, int64(blockId), mh.option)
 }
 


### PR DESCRIPTION
Currently GasPrice in metrics always zero because we record them before update.