### PR TITLE
[uniswap] : fix bug associated with account creation

### DIFF
--- a/uniswap/tasks/basic/basic.ts
+++ b/uniswap/tasks/basic/basic.ts
@@ -59,14 +59,12 @@ export async function createSmartAccount(
         }),
   });
 
-  if (config.faucetDeposit) {
-    await topUpSmartAccount(smartAccount.address);
+  await topUpSmartAccount(smartAccount.address);
 
-    const deployed = await smartAccount.checkDeploymentStatus();
-    if (!deployed) {
-      console.log("Deploying smart account", smartAccount.address);
-      await smartAccount.selfDeploy();
-    }
+  const deployed = await smartAccount.checkDeploymentStatus();
+  if (!deployed) {
+    console.log("Deploying smart account", smartAccount.address);
+    await smartAccount.selfDeploy();
   }
 
   return smartAccount;


### PR DESCRIPTION
Currently the uniswap tasks fail when `faucetDeposit` key is not set in `.env` and the `.env.example` as well doesn't include any information about this. Removing this check for checking its existence will let the tasks run correctly. 