### PR TITLE
Sync Committee: Transition to Batch-Level Operations

### DIFF
--- a/nil/services/synccommittee/core/aggregator.go
+++ b/nil/services/synccommittee/core/aggregator.go
@@ -61,7 +61,7 @@ type aggregator struct {
 	blockStorage   AggregatorBlockStorage
 	taskStorage    AggregatorTaskStorage
 	batchCommitter batches.BatchCommitter
-	resetter       reset.StateResetter
+	resetter       *reset.StateResetter
 	timer          common.Timer
 	metrics        AggregatorMetrics
 	workerAction   *concurrent.Suspendable
@@ -71,7 +71,7 @@ func NewAggregator(
 	rpcClient client.Client,
 	blockStorage AggregatorBlockStorage,
 	taskStorage AggregatorTaskStorage,
-	resetter reset.StateResetter,
+	resetter *reset.StateResetter,
 	timer common.Timer,
 	logger zerolog.Logger,
 	metrics AggregatorMetrics,

--- a/nil/services/synccommittee/core/aggregator_test.go
+++ b/nil/services/synccommittee/core/aggregator_test.go
@@ -142,12 +142,12 @@ func (s *AggregatorTestSuite) Test_Main_Parent_Hash_Mismatch() {
 	for _, provedBatch := range batches[:2] {
 		err := s.blockStorage.SetBlockBatch(s.ctx, provedBatch)
 		s.Require().NoError(err)
-		err = s.blockStorage.SetBlockAsProved(s.ctx, scTypes.IdFromBlock(provedBatch.MainShardBlock))
+		err = s.blockStorage.SetBatchAsProved(s.ctx, provedBatch.Id)
 		s.Require().NoError(err)
 	}
 
 	// Set first batch as proposed, latestProvedStateRoot value is updated
-	err := s.blockStorage.SetBlockAsProposed(s.ctx, scTypes.IdFromBlock(batches[0].MainShardBlock))
+	err := s.blockStorage.SetBatchAsProposed(s.ctx, batches[0].Id)
 	s.Require().NoError(err)
 	latestProved, err := s.blockStorage.TryGetProvedStateRoot(s.ctx)
 	s.Require().NoError(err)
@@ -208,7 +208,7 @@ func (s *AggregatorTestSuite) Test_Fetch_Next_Valid() {
 
 func (s *AggregatorTestSuite) Test_Block_Storage_Capacity_Exceeded() {
 	// only one test batch can fit in the storage
-	storageConfig := storage.NewBlockStorageConfig(testaide.BatchSize)
+	storageConfig := storage.NewBlockStorageConfig(1)
 	blockStorage := s.newTestBlockStorage(storageConfig)
 
 	batches := testaide.NewBatchesSequence(2)

--- a/nil/services/synccommittee/core/block_tasks_integration_test.go
+++ b/nil/services/synccommittee/core/block_tasks_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/scheduler"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/storage"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/testaide"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -185,6 +186,6 @@ func newTestSuccessProviderResult(taskToExecute *types.Task, executorId types.Ta
 
 type noopStateResetLauncher struct{}
 
-func (l *noopStateResetLauncher) LaunchPartialResetWithSuspension(_ context.Context, _ common.Hash) error {
+func (l *noopStateResetLauncher) LaunchPartialResetWithSuspension(_ context.Context, _ types.BatchId) error {
 	return nil
 }

--- a/nil/services/synccommittee/core/reset/resetter.go
+++ b/nil/services/synccommittee/core/reset/resetter.go
@@ -2,58 +2,69 @@ package reset
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/NilFoundation/nil/nil/common"
 	"github.com/NilFoundation/nil/nil/common/logging"
+	scTypes "github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
 	"github.com/rs/zerolog"
 )
 
-type StateResetter interface {
-	// ResetProgressPartial resets Sync Committee's block processing progress
-	// to a point preceding main shard block with the specified hash.
-	ResetProgressPartial(ctx context.Context, firstMainHashToPurge common.Hash) error
+type BatchResetter interface {
+	// ResetBatchesRange resets Sync Committee's block processing progress
+	// to a point preceding batch with the specified ID.
+	ResetBatchesRange(ctx context.Context, firstBatchToPurge scTypes.BatchId) (purgedBatches []scTypes.BatchId, err error)
 
-	// ResetProgressNotProved resets Sync Committee's progress for all not yet proven blocks.
-	ResetProgressNotProved(ctx context.Context) error
+	// ResetBatchesNotProved resets Sync Committee's progress for all not yet proved batches.
+	ResetBatchesNotProved(ctx context.Context) error
 }
 
-func NewStateResetter(logger zerolog.Logger, resetters ...StateResetter) StateResetter {
-	return &compositeStateResetter{
-		resetters: resetters,
-		logger:    logger,
+type StateResetter struct {
+	batchResetter BatchResetter
+	logger        zerolog.Logger
+}
+
+func NewStateResetter(logger zerolog.Logger, batchResetter BatchResetter) *StateResetter {
+	return &StateResetter{
+		batchResetter: batchResetter,
+		logger:        logger,
 	}
 }
 
-type compositeStateResetter struct {
-	resetters []StateResetter
-	logger    zerolog.Logger
-}
-
-func (r *compositeStateResetter) ResetProgressPartial(ctx context.Context, firstMainHashToPurge common.Hash) error {
+func (r *StateResetter) ResetProgressPartial(ctx context.Context, failedBatchId scTypes.BatchId) error {
 	r.logger.Info().
-		Stringer(logging.FieldBlockMainShardHash, firstMainHashToPurge).
+		Stringer(logging.FieldBatchId, failedBatchId).
 		Msg("Started partial progress reset")
 
-	for _, resetter := range r.resetters {
-		if err := resetter.ResetProgressPartial(ctx, firstMainHashToPurge); err != nil {
-			return err
+	purgedBatchIds, err := r.batchResetter.ResetBatchesRange(ctx, failedBatchId)
+	if err != nil {
+		return err
+	}
+
+	for _, batchId := range purgedBatchIds {
+		// Tasks associated with the failed batch should not be cancelled at this point,
+		// they will be marked as failed later
+		if batchId == failedBatchId {
+			continue
 		}
+
+		// todo: cancel tasks in the storage and push cancellation requests to executors
+		// https://www.notion.so/nilfoundation/requires-analysis-Child-Task-Cancellation-162c61485260803882b3e50b89d2f5c4?pvs=4
+
+		r.logger.Info().Stringer(logging.FieldBatchId, batchId).Msg("Cancelled batch tasks")
 	}
 
 	r.logger.Info().
-		Stringer(logging.FieldBlockMainShardHash, firstMainHashToPurge).
+		Stringer(logging.FieldBatchId, failedBatchId).
 		Msg("Finished partial progress reset")
 
 	return nil
 }
 
-func (r *compositeStateResetter) ResetProgressNotProved(ctx context.Context) error {
+func (r *StateResetter) ResetProgressNotProved(ctx context.Context) error {
 	r.logger.Info().Msg("Started not proven progress reset")
 
-	for _, resetter := range r.resetters {
-		if err := resetter.ResetProgressNotProved(ctx); err != nil {
-			return err
-		}
+	if err := r.batchResetter.ResetBatchesNotProved(ctx); err != nil {
+		return fmt.Errorf("failed to reset progress for not proved batches: %w", err)
 	}
 
 	r.logger.Info().Msg("Finished not proven progress reset")

--- a/nil/services/synccommittee/internal/metrics/sync_committee_metrics.go
+++ b/nil/services/synccommittee/internal/metrics/sync_committee_metrics.go
@@ -21,7 +21,7 @@ type SyncCommitteeMetricsHandler struct {
 	blockBatchSize         telemetry.Histogram
 
 	// BlockStorageMetrics
-	totalMainBlocksProved telemetry.Counter
+	totalBatchesProved telemetry.Counter
 
 	// ProposerMetrics
 	totalL1TxSent       telemetry.Counter
@@ -66,7 +66,7 @@ func (h *SyncCommitteeMetricsHandler) init(attributes metric.MeasurementOption, 
 func (h *SyncCommitteeMetricsHandler) initBlockStorageMetrics(meter telemetry.Meter) error {
 	var err error
 
-	if h.totalMainBlocksProved, err = meter.Int64Counter(namespace + "total_main_blocks_proved"); err != nil {
+	if h.totalBatchesProved, err = meter.Int64Counter(namespace + "total_batches_proved"); err != nil {
 		return err
 	}
 
@@ -112,8 +112,8 @@ func (h *SyncCommitteeMetricsHandler) RecordBlockBatchSize(ctx context.Context, 
 	h.blockBatchSize.Record(ctx, batchSize, h.attributes)
 }
 
-func (h *SyncCommitteeMetricsHandler) RecordMainBlockProved(ctx context.Context) {
-	h.totalMainBlocksProved.Add(ctx, 1, h.attributes)
+func (h *SyncCommitteeMetricsHandler) RecordBatchProved(ctx context.Context) {
+	h.totalBatchesProved.Add(ctx, 1, h.attributes)
 }
 
 func (h *SyncCommitteeMetricsHandler) RecordProposerTxSent(ctx context.Context, proposalData *types.ProposalData) {

--- a/nil/services/synccommittee/internal/storage/errors.go
+++ b/nil/services/synccommittee/internal/storage/errors.go
@@ -3,8 +3,9 @@ package storage
 import "errors"
 
 var (
-	ErrTaskAlreadyExists    = errors.New("task with a given identifier already exists")
-	ErrSerializationFailed  = errors.New("failed to serialize/deserialize object")
-	ErrCapacityLimitReached = errors.New("storage capacity limit reached")
-	errNilTaskEntry         = errors.New("task entry cannot be nil")
+	ErrStateRootNotInitialized = errors.New("proved state root is not initialized")
+	ErrTaskAlreadyExists       = errors.New("task with a given identifier already exists")
+	ErrSerializationFailed     = errors.New("failed to serialize/deserialize object")
+	ErrCapacityLimitReached    = errors.New("storage capacity limit reached")
+	errNilTaskEntry            = errors.New("task entry cannot be nil")
 )

--- a/nil/services/synccommittee/internal/types/block_batch.go
+++ b/nil/services/synccommittee/internal/types/block_batch.go
@@ -11,8 +11,10 @@ import (
 )
 
 var (
-	ErrBatchNotReady = errors.New("batch is not ready for handling")
-	ErrBatchMismatch = errors.New("batch mismatch")
+	ErrBatchNotReady  = errors.New("batch is not ready for handling")
+	ErrBatchMismatch  = errors.New("batch mismatch")
+	ErrBatchNotProved = errors.New("batch is not proved")
+	ErrBlockMismatch  = errors.New("block mismatch")
 )
 
 // BatchId Unique ID of a batch of blocks.

--- a/nil/services/synccommittee/internal/types/blocks.go
+++ b/nil/services/synccommittee/internal/types/blocks.go
@@ -130,10 +130,6 @@ func IdFromBlock(block *jsonrpc.RPCBlock) BlockId {
 	return BlockId{block.ShardId, block.Hash}
 }
 
-func ParentBlockId(block *jsonrpc.RPCBlock) BlockId {
-	return BlockId{block.ShardId, block.ParentHash}
-}
-
 func ChildBlockIds(mainShardBlock *jsonrpc.RPCBlock) ([]BlockId, error) {
 	if mainShardBlock == nil {
 		return nil, errors.New("mainShardBlock cannot be nil")
@@ -216,6 +212,7 @@ func NewTransaction(transaction *jsonrpc.RPCInTransaction) *PrunedTransaction {
 }
 
 type ProposalData struct {
+	BatchId            BatchId
 	MainShardBlockHash common.Hash
 	Transactions       []*PrunedTransaction
 	OldProvedStateRoot common.Hash

--- a/nil/services/synccommittee/internal/types/errors.go
+++ b/nil/services/synccommittee/internal/types/errors.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	ErrBlockNotFound   = errors.New("block with the specified id is not found")
-	ErrBlockMismatch   = errors.New("block mismatch")
+	ErrBatchNotFound   = errors.New("batch with the specified id is not found")
 	ErrBlockProcessing = errors.New("block processing error")
 )
 


### PR DESCRIPTION
## Overview
This update replaces block-level operations with batch-level processing across the Sync Committee services to:
- Simplify task cancellation logic.
- Support the new multi-block batching model.

## Block Storage Changes
- Introduced `batchEntry` struct to hold references to blocks, stored in a new dedicated table.
- Removed the `IsProved` field from `blockEntry`; it is now associated with the batch.
- Replaced `SetBlockAsProved(BlockId)` with `SetBatchAsProved(BatchId)`.
- Updated `TryGetNextProposalData()` to use the main shard block hash as the state root instead of `ChildBlocksRootHash`.
- Replaced `SetBlockAsProposed(BlockId)` with `SetBatchAsProposed(BatchId)`.

## Partial Reset Enhancements
- The starting point is now determined by `BatchId` instead of the main shard block hash.
- Switched from block-based iteration to a mechanism using lightweight batch headers (`batchEntry`), reducing the impact of individual block size on reset transaction size.
- Adjusted the default capacity limit from **200 blocks** to **100 batches**.