### PR TITLE
[cluster common] Use EmptyHash instead of Hash{}

### DIFF
--- a/nil/cmd/exporter/internal/clickhouse/scheme.go
+++ b/nil/cmd/exporter/internal/clickhouse/scheme.go
@@ -105,7 +105,7 @@ func tableExists(ctx context.Context, conn driver.Conn, tableName string) (bool,
 
 func readVersion(ctx context.Context, conn driver.Conn) (common.Hash, error) {
 	if exists, err := tableExists(ctx, conn, "blocks"); err != nil || !exists {
-		return common.Hash{}, err
+		return common.EmptyHash, err
 	}
 
 	var version common.Hash
@@ -115,9 +115,9 @@ func readVersion(ctx context.Context, conn driver.Conn) (common.Hash, error) {
 		WHERE shard_id = 0 AND id = 0
 	`).Scan(&version); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return common.Hash{}, nil
+			return common.EmptyHash, nil
 		}
-		return common.Hash{}, err
+		return common.EmptyHash, err
 	}
 
 	return version, nil

--- a/nil/cmd/exporter/internal/exporter.go
+++ b/nil/cmd/exporter/internal/exporter.go
@@ -88,7 +88,7 @@ func (e *exporter) setup(ctx context.Context) ([]types.ShardId, error) {
 func (e *exporter) readVersionFromClient(ctx context.Context) (common.Hash, error) {
 	b, err := e.client.GetBlock(ctx, types.MainShardId, 0, false)
 	if err != nil {
-		return common.Hash{}, fmt.Errorf("failed to get genesis block from main shard: %w", err)
+		return common.EmptyHash, fmt.Errorf("failed to get genesis block from main shard: %w", err)
 	}
 	return b.Hash, nil
 }

--- a/nil/internal/collate/bootstrap.go
+++ b/nil/internal/collate/bootstrap.go
@@ -110,17 +110,17 @@ func fetchSnapshot(ctx context.Context, nm *network.Manager, peerAddr network.Ad
 func fetchGenesisBlockHash(ctx context.Context, nm *network.Manager, peerAddr network.AddrInfo) (common.Hash, error) {
 	peerId, err := nm.Connect(ctx, peerAddr)
 	if err != nil {
-		return common.Hash{}, fmt.Errorf("failed to connect to %s: %w", peerAddr, err)
+		return common.EmptyHash, fmt.Errorf("failed to connect to %s: %w", peerAddr, err)
 	}
 
 	resp, err := nm.SendRequestAndGetResponse(ctx, peerId, topicVersion, nil)
 	if err != nil {
-		return common.Hash{}, fmt.Errorf("failed to fetch genesis block hash: %w", err)
+		return common.EmptyHash, fmt.Errorf("failed to fetch genesis block hash: %w", err)
 	}
 
 	var res common.Hash
 	if err := res.UnmarshalSSZ(resp); err != nil {
-		return common.Hash{}, fmt.Errorf("failed to unmarshal genesis block hash: %w", err)
+		return common.EmptyHash, fmt.Errorf("failed to unmarshal genesis block hash: %w", err)
 	}
 
 	return res, nil

--- a/nil/internal/execution/account_state.go
+++ b/nil/internal/execution/account_state.go
@@ -163,7 +163,7 @@ func (as *AccountState) GetState(key common.Hash) (common.Hash, error) {
 
 	newVal, err := as.GetCommittedState(key)
 	if err != nil {
-		return common.Hash{}, err
+		return common.EmptyHash, err
 	}
 	as.State[key] = newVal
 	return newVal, nil

--- a/nil/internal/execution/block_cache.go
+++ b/nil/internal/execution/block_cache.go
@@ -22,7 +22,7 @@ func getHashFn(es *ExecutionState, ref *types.Block) func(n uint64) (common.Hash
 		if lastBlockId <= n {
 			// This situation can happen if we're doing tracing and using
 			// block overrides.
-			return common.Hash{}, nil
+			return common.EmptyHash, nil
 		}
 		// If there's no hash cache yet, make one
 		if len(cache) == 0 {
@@ -40,7 +40,7 @@ func getHashFn(es *ExecutionState, ref *types.Block) func(n uint64) (common.Hash
 				break
 			}
 			if err != nil {
-				return common.Hash{}, err
+				return common.EmptyHash, err
 			}
 
 			cache = append(cache, data.Block().PrevBlock)
@@ -50,6 +50,6 @@ func getHashFn(es *ExecutionState, ref *types.Block) func(n uint64) (common.Hash
 				return lastKnownHash, nil
 			}
 		}
-		return common.Hash{}, nil
+		return common.EmptyHash, nil
 	}
 }

--- a/nil/internal/execution/execution_state_test.go
+++ b/nil/internal/execution/execution_state_test.go
@@ -309,18 +309,14 @@ func TestSnapshot(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, data1, v)
 
-	if v := s.GetCommittedState(stateobjaddr, storageaddr); v != (common.Hash{}) {
-		t.Errorf("wrong committed storage value %v, want %v", v, common.Hash{})
-	}
+	require.Zero(t, s.GetCommittedState(stateobjaddr, storageaddr))
 
 	// revert up to the genesis state and ensure correct content
 	s.RevertToSnapshot(genesis)
 	v, err = s.GetState(stateobjaddr, storageaddr)
 	require.NoError(t, err)
 	assert.Empty(t, v)
-	if v := s.GetCommittedState(stateobjaddr, storageaddr); v != (common.Hash{}) {
-		t.Errorf("wrong committed storage value %v, want %v", v, common.Hash{})
-	}
+	require.Zero(t, s.GetCommittedState(stateobjaddr, storageaddr))
 }
 
 func TestSnapshotEmpty(t *testing.T) {

--- a/nil/internal/execution/state.go
+++ b/nil/internal/execution/state.go
@@ -421,7 +421,7 @@ func (es *ExecutionState) Exists(addr types.Address) (bool, error) {
 func (es *ExecutionState) GetCode(addr types.Address) ([]byte, common.Hash, error) {
 	acc, err := es.GetAccount(addr)
 	if err != nil || acc == nil {
-		return nil, common.Hash{}, err
+		return nil, common.EmptyHash, err
 	}
 	return acc.Code, acc.CodeHash, nil
 }
@@ -457,7 +457,7 @@ func (es *ExecutionState) RevertToSnapshot(revid int) {
 func (es *ExecutionState) GetStorageRoot(addr types.Address) (common.Hash, error) {
 	acc, err := es.GetAccount(addr)
 	if err != nil || acc == nil {
-		return common.Hash{}, err
+		return common.EmptyHash, err
 	}
 	return acc.StorageTree.RootHash(), nil
 }

--- a/nil/internal/execution/transient_storage.go
+++ b/nil/internal/execution/transient_storage.go
@@ -50,7 +50,7 @@ func (t transientStorage) Set(addr types.Address, key, value common.Hash) {
 func (t transientStorage) Get(addr types.Address, key common.Hash) common.Hash {
 	val, ok := t[addr]
 	if !ok {
-		return common.Hash{}
+		return common.EmptyHash
 	}
 	return val[key]
 }

--- a/nil/internal/vm/instructions.go
+++ b/nil/internal/vm/instructions.go
@@ -403,7 +403,7 @@ func opExtCodeCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext)
 //     should return the relative code hash and set it as the result.
 //
 //  2. Caller tries to get the code hash of a non-existent account, state should
-//     return common.Hash{} and zero will be set as the result.
+//     return common.EmptyHash and zero will be set as the result.
 //
 //  3. Caller tries to get the code hash for an account without contract code, state
 //     should return emptyCodeHash(0xc5d246...) as the result.

--- a/nil/services/rpc/filters/filters.go
+++ b/nil/services/rpc/filters/filters.go
@@ -315,7 +315,7 @@ func (m *FiltersManager) OnNewBlock(block *types.Block) {
 func (m *FiltersManager) getLastBlockHash() (common.Hash, error) {
 	tx, err := m.db.CreateRoTx(m.ctx)
 	if err != nil {
-		return common.Hash{}, err
+		return common.EmptyHash, err
 	}
 	defer tx.Rollback()
 
@@ -402,7 +402,7 @@ func (args *FilterQuery) UnmarshalJSON(data []byte) error {
 	}
 
 	// topics is an array consisting of strings and/or arrays of strings.
-	// JSON null values are converted to common.Hash{} and ignored by the filter manager.
+	// JSON null values are converted to common.EmptyHash and ignored by the filter manager.
 	if len(raw.Topics) > 0 {
 		args.Topics = make([][]common.Hash, len(raw.Topics))
 		for i, t := range raw.Topics {

--- a/nil/services/rpc/jsonrpc/send_transaction.go
+++ b/nil/services/rpc/jsonrpc/send_transaction.go
@@ -43,7 +43,7 @@ func (api *APIImpl) SendRawTransaction(ctx context.Context, encoded hexutil.Byte
 
 	if reason != txnpool.NotSet {
 		log.Err(ErrTransactionDiscarded).Msgf("%s", reason)
-		return common.Hash{}, fmt.Errorf("%w: %s", ErrTransactionDiscarded, reason)
+		return common.EmptyHash, fmt.Errorf("%w: %s", ErrTransactionDiscarded, reason)
 	}
 
 	h := extTxn.Hash()

--- a/nil/services/rpc/rawapi/local_block.go
+++ b/nil/services/rpc/rawapi/local_block.go
@@ -71,11 +71,11 @@ func (api *LocalShardApi) getBlockHashByReference(tx db.RoTx, blockReference raw
 		case rawapitypes.LatestBlock, rawapitypes.PendingBlock:
 			return db.ReadLastBlockHash(tx, api.ShardId)
 		}
-		return common.Hash{}, errors.New("unknown named block identifier")
+		return common.EmptyHash, errors.New("unknown named block identifier")
 	case rawapitypes.HashBlockReference:
 		return blockReference.Hash(), nil
 	}
-	return common.Hash{}, errors.New("unknown block reference type")
+	return common.EmptyHash, errors.New("unknown block reference type")
 }
 
 func (api *LocalShardApi) getBlockByHash(tx db.RoTx, hash common.Hash, withTransactions bool) (*types.RawBlockWithExtractedData, error) {

--- a/nil/services/synccommittee/prover/tracer/state_db.go
+++ b/nil/services/synccommittee/prover/tracer/state_db.go
@@ -645,7 +645,7 @@ func (tsdb *TracerStateDB) SetState(addr types.Address, key common.Hash, val com
 func (tsdb *TracerStateDB) GetStorageRoot(addr types.Address) (common.Hash, error) {
 	acc, err := tsdb.mptTracer.GetAccount(addr)
 	if err != nil || acc == nil {
-		return common.Hash{}, err
+		return common.EmptyHash, err
 	}
 
 	return acc.AccountState.StorageTree.RootHash(), nil


### PR DESCRIPTION
Based on https://github.com/NilFoundation/nil/pull/434#discussion_r1983573480
It was suggested that we should uniformly use `common.EmptyHash` instead of `common.Hash{}`.
Here's the implementation. It only avoids files of geth (they have their own code style).