### PR TITLE
[network] Introduce relay + refactor cmd flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GO_DBG_BUILD = GOPRIVATE="$(GOPRIVATE)" $(GO) build -tags $(BUILD_TAGS),debug,as
 GOTEST = GOPRIVATE="$(GOPRIVATE)" GODEBUG=cgocheck=0 $(GO) test -tags $(BUILD_TAGS),debug,assert,test $(GO_FLAGS) ./... -p 2
 
 SC_COMMANDS = sync_committee sync_committee_cli proof_provider prover nil_block_generator
-COMMANDS += nild nil nil_load_generator exporter cometa faucet journald_forwarder $(SC_COMMANDS)
+COMMANDS += nild nil nil_load_generator exporter cometa faucet journald_forwarder relay $(SC_COMMANDS)
 
 all: $(COMMANDS)
 

--- a/nil/cmd/exporter/main.go
+++ b/nil/cmd/exporter/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/NilFoundation/nil/nil/cmd/exporter/internal/clickhouse"
 	"github.com/NilFoundation/nil/nil/common/check"
 	"github.com/NilFoundation/nil/nil/common/logging"
+	"github.com/NilFoundation/nil/nil/internal/cobrax"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -41,16 +42,6 @@ func initConfig() {
 	viper.AutomaticEnv()
 }
 
-// This makes the --help command exit instead of proceeding to run
-// the exporter
-func ApplyExitOnHelp(c *cobra.Command, exitCode int) {
-	helpFunc := c.HelpFunc()
-	c.SetHelpFunc(func(c *cobra.Command, s []string) {
-		helpFunc(c, s)
-		os.Exit(exitCode)
-	})
-}
-
 func main() {
 	logging.SetLogSeverityFromEnv()
 	logging.SetupGlobalLogger("info")
@@ -78,7 +69,7 @@ You could config it via config file or flags or environment variables.`,
 			}
 		},
 	}
-	ApplyExitOnHelp(rootCmd, 0)
+	cobrax.ExitOnHelp(rootCmd)
 
 	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file (default is $CWD/exporter.cobra.yaml)")
 	rootCmd.Flags().StringP("api-endpoint", "a", "http://127.0.0.1:8529", "API endpoint")

--- a/nil/cmd/nild/devnet.go
+++ b/nil/cmd/nild/devnet.go
@@ -312,7 +312,7 @@ func (devnet *devnet) writeServerConfig(instanceId int, srv server, only string)
 	cfg.ZeroState = devnet.zeroState
 
 	var err error
-	cfg.NetworkKeysPath, err = filepath.Abs(srv.NetworkKeysFile())
+	cfg.Network.KeysPath, err = filepath.Abs(srv.NetworkKeysFile())
 	if err != nil {
 		return fmt.Errorf("failed to get absolute path for network keys: %w", err)
 	}

--- a/nil/cmd/relay/main.go
+++ b/nil/cmd/relay/main.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"context"
+	"os/signal"
+	"syscall"
+
+	"github.com/NilFoundation/nil/nil/common/check"
+	"github.com/NilFoundation/nil/nil/common/logging"
+	"github.com/NilFoundation/nil/nil/internal/cobrax"
+	"github.com/NilFoundation/nil/nil/internal/cobrax/cmdflags"
+	"github.com/NilFoundation/nil/nil/internal/network"
+	"github.com/NilFoundation/nil/nil/internal/profiling"
+	"github.com/NilFoundation/nil/nil/internal/telemetry"
+	"github.com/spf13/cobra"
+)
+
+type config struct {
+	LogLevel  string `yaml:"logLevel,omitempty"`
+	PprofPort int    `yaml:"pprofPort,omitempty"`
+
+	Network   *network.Config   `yaml:"network,omitempty"`
+	Telemetry *telemetry.Config `yaml:"telemetry,omitempty"`
+}
+
+func parseArgs() *config {
+	cfg := &config{
+		Network:   network.NewDefaultConfig(),
+		Telemetry: telemetry.NewDefaultConfig(),
+	}
+	cfg.Network.Relay = true
+
+	check.PanicIfErr(cobrax.LoadConfigFromFile(cobrax.GetConfigNameFromArgs(), cfg))
+
+	rootCmd := &cobra.Command{
+		Use:           "relay [flags]",
+		Short:         "relay for nild cluster network",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+
+	cobrax.AddConfigFlag(rootCmd.Flags())
+	cobrax.AddLogLevelFlag(rootCmd.Flags(), &cfg.LogLevel)
+	cobrax.AddPprofPortFlag(rootCmd.Flags(), &cfg.PprofPort)
+	cmdflags.AddNetwork(rootCmd.Flags(), cfg.Network)
+	cmdflags.AddTelemetry(rootCmd.Flags(), cfg.Telemetry)
+
+	rootCmd.AddCommand(cobrax.VersionCmd("relay"))
+
+	check.PanicIfErr(rootCmd.Execute())
+
+	return cfg
+}
+
+func main() {
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer cancel()
+
+	cfg := parseArgs()
+
+	logging.SetupGlobalLogger(cfg.LogLevel)
+	profiling.Start(cfg.PprofPort)
+
+	check.PanicIfErr(telemetry.Init(ctx, cfg.Telemetry))
+	defer telemetry.Shutdown(ctx)
+
+	nm, err := network.NewManager(ctx, cfg.Network)
+	check.PanicIfErr(err)
+	defer nm.Close()
+
+	<-ctx.Done()
+}

--- a/nil/internal/cobrax/cmdflags/network.go
+++ b/nil/internal/cobrax/cmdflags/network.go
@@ -1,0 +1,18 @@
+package cmdflags
+
+import (
+	"github.com/NilFoundation/nil/nil/common/check"
+	"github.com/NilFoundation/nil/nil/internal/network"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+func AddNetwork(fset *pflag.FlagSet, cfg *network.Config) {
+	fset.StringVar(&cfg.KeysPath, "keys-path", cfg.KeysPath, "path to libp2p keys")
+	fset.IntVar(&cfg.TcpPort, "tcp-port", cfg.TcpPort, "tcp port for the network")
+	fset.IntVar(&cfg.QuicPort, "quic-port", cfg.QuicPort, "quic port for the network")
+	fset.BoolVar(&cfg.Relay, "relay", cfg.Relay, "enable relay")
+	fset.BoolVar(&cfg.DHTEnabled, "with-discovery", cfg.DHTEnabled, "enable discovery (with Kademlia DHT)")
+	fset.Var(&cfg.DHTBootstrapPeers, "discovery-bootstrap-peers", "bootstrap peers for discovery")
+	check.PanicIfErr(fset.SetAnnotation("discovery-bootstrap-peers", cobra.BashCompOneRequiredFlag, []string{"with-discovery"}))
+}

--- a/nil/internal/cobrax/cmdflags/telemetry.go
+++ b/nil/internal/cobrax/cmdflags/telemetry.go
@@ -1,0 +1,10 @@
+package cmdflags
+
+import (
+	"github.com/NilFoundation/nil/nil/internal/telemetry"
+	"github.com/spf13/pflag"
+)
+
+func AddTelemetry(fset *pflag.FlagSet, config *telemetry.Config) {
+	fset.BoolVar(&config.ExportMetrics, "metrics", config.ExportMetrics, "export metrics via grpc")
+}

--- a/nil/internal/cobrax/commands.go
+++ b/nil/internal/cobrax/commands.go
@@ -1,0 +1,27 @@
+package cobrax
+
+import (
+	"os"
+
+	"github.com/NilFoundation/nil/nil/common/version"
+	"github.com/spf13/cobra"
+)
+
+func ExitOnHelp(c *cobra.Command) {
+	helpFunc := c.HelpFunc()
+	c.SetHelpFunc(func(c *cobra.Command, s []string) {
+		helpFunc(c, s)
+		os.Exit(0)
+	})
+}
+
+func VersionCmd(title string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print the version number",
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Println(version.BuildVersionString(title))
+			os.Exit(0)
+		},
+	}
+}

--- a/nil/internal/cobrax/config.go
+++ b/nil/internal/cobrax/config.go
@@ -1,0 +1,45 @@
+package cobrax
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/pflag"
+	"gopkg.in/yaml.v3"
+)
+
+// AddConfigFlag adds a flag to the flag set to specify a config file.
+// It doesn't attach the flag to any variable because normally GetConfigNameFromArgs is used.
+func AddConfigFlag(fset *pflag.FlagSet) {
+	fset.StringP("config", "c", "", "config file")
+}
+
+// GetConfigNameFromArgs searches for a config file name in the command line arguments.
+// Generally, it should be called before argument parsing because the latter depends on the config (default values).
+func GetConfigNameFromArgs() string {
+	for i, f := range os.Args[:len(os.Args)-1] {
+		if f == "--config" || f == "-c" {
+			return os.Args[i+1]
+		}
+	}
+	return ""
+}
+
+// LoadConfigFromFile reads a YAML file and unmarshals it into the destination.
+// If the file name is empty, it does nothing.
+// Arg dest must be a non-nil pointer (initialized with defaults).
+func LoadConfigFromFile[T any](name string, dest *T) error {
+	if name == "" {
+		return nil
+	}
+
+	data, err := os.ReadFile(name)
+	if err != nil {
+		return fmt.Errorf("can't read config %s: %w", name, err)
+	}
+
+	if err := yaml.Unmarshal(data, dest); err != nil {
+		return fmt.Errorf("can't parse config %s: %w", name, err)
+	}
+	return nil
+}

--- a/nil/internal/cobrax/flags.go
+++ b/nil/internal/cobrax/flags.go
@@ -1,0 +1,24 @@
+package cobrax
+
+import (
+	"github.com/NilFoundation/nil/nil/internal/profiling"
+	"github.com/spf13/pflag"
+)
+
+func AddLogLevelFlag(fset *pflag.FlagSet, dst *string) {
+	AddCustomLogLevelFlag(fset, "log-level", "l", dst)
+}
+
+func AddCustomLogLevelFlag(fset *pflag.FlagSet, name, short string, dst *string) {
+	if *dst == "" {
+		*dst = "info"
+	}
+	fset.StringVarP(dst, name, short, *dst, "log level: trace|debug|info|warn|error|fatal|panic")
+}
+
+func AddPprofPortFlag(fset *pflag.FlagSet, dst *int) {
+	if *dst == 0 {
+		*dst = profiling.DefaultPort
+	}
+	fset.IntVar(dst, "pprof-port", *dst, "port to serve pprof profiling information")
+}

--- a/nil/internal/network/config.go
+++ b/nil/internal/network/config.go
@@ -10,10 +10,14 @@ type PeerID = peer.ID
 type Config struct {
 	PrivateKey PrivateKey `yaml:"-"`
 
+	KeysPath string `yaml:"keysPath,omitempty"`
+
 	Prefix      string `yaml:"prefix,omitempty"`
 	IPV4Address string `yaml:"ipv4,omitempty"`
 	TcpPort     int    `yaml:"tcpPort,omitempty"`
 	QuicPort    int    `yaml:"quicPort,omitempty"`
+
+	Relay bool `yaml:"relay,omitempty"`
 
 	DHTEnabled        bool          `yaml:"dhtEnabled,omitempty"`
 	DHTBootstrapPeers AddrInfoSlice `yaml:"dhtBootstrapPeers,omitempty"`
@@ -22,8 +26,9 @@ type Config struct {
 
 func NewDefaultConfig() *Config {
 	return &Config{
-		DHTMode: dht.ModeAutoServer,
-		Prefix:  "/nil",
+		KeysPath: "network-keys.yaml",
+		DHTMode:  dht.ModeAutoServer,
+		Prefix:   "/nil",
 	}
 }
 

--- a/nil/internal/network/host.go
+++ b/nil/internal/network/host.go
@@ -70,6 +70,10 @@ func newHost(ctx context.Context, conf *Config) (Host, error) {
 		)
 	}
 
+	if conf.Relay {
+		options = append(options, libp2p.EnableRelayService())
+	}
+
 	return libp2p.New(options...)
 }
 

--- a/nil/internal/network/keys.go
+++ b/nil/internal/network/keys.go
@@ -3,7 +3,6 @@ package network
 import (
 	"crypto/rand"
 	"errors"
-	"fmt"
 
 	"github.com/NilFoundation/nil/nil/internal/network/internal"
 	libp2pcrypto "github.com/libp2p/go-libp2p/core/crypto"
@@ -38,21 +37,6 @@ func LoadOrGenerateKeys(fileName string) (PrivateKey, error) {
 func GeneratePrivateKey() (libp2pcrypto.PrivKey, error) {
 	res, _, err := libp2pcrypto.GenerateSecp256k1Key(rand.Reader)
 	return res, err
-}
-
-func GenerateAndDumpKeys(fileName string) (PrivateKey, error) {
-	privKey, err := GeneratePrivateKey()
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate keys: %w", err)
-	}
-
-	if err := internal.DumpKey(fileName, internal.Libp2pKey{PrivKey: privKey}); err != nil {
-		return nil, fmt.Errorf("failed to save keys: %w", err)
-	}
-
-	internal.Logger.Info().Msgf("Saved network keys to %s", fileName)
-
-	return privKey, nil
 }
 
 func SerializeKeys(privKey libp2pcrypto.PrivKey) ([]byte, []byte, peer.ID, error) {

--- a/nil/internal/network/manager.go
+++ b/nil/internal/network/manager.go
@@ -92,7 +92,15 @@ func NewManager(ctx context.Context, conf *Config) (*Manager, error) {
 	}
 
 	if conf.PrivateKey == nil {
-		return nil, ErrPrivateKeyMissing
+		if conf.KeysPath == "" {
+			return nil, ErrPrivateKeyMissing
+		}
+
+		privateKey, err := LoadOrGenerateKeys(conf.KeysPath)
+		if err != nil {
+			return nil, err
+		}
+		conf.PrivateKey = privateKey
 	}
 
 	h, err := newHost(ctx, conf)

--- a/nil/internal/profiling/profiling.go
+++ b/nil/internal/profiling/profiling.go
@@ -9,7 +9,6 @@ import (
 const DefaultPort = 6060
 
 func Start(port int) {
-	// Start the pprof server.
 	go func() {
 		_ = http.ListenAndServe("localhost:"+strconv.Itoa(port), nil) //nolint:gosec
 	}()

--- a/nil/services/nilservice/config.go
+++ b/nil/services/nilservice/config.go
@@ -52,9 +52,11 @@ type Config struct {
 
 	// Keys
 	MainKeysPath         string                     `yaml:"mainKeysPath,omitempty"`
-	NetworkKeysPath      string                     `yaml:"networkKeysPath,omitempty"`
 	ValidatorKeysPath    string                     `yaml:"validatorKeysPath,omitempty"`
 	ValidatorKeysManager *keys.ValidatorKeysManager `yaml:"-"`
+
+	// deprecated
+	NetworkKeysPath string `yaml:"networkKeysPath,omitempty"`
 
 	// HttpUrl is calculated from RPCPort
 	HttpUrl string `yaml:"-"`
@@ -93,7 +95,6 @@ func NewDefaultConfig() *Config {
 
 		NShards:           uint32(DefaultNShards),
 		MainKeysPath:      "keys.yaml",
-		NetworkKeysPath:   "network-keys.yaml",
 		ValidatorKeysPath: "validator-keys.yaml",
 
 		GracefulShutdown: true,

--- a/nil/services/nilservice/service.go
+++ b/nil/services/nilservice/service.go
@@ -533,15 +533,6 @@ func createNetworkManager(ctx context.Context, cfg *Config) (*network.Manager, e
 		return nil, nil
 	}
 
-	if cfg.Network.PrivateKey == nil {
-		privKey, err := network.LoadOrGenerateKeys(cfg.NetworkKeysPath)
-		if err != nil {
-			return nil, err
-		}
-
-		cfg.Network.PrivateKey = privKey
-	}
-
 	return network.NewManager(ctx, cfg.Network)
 }
 


### PR DESCRIPTION
https://github.com/NilFoundation/nil/issues/489
The cluster should be available for libp2p connections from the public network (mainly from archive nodes).
Here is the first part of the implementation: adding a relay service.
The service is very basic, and, apart from basic stuff like logging and telemetry, only sets itself up as a libp2p relay service and waits to be killed.
I'm going to test it with cluster nodes that explicitly connect to it as a relay (also, auto-relay feature is implemented in libp2p, but I'm not sure about its feature of advertising relayed nodes). It should be enough for the initial setup.
Next PR will present the working setup.

In order to reduce boilerplate and reuse similar cli interfaces, I've introduced `cobrax` and functions in `telemetry` and `network` that add common flags to the cli args.
This PR is mostly the refactoring, and `relay` mainly serves as an example of how the result is used to compose a new service in a cleaner code.