### PR TITLE
[vm] fix PanicDuringExecution if contract deployed with tokens

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -69,6 +69,12 @@ linters-settings:
     excludes:
       - G115
 
+  govet:
+    enable-all: true
+    disable:
+      - fieldalignment
+      - shadow
+
 issues:
   exclude-dirs:
     - clickhouse

--- a/nil/contracts/solidity/tests/TokensTest.sol
+++ b/nil/contracts/solidity/tests/TokensTest.sol
@@ -51,6 +51,29 @@ contract TokensTest is NilTokenBase {
         );
     }
 
+    function testAsyncDeployWithTokens(
+        uint shardId,
+        uint feeCredit,
+        uint value,
+        bytes memory code,
+        uint256 salt,
+        Nil.Token[] memory tokens
+    ) public onlyExternal returns (address) {
+        address contractAddress = Nil.createAddress(shardId, code, salt);
+        // 0xfd == Nil.ASYNC_CALL
+        __Precompile__(address(0xfd)).precompileAsyncCall{value: value}(
+            true,
+            Nil.FORWARD_REMAINING,
+            contractAddress,
+            address(0),
+            address(this),
+            feeCredit,
+            tokens,
+            bytes.concat(code, bytes32(salt))
+        );
+        return contractAddress;
+    }
+
     function testTransactionTokens(Nil.Token[] memory tokens) public payable {
         Nil.Token[] memory transactionTokens = Nil.txnTokens();
         require(

--- a/nil/internal/vm/precompiled.go
+++ b/nil/internal/vm/precompiled.go
@@ -441,7 +441,7 @@ func (c *asyncCall) Run(state StateDB, input []byte, value *uint256.Int, caller 
 	var kind types.TransactionKind
 	if deploy {
 		if len(tokens) != 0 {
-			return nil, types.NewVmVerboseError(types.ErrorAsyncDeployMustNotHaveToken, err.Error())
+			return nil, types.NewVmError(types.ErrorAsyncDeployMustNotHaveToken)
 		}
 		kind = types.DeployTransactionKind
 	} else {


### PR DESCRIPTION
This patch fixes following issue:
```
../../internal/collate/proposer.go:249 > Transaction execution failed. It doesn't prevent adding it to the block. error="PanicDuringExecution: runtime error: invalid memory address or nil pointer dereference" shardId=[1]	 txnHash=[0x0001d9bb8d922e7078faf8345b41498fc4c6aee8529201124200ba84fafb064c]
```

It was hard to reproduce this issue but anyway it's possible. The reason is that `err` object always was `nil`.