### PR TITLE
fix: wrap injected script in IIFE to prevent global variable leaks

### DIFF
--- a/wallet-extension/vite.contentScript-nil.ts
+++ b/wallet-extension/vite.contentScript-nil.ts
@@ -14,6 +14,8 @@ export default defineConfig({
         injected: resolve(root, 'contentScripts', 'nil.ts')
       },
       output: {
+        format: 'iife',
+        name: 'NilWalletInjected',
         entryFileNames: 'nil.js', // Generate single file for each input
       },
     },


### PR DESCRIPTION
## Description

This fix updates the Vite build configuration for the injected script (nil.ts) by switching the output format to 'iife' and adding a unique global name. This change ensures the entire bundle is wrapped in an isolated function scope, preventing internal variables from leaking into the page's global context

Fixed https://github.com/NilFoundation/nil/issues/484