### PR TITLE
[GH-#] Make sure that the errors are valid UTF-8 strings

### DIFF
--- a/nil/contracts/solidity/tests/Test.sol
+++ b/nil/contracts/solidity/tests/Test.sol
@@ -13,6 +13,10 @@ contract Test is NilBase {
 
     constructor() payable {}
 
+    function garbageInRequire(bool f, string memory m) public pure {
+        require(f, m);
+    }
+
     function emitEvent(uint a, uint b) public payable {
         emit testEvent(a, b);
     }

--- a/nil/internal/execution/state.go
+++ b/nil/internal/execution/state.go
@@ -10,10 +10,12 @@ import (
 	"math"
 	"math/big"
 	"sort"
+	"unicode/utf8"
 
 	"github.com/NilFoundation/nil/nil/common"
 	"github.com/NilFoundation/nil/nil/common/assert"
 	"github.com/NilFoundation/nil/nil/common/check"
+	"github.com/NilFoundation/nil/nil/common/hexutil"
 	"github.com/NilFoundation/nil/nil/common/logging"
 	"github.com/NilFoundation/nil/nil/internal/abi"
 	"github.com/NilFoundation/nil/nil/internal/config"
@@ -1225,6 +1227,9 @@ func decodeRevertTransaction(data []byte) string {
 	var revString string
 	if index := bytes.IndexByte(data, 0); index > 0 {
 		revString = string(data[:index])
+		if !utf8.ValidString(revString) {
+			return "Not a UTF-8 string: " + hexutil.Encode(data[:index])
+		}
 	}
 	return revString
 }

--- a/nil/tests/regression/regression_test.go
+++ b/nil/tests/regression/regression_test.go
@@ -116,6 +116,17 @@ func (s *SuiteRegression) TestProposerOutOfGas() {
 	s.Require().Equal("OutOfGasDynamic", receipt.OutReceipts[0].Status)
 }
 
+func (s *SuiteRegression) TestNonStringError() {
+	abi, err := contracts.GetAbi(contracts.NameTest)
+	s.Require().NoError(err)
+
+	data := []byte{0xC3, 0x28}
+	calldata := s.AbiPack(abi, "garbageInRequire", false, string(data))
+	receipt := s.SendExternalTransactionNoCheck(calldata, s.testAddress)
+	s.Require().False(receipt.Success)
+	s.Require().Contains(receipt.ErrorMessage, "ExecutionReverted: Not a UTF-8 string: 0xc328")
+}
+
 func TestRegression(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Faced errors in the cluster log:
```
{
  "level": "error",
  "component": "network",
  "p2pIdentity": "16Uiu2HAmQ62Uh4CaACYPp3Lj9igQmg7F6ciSTszbMUzP238kEpv9",
  "protocolId": "/nil/shard/1/rawapi/GetFullBlockData",
  "error": "failed to pack Protobuf response: string field contains invalid UTF-8",
  "caller": "github.com/NilFoundation/nil/nil/internal/network/manager.go:199",
  "time": "2025-03-10T14:48:00Z",
  "message": "Failed to handle request"
}
```