### PR TITLE
[collate] add wait main shard block logic to block replay 

### DIFF
--- a/nil/internal/collate/scheduler.go
+++ b/nil/internal/collate/scheduler.go
@@ -42,7 +42,6 @@ type Params struct {
 
 type Scheduler struct {
 	consensus      Consensus
-	syncer         *Syncer
 	txFabric       db.DB
 	validator      *Validator
 	networkManager *network.Manager
@@ -73,11 +72,8 @@ func (s *Scheduler) Validator() *Validator {
 	return s.validator
 }
 
-func (s *Scheduler) Run(ctx context.Context, syncer *Syncer, consensus Consensus) error {
-	syncer.WaitComplete()
-
+func (s *Scheduler) Run(ctx context.Context, consensus Consensus) error {
 	s.logger.Info().Msg("Starting collation...")
-	s.syncer = syncer
 
 	// Enable handler for blocks relaying
 	SetRequestHandler(ctx, s.networkManager, s.params.ShardId, s.txFabric, s.logger)
@@ -115,8 +111,8 @@ func (s *Scheduler) doCollate(ctx context.Context) error {
 			return err
 		}
 
-		subId, syncCh := s.syncer.Subscribe()
-		defer s.syncer.Unsubscribe(subId)
+		subId, syncCh := s.validator.Subscribe()
+		defer s.validator.Unsubscribe(subId)
 
 		ctx, cancelFn := context.WithCancel(ctx)
 		defer cancelFn()

--- a/nil/services/nilservice/service.go
+++ b/nil/services/nilservice/service.go
@@ -618,7 +618,7 @@ func createShards(
 				if err := consensus.Init(ctx); err != nil {
 					return err
 				}
-				if err := collator.Run(ctx, syncers.syncers[i], consensus); err != nil {
+				if err := collator.Run(ctx, consensus); err != nil {
 					logger.Error().
 						Err(err).
 						Stringer(logging.FieldShardId, shardId).

--- a/nil/services/nilservice/service.go
+++ b/nil/services/nilservice/service.go
@@ -573,7 +573,7 @@ func createValidators(ctx context.Context, cfg *Config, database db.DB, networkM
 			}
 		}
 
-		list[i] = collate.NewValidator(params, database, txpool, networkManager)
+		list[i] = collate.NewValidator(params, list[0], database, txpool, networkManager)
 	}
 	return list, nil
 }


### PR DESCRIPTION
It's possible case that during block replay specific block.mainShardHash
is not available. That shouldn't happen normally since we replay main shard
really fast.
But because of network issues or something else it can be a problem.
So this patch adds simple logic that tries to wait expected block using
subscriptions.