### PR TITLE
[txpool] Fix bug in transactions retrieving

### DIFF
--- a/nil/services/txnpool/meta_txn.go
+++ b/nil/services/txnpool/meta_txn.go
@@ -22,6 +22,15 @@ func newMetaTxn(txn *types.Transaction, baseFee types.Value) *metaTxn {
 	}
 }
 
+func (m *metaTxn) Clone() *metaTxn {
+	return &metaTxn{
+		TxnWithHash:          m.TxnWithHash,
+		effectivePriorityFee: m.effectivePriorityFee,
+		bestIndex:            m.bestIndex,
+		valid:                m.valid,
+	}
+}
+
 func (m *metaTxn) IsValid() bool {
 	return m.valid
 }

--- a/nil/services/txnpool/txnpool.go
+++ b/nil/services/txnpool/txnpool.go
@@ -415,6 +415,7 @@ func (p *TxnPool) Peek(n int) ([]*types.TxnWithHash, error) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
+	// Peek algorithm will alter the queue, so we need to clone it first.
 	q := p.queue.Clone()
 	res := make([]*types.TxnWithHash, 0, q.Len())
 
@@ -423,7 +424,7 @@ func (p *TxnPool) Peek(n int) ([]*types.TxnWithHash, error) {
 		check.PanicIfNot(ok)
 		res = append(res, txn.TxnWithHash)
 		if txn = p.nextSenderTxnLocked(txn.To, txn.Seqno); txn != nil {
-			heap.Push(q, txn)
+			heap.Push(q, txn.Clone())
 		}
 	}
 

--- a/nil/services/txnpool/txnpool_test.go
+++ b/nil/services/txnpool/txnpool_test.go
@@ -339,6 +339,16 @@ func (s *SuiteTxnPool) TestNetwork() {
 	}, 20*time.Second, 200*time.Millisecond)
 }
 
+func (s *SuiteTxnPool) TestUnverifiedDuplicates() {
+	txn1 := newTransaction(defaultAddress, 0, 123)
+	txn2 := newTransaction(defaultAddress, 1, 123)
+
+	s.addTransactionsSuccessfully(txn1, txn2)
+
+	err := s.pool.Discard(s.ctx, []common.Hash{txn1.Hash(), txn2.Hash()}, DuplicateHash)
+	s.Require().NoError(err)
+}
+
 func (s *SuiteTxnPool) checkTransactionsOrder(vals ...int) {
 	s.T().Helper()
 

--- a/nil/tests/basic/basic_test.go
+++ b/nil/tests/basic/basic_test.go
@@ -897,6 +897,22 @@ func (s *SuiteRpc) TestRpcTransactionContent() {
 	s.EqualValues(3, txn2.Flags.Bits)
 }
 
+func (s *SuiteRpc) TestTwoInvalidSignatureTxs() {
+	shardId := types.BaseShardId
+	_, _, err := s.Client.DeployContract(s.Context, shardId, types.MainSmartAccountAddress,
+		contracts.CounterDeployPayload(s.T()), types.Value{}, types.NewFeePackFromGas(1_000_000), nil)
+	s.Require().NoError(err)
+
+	_, _, err = s.Client.DeployContract(s.Context, shardId, types.MainSmartAccountAddress,
+		contracts.CounterDeployPayload(s.T()), types.Value{}, types.NewFeePackFromGas(1_000_000), nil)
+	s.Require().NoError(err)
+
+	block, err := s.Client.GetBlock(s.Context, shardId, "latest", false)
+	s.Require().NoError(err)
+
+	tests.WaitBlock(s.T(), s.Context, s.Client, shardId, uint64(block.Number)+1)
+}
+
 func (s *SuiteRpc) TestDbApi() {
 	block, err := s.Client.GetBlock(s.Context, types.BaseShardId, transport.LatestBlockNumber, false)
 	s.Require().NoError(err)


### PR DESCRIPTION
`Peek` method should be constant and should not modify content of txpool. But it did by calling `heap.Push(q, txn)`, because txn refers to the real metaTx and its `bestIndex` is changed.
Fixed by cloning it. Also added reset of `bestIndex` during popping from the queue.