### PR TITLE
[tests] disable consensus for synccommittee test to prevent CI failures

### DIFF
--- a/nil/services/synccommittee/core/service_test.go
+++ b/nil/services/synccommittee/core/service_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/NilFoundation/nil/nil/common"
 	"github.com/NilFoundation/nil/nil/common/logging"
-	"github.com/NilFoundation/nil/nil/internal/collate"
 	"github.com/NilFoundation/nil/nil/internal/db"
 	"github.com/NilFoundation/nil/nil/services/nilservice"
 	rpctest "github.com/NilFoundation/nil/nil/services/rpc"
@@ -39,8 +38,8 @@ func (s *SyncCommitteeTestSuite) SetupSuite() {
 	nilserviceCfg := &nilservice.Config{
 		NShards:              s.nShards,
 		HttpUrl:              s.url,
-		Topology:             collate.TrivialShardTopologyId,
-		CollatorTickPeriodMs: 100,
+		CollatorTickPeriodMs: 200,
+		DisableConsensus:     true,
 	}
 
 	s.Start(nilserviceCfg)

--- a/nil/services/synccommittee/prover/tracer/tracer_nild_test.go
+++ b/nil/services/synccommittee/prover/tracer/tracer_nild_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/NilFoundation/nil/nil/common/logging"
-	"github.com/NilFoundation/nil/nil/internal/collate"
 	"github.com/NilFoundation/nil/nil/internal/contracts"
 	"github.com/NilFoundation/nil/nil/internal/execution"
 	"github.com/NilFoundation/nil/nil/internal/types"
@@ -51,8 +50,8 @@ func (s *TracerNildTestSuite) SetupSuite() {
 	nilserviceCfg := &nilservice.Config{
 		NShards:              3,
 		HttpUrl:              rpctest.GetSockPath(s.T()),
-		Topology:             collate.TrivialShardTopologyId,
-		CollatorTickPeriodMs: 100,
+		CollatorTickPeriodMs: 400,
+		DisableConsensus:     true,
 	}
 
 	s.Start(nilserviceCfg)
@@ -112,7 +111,7 @@ func (s *TracerNildTestSuite) TestCounterContract() {
 	})
 
 	s.Run("Add", func() {
-		// Add to countuer (state change)
+		// Add to counter (state change)
 		txHash, err := s.Client.SendTransactionViaSmartAccount(
 			s.Context,
 			types.MainSmartAccountAddress,


### PR DESCRIPTION
For some reasons we see following failures in CI:
```
2025-03-11T08:47:24.4638935Z nil> 2025-03-11 08:47:09 DBG [consensus]         ../../../../go-ibft/core/ibft.go:444 > block proposal accepted shardId=[1]
2025-03-11T08:47:24.4639316Z nil> 2025-03-11 08:47:09 DBG [consensus]         ../../../../go-ibft/core/ibft.go:448 > pre-prepare message multicasted shardId=[2]
2025-03-11T08:47:24.4639642Z nil> 2025-03-11 08:47:09 DBG [consensus]         ../../../../go-ibft/core/ibft.go:840 > enter: prepare state shardId=[2]
2025-03-11T08:47:24.4639763Z nil> signal: killed
2025-03-11T08:47:24.4640119Z nil> FAIL       github.com/NilFoundation/nil/nil/services/synccommittee/prover/tracer   232.386s
2025-03-11T08:47:24.4640588Z nil> ok         github.com/NilFoundation/nil/nil/services/synccommittee/prover/tracer/internal/mpttracer        1.405s
```

Seems test consumes a lot of resourses. Probably it should be discovered. But for now the best option is to disable consensus.