### PR TITLE
[execution] increase default balance for default faucets

### DIFF
--- a/nil/internal/execution/zerostate.go
+++ b/nil/internal/execution/zerostate.go
@@ -40,12 +40,12 @@ type ZeroStateConfig struct {
 }
 
 func CreateDefaultZeroStateConfig(mainPublicKey []byte) (*ZeroStateConfig, error) {
-	smartAccountValue, err := types.NewValueFromDecimal("10000000000000000000000")
+	smartAccountValue, err := types.NewValueFromDecimal("10000000000000000000000000000")
 	if err != nil {
 		return nil, err
 	}
 	faucetValue := smartAccountValue.Mul(types.NewValueFromUint64(uint64(2)))
-	tokenValue, err := types.NewValueFromDecimal("100000000000000")
+	tokenValue, err := types.NewValueFromDecimal("100000000000000000000")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Balance before: ~10^14
Default gas price: ~10^7
Gas to process one faucet request: ~10^4

That mean faucet can perform only 1k transactions. That's extremely small even for our test environment. So let's increase default balance of faucets in 10^6 times.