### PR TITLE
[nilservice] improve validation for validator nodes

### DIFF
--- a/nil/services/nilservice/config.go
+++ b/nil/services/nilservice/config.go
@@ -172,6 +172,15 @@ func (c *Config) Validate() error {
 		}
 	}
 
+	if c.MyShards != nil && !c.DisableConsensus {
+		if !slices.Contains(c.MyShards, uint(types.MainShardId)) {
+			return errors.New("main shard must be included in MyShards")
+		}
+		if len(c.MyShards) == 1 {
+			return errors.New("standalone main shard doesn't make sense with enabled consensus")
+		}
+	}
+
 	return nil
 }
 

--- a/nil/services/nilservice/service.go
+++ b/nil/services/nilservice/service.go
@@ -184,12 +184,9 @@ func setP2pRequestHandlers(ctx context.Context, rawApi *rawapi.NodeApiOverShardA
 	return nil
 }
 
-func validateArchiveNodeConfig(cfg *Config, nm *network.Manager) error {
+func validateArchiveNodeConfig(_ *Config, nm *network.Manager) error {
 	if nm == nil {
 		return errors.New("failed to start archive node without network configuration")
-	}
-	if !slices.Contains(cfg.MyShards, uint(types.MainShardId)) {
-		return errors.New("on archive node, main shard must be included in MyShards")
 	}
 	return nil
 }


### PR DESCRIPTION
In case if consensus enabled we expect that all validator of non-main shards will be validate main shard as well. This patch extends a bit validation to prevent following cases:
  - main shard is not specified in the list of shards
  - standalone main shard