### PR TITLE
fix: support to pure type function and boolean inputs

### DIFF
--- a/explorer_frontend/src/features/contracts/components/Management/Method.tsx
+++ b/explorer_frontend/src/features/contracts/components/Management/Method.tsx
@@ -53,7 +53,7 @@ const getMethodType = (func: AbiFunction): MethodType => {
     return "Payable";
   }
 
-  if (func.stateMutability === "view") {
+  if (func.stateMutability === "view" || func.stateMutability === "pure") {
     return "Read";
   }
 

--- a/explorer_frontend/src/features/contracts/init.ts
+++ b/explorer_frontend/src/features/contracts/init.ts
@@ -411,7 +411,18 @@ sample({
             continue;
           }
           const name = input.name;
-          args.push(callParams[name] || "");
+
+          if (input.type === "bool") {
+            args.push(
+              callParams[name] === "true"
+                ? true
+                : callParams[name] === "false"
+                  ? false
+                  : Boolean(callParams[name]),
+            );
+          } else {
+            args.push(callParams[name] || "");
+          }
         }
       }
     }


### PR DESCRIPTION
This PR solves 2 minor issues https://github.com/NilFoundation/nil/issues/452 and https://github.com/NilFoundation/nil/issues/441 which are crucial functionalities to be supported in the playground. It adds support to pure type functions being queryable via the playground as well as the support to input boolean values in inputs. 