### PR TITLE
[cometa] fix compilation bug caused by missing generated files

### DIFF
--- a/nil/services/cometa/tests/Issue465.sol
+++ b/nil/services/cometa/tests/Issue465.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.9;
+
+contract Caller {
+    function sendValue(address dst) public {}
+}
+
+contract Receiver {
+    function depositAndReturn() public {}
+}

--- a/nil/services/cometa/tests/issue465.json
+++ b/nil/services/cometa/tests/issue465.json
@@ -1,0 +1,12 @@
+{
+  "contractName": "Issue465.sol:Receiver",
+  "compilerVersion": "0.8.28",
+  "settings": {
+    "evmVersion": "london"
+  },
+  "sources": {
+    "Issue465.sol": {
+      "urls": ["Issue465.sol"]
+    }
+  }
+}


### PR DESCRIPTION
In some cases Solidity compiler does not produce generated sources. Cometa did not expect this and therefore failed.

Closes #465