### PR TITLE
[pubsub] Disable flaky test until better solution

### DIFF
--- a/nil/internal/network/pubsub_test.go
+++ b/nil/internal/network/pubsub_test.go
@@ -94,6 +94,9 @@ func (s *PubSubSuite) TestTwoHosts() {
 }
 
 func (s *PubSubSuite) TestComplexScenario() {
+	// todo: this test often fails in CI but works locally
+	s.T().SkipNow()
+
 	const n = 5
 	const centralHost = 3
 


### PR DESCRIPTION
The pub-sub test is extremely prone to failing in CI, yet often passes locally.
Example: https://github.com/NilFoundation/nil/actions/runs/13705312486/job/38329100031?pr=488
Here I disable the "complex scenario" but keep the code so that it can be run locally if desired.

This way of testing libp2p really makes little sense. At the basic level, libp2p works. Complex cases can only work on a real network anyway.