### PR TITLE
fix custom token in playground wallet

### DIFF
--- a/explorer_frontend/src/features/account-connector/components/Token.tsx
+++ b/explorer_frontend/src/features/account-connector/components/Token.tsx
@@ -65,7 +65,7 @@ const Token: FC<TokenProps> = ({ name, balance, isMain = false }) => {
               alignItems: "center",
             })}
           >
-            {getTokenSymbolByAddress(name)}
+            {getTokenSymbolByAddress(name) !== "" ? getTokenSymbolByAddress(name) : name}
           </LabelXSmall>
         )}
       </div>
@@ -78,7 +78,9 @@ const Token: FC<TokenProps> = ({ name, balance, isMain = false }) => {
           display: "block",
         })}
       >
-        <OverflowEllipsis charsFromTheEnd={4}>{getTokenSymbolByAddress(name)}</OverflowEllipsis>
+        <OverflowEllipsis charsFromTheEnd={4}>
+          {getTokenSymbolByAddress(name) !== "" ? getTokenSymbolByAddress(name) : name}
+        </OverflowEllipsis>
       </LabelMedium>
       <LabelSmall
         className={css({

--- a/explorer_frontend/src/features/tokens/assets/custom.svg
+++ b/explorer_frontend/src/features/tokens/assets/custom.svg
@@ -1,0 +1,5 @@
+<svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 8C0 3.58172 3.58172 0 8 0H40C44.4183 0 48 3.58172 48 8V40C48 44.4183 44.4183 48 40 48H8C3.58172 48 0 44.4183 0 40V8Z" fill="#F1F1F1"/>
+<path d="M24 40C32.8366 40 40 32.8366 40 24C40 15.1634 32.8366 8 24 8C15.1634 8 8 15.1634 8 24C8 32.8366 15.1634 40 24 40Z" fill="#D6D6D6"/>
+<rect x="24" y="19.286" width="6.66667" height="6.66667" rx="1.33333" transform="rotate(45 24 19.286)" stroke="#727272" stroke-width="2" stroke-linejoin="round"/>
+</svg>

--- a/explorer_frontend/src/features/tokens/utils.ts
+++ b/explorer_frontend/src/features/tokens/utils.ts
@@ -1,5 +1,6 @@
 import { Token } from "./Token";
 import btc from "./assets/btc.svg";
+import custom from "./assets/custom.svg";
 import eth from "./assets/eth.svg";
 import nil from "./assets/nil.svg";
 import usdt from "./assets/usdt.svg";
@@ -15,7 +16,7 @@ export const getTokenIcon = (name: string) => {
     case Token.BTC:
       return btc;
     default:
-      return null;
+      return custom;
   }
 };
 
@@ -34,7 +35,11 @@ export const getTokenSymbolByAddress = (address: string) => {
   if (address === btcAddress) {
     return Token.BTC;
   }
-  return address;
+  if (address === Token.NIL) {
+    return Token.NIL;
+  }
+
+  return "";
 };
 
 export const getTokenAddressBySymbol = (symbol: string) => {


### PR DESCRIPTION
## Description

We had an issue, were we were not handling custom default tokens on playground wallet, and when someone would add it it would break ux. This PR add fail safe mechanism for properly handling these

This PR does not integrates all custom mock tokens we want, if someone needs new custom tokens, and you want to display them in the wallets, they need to be added (label, icon..)
<img width="433" alt="Screenshot 2025-03-07 at 12 35 33" src="https://github.com/user-attachments/assets/7ee657b9-1003-40ef-b2f5-5853936afd8b" />

