### PR TITLE
Sync Committee: Proof batch in single task

### DIFF
--- a/nil/cmd/prover/main.go
+++ b/nil/cmd/prover/main.go
@@ -68,13 +68,13 @@ func execute() error {
 			if err != nil {
 				return err
 			}
-			traceConfig.ShardID, err = types.ParseShardIdFromString(args[1])
-			if err != nil {
-				return err
-			}
-			traceConfig.BlockIDs = make([]transport.BlockReference, len(args)-2)
+			traceConfig.BlockIDs = make([]tracer.BlockId, len(args)-2)
 			for i, blockArg := range args[2:] {
-				traceConfig.BlockIDs[i], err = transport.AsBlockReference(blockArg)
+				traceConfig.BlockIDs[i].ShardId, err = types.ParseShardIdFromString(args[1])
+				if err != nil {
+					return err
+				}
+				traceConfig.BlockIDs[i].Id, err = transport.AsBlockReference(blockArg)
 				if err != nil {
 					return err
 				}

--- a/nil/cmd/sync_committee/main.go
+++ b/nil/cmd/sync_committee/main.go
@@ -58,6 +58,7 @@ func addFlags(cmd *cobra.Command, cfg *cmdConfig) {
 	cmd.Flags().StringVar(&cfg.ProposerParams.PrivateKey, "l1-private-key", cfg.ProposerParams.PrivateKey, "L1 account private key")
 	cmd.Flags().StringVar(&cfg.ProposerParams.ContractAddress, "l1-contract-address", cfg.ProposerParams.ContractAddress, "L1 update state contract address")
 	cmd.Flags().DurationVar(&cfg.ProposerParams.EthClientTimeout, "l1-client-timeout", cfg.ProposerParams.EthClientTimeout, "L1 client timeout")
+	cmd.Flags().BoolVar(&cfg.ProposerParams.DisableL1, "disable-l1", cfg.ProposerParams.DisableL1, "Disable send trancations to L1")
 	logLevel := cmd.Flags().String("log-level", "info", "log level: trace|debug|info|warn|error|fatal|panic")
 
 	// Telemetry flags

--- a/nil/services/synccommittee/core/aggregator_test.go
+++ b/nil/services/synccommittee/core/aggregator_test.go
@@ -305,23 +305,11 @@ func (s *AggregatorTestSuite) requireMainBlockHandled(mainBlock *jsonrpc.RPCBloc
 		s.requireBlockStored(childId)
 	}
 
-	var parentTaskId scTypes.TaskId
-
-	// one ProofBlock task per exec block was created
-	for range childIds {
-		taskToExecute, err := s.taskStorage.RequestTaskToExecute(s.ctx, testaide.RandomExecutorId())
-		s.Require().NoError(err)
-		s.Require().NotNil(taskToExecute)
-		s.Require().Equal(scTypes.ProofBlock, taskToExecute.TaskType)
-		s.Require().NotNil(taskToExecute.ParentTaskId)
-		parentTaskId = *taskToExecute.ParentTaskId
-	}
-
-	// root AggregateProofs was created
-	parentTask, err := s.taskStorage.TryGetTaskEntry(s.ctx, parentTaskId)
+	// one ProofBatch task created
+	taskToExecute, err := s.taskStorage.RequestTaskToExecute(s.ctx, testaide.RandomExecutorId())
 	s.Require().NoError(err)
-	s.Require().NotNil(parentTask)
-	s.Require().Equal(scTypes.AggregateProofs, parentTask.Task.TaskType)
+	s.Require().NotNil(taskToExecute)
+	s.Require().Equal(scTypes.ProofBatch, taskToExecute.TaskType)
 }
 
 func (s *AggregatorTestSuite) requireBlockStored(blockId scTypes.BlockId) {

--- a/nil/services/synccommittee/core/block_batch_test.go
+++ b/nil/services/synccommittee/core/block_batch_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/NilFoundation/nil/nil/common"
-	coreTypes "github.com/NilFoundation/nil/nil/internal/types"
+	// coreTypes "github.com/NilFoundation/nil/nil/internal/types"
 	"github.com/NilFoundation/nil/nil/services/rpc/jsonrpc"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/testaide"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
@@ -116,6 +116,7 @@ func (s *BlockBatchTestSuite) TestNewBlockBatch() {
 	}
 }
 
+/* TODO update with respect new task policy
 func (s *BlockBatchTestSuite) TestCreateProofTasks() {
 	const childBLockCount = 4
 	batch := testaide.NewBlockBatch(childBLockCount)
@@ -149,4 +150,4 @@ func (s *BlockBatchTestSuite) TestCreateProofTasks() {
 		s.Require().Equal(childBlock.Number, childTask.BlockNum)
 		s.Require().Equal(mainShardTask.Id, *childTask.ParentTaskId)
 	}
-}
+}*/

--- a/nil/services/synccommittee/core/block_tasks_integration_test.go
+++ b/nil/services/synccommittee/core/block_tasks_integration_test.go
@@ -7,12 +7,10 @@ import (
 	"github.com/NilFoundation/nil/nil/common"
 	"github.com/NilFoundation/nil/nil/common/logging"
 	"github.com/NilFoundation/nil/nil/internal/db"
-	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/api"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/metrics"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/scheduler"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/storage"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/testaide"
-	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -71,6 +69,7 @@ func (s *BlockTasksIntegrationTestSuite) SetupTest() {
 	s.Require().NoError(err, "failed to set proved root in SetUpTest")
 }
 
+/* TODO update with respect new task policy
 func (s *BlockTasksIntegrationTestSuite) Test_Provide_Tasks_And_Handle_Success_Result() {
 	batch := testaide.NewBlockBatch(1)
 	err := s.blockStorage.SetBlockBatch(s.ctx, batch)
@@ -182,7 +181,7 @@ func newTestSuccessProviderResult(taskToExecute *types.Task, executorId types.Ta
 		types.TaskOutputArtifacts{},
 		types.TaskResultData{},
 	)
-}
+}*/
 
 type noopStateResetLauncher struct{}
 

--- a/nil/services/synccommittee/internal/types/block_batch.go
+++ b/nil/services/synccommittee/internal/types/block_batch.go
@@ -122,20 +122,16 @@ func (b *BlockBatch) AllBlocks() []*jsonrpc.RPCBlock {
 	return blocks
 }
 
+// TODO: update signature CreateProofTask(currentTime time.Time) (*TaskEntry, error)
 func (b *BlockBatch) CreateProofTasks(currentTime time.Time) ([]*TaskEntry, error) {
-	taskEntries := make([]*TaskEntry, 0, len(b.ChildBlocks)+1)
+	taskEntries := make([]*TaskEntry, 0, 1)
 
-	aggregateProofsTask := NewAggregateProofsTaskEntry(b.Id, b.MainShardBlock, currentTime)
-	taskEntries = append(taskEntries, aggregateProofsTask)
-
-	for _, childBlock := range b.ChildBlocks {
-		blockProofTask, err := NewBlockProofTaskEntry(b.Id, aggregateProofsTask, childBlock, currentTime)
-		if err != nil {
-			return nil, err
-		}
-
-		taskEntries = append(taskEntries, blockProofTask)
+	batchProofTask, err := NewBatchProofTaskEntry(b.Id, b.AllBlocks(), currentTime)
+	if err != nil {
+		return nil, err
 	}
+
+	taskEntries = append(taskEntries, batchProofTask)
 
 	return taskEntries, nil
 }

--- a/nil/services/synccommittee/internal/types/task_type.go
+++ b/nil/services/synccommittee/internal/types/task_type.go
@@ -13,6 +13,7 @@ const (
 	TaskTypeNone TaskType = iota
 	AggregateProofs
 	ProofBlock
+	ProofBatch
 	PartialProve
 	AggregatedChallenge
 	CombinedQ
@@ -24,6 +25,7 @@ const (
 var TaskTypes = map[string]TaskType{
 	"AggregateProofs":      AggregateProofs,
 	"ProofBlock":           ProofBlock,
+	"ProofBatch":           ProofBatch,
 	"PartialProve":         PartialProve,
 	"AggregatedChallenge":  AggregatedChallenge,
 	"CombinedQ":            CombinedQ,

--- a/nil/services/synccommittee/proofprovider/task_handler_test.go
+++ b/nil/services/synccommittee/proofprovider/task_handler_test.go
@@ -83,36 +83,11 @@ func (s *TaskHandlerTestSuite) TestReturnErrorOnUnexpectedTaskType() {
 	}
 }
 
-func (s *TaskHandlerTestSuite) TestHandleAggregateProofsTask() {
+func (s *TaskHandlerTestSuite) TestHandleBatchProofTask() {
 	now := s.timer.NowTime()
 	executorId := testaide.RandomExecutorId()
-	mainBlock := testaide.NewMainShardBlock()
-	taskEntry := types.NewAggregateProofsTaskEntry(types.NewBatchId(), mainBlock, now)
-	aggProofsTask := taskEntry.Task
-
-	err := s.taskHandler.Handle(s.context, executorId, &taskEntry.Task)
-	s.Require().NoError(err)
-
-	otherExecutorId := testaide.RandomExecutorId()
-	requestedTask, err := s.taskStorage.RequestTaskToExecute(s.context, otherExecutorId)
-	s.Require().NoError(err)
-	s.Require().NotNil(requestedTask)
-
-	s.Require().NotEqual(aggProofsTask.Id, requestedTask.Id)
-	s.Require().Equal(&aggProofsTask.Id, requestedTask.ParentTaskId)
-
-	s.Require().Equal(aggProofsTask.BatchId, requestedTask.BatchId)
-	s.Require().Equal(aggProofsTask.ShardId, requestedTask.ShardId)
-	s.Require().Equal(aggProofsTask.BlockNum, requestedTask.BlockNum)
-	s.Require().Equal(aggProofsTask.BlockHash, requestedTask.BlockHash)
-}
-
-func (s *TaskHandlerTestSuite) TestHandleBlockProofTask() {
-	now := s.timer.NowTime()
-	executorId := testaide.RandomExecutorId()
-	execBlock := testaide.NewExecutionShardBlock()
-	aggregateProofsEntry := types.NewAggregateProofsTaskEntry(types.NewBatchId(), execBlock, now)
-	taskEntry, err := types.NewBlockProofTaskEntry(types.NewBatchId(), aggregateProofsEntry, execBlock, now)
+	batch := testaide.NewBlockBatch(testaide.ShardsCount)
+	taskEntry, err := types.NewBatchProofTaskEntry(types.NewBatchId(), batch.AllBlocks(), now)
 	s.Require().NoError(err)
 
 	err = s.taskHandler.Handle(s.context, executorId, &taskEntry.Task)

--- a/nil/services/synccommittee/proofprovider/task_state_change_handler.go
+++ b/nil/services/synccommittee/proofprovider/task_state_change_handler.go
@@ -38,7 +38,7 @@ func (h taskStateChangeHandler) OnTaskTerminated(ctx context.Context, task *type
 		return nil
 	}
 
-	if task.TaskType != types.MergeProof && task.TaskType != types.AggregateProofs {
+	if task.TaskType != types.MergeProof {
 		log.NewTaskEvent(h.logger, zerolog.DebugLevel, task).Msgf("Task has type %d, skipping", task.TaskType)
 		return nil
 	}

--- a/nil/services/synccommittee/prover/commands/command_factory.go
+++ b/nil/services/synccommittee/prover/commands/command_factory.go
@@ -33,7 +33,7 @@ func (factory *CommandFactory) MakeHandlerCommandForTaskType(taskType types.Task
 		return NewMergeProofCmd(factory.config), nil
 	case types.AggregateProofs:
 		return NewAggregateProofCmd(factory.config), nil
-	case types.ProofBlock:
+	case types.ProofBlock, types.ProofBatch:
 		return nil, types.NewTaskErrNotSupportedType(taskType)
 	case types.TaskTypeNone:
 		return nil, types.NewTaskExecErrorf(types.TaskErrInvalidTask, "TaskType cannot be None")

--- a/nil/services/synccommittee/prover/task_handler.go
+++ b/nil/services/synccommittee/prover/task_handler.go
@@ -76,7 +76,7 @@ func (h *taskHandler) Handle(ctx context.Context, executorId types.TaskExecutorI
 }
 
 func (h *taskHandler) handleImpl(ctx context.Context, task *types.Task) (*executionResult, error) {
-	if task.TaskType == types.ProofBlock {
+	if task.TaskType == types.ProofBatch {
 		return nil, types.NewTaskErrNotSupportedType(task.TaskType)
 	}
 

--- a/nil/services/synccommittee/prover/tracer/state_db.go
+++ b/nil/services/synccommittee/prover/tracer/state_db.go
@@ -776,7 +776,7 @@ func (tsdb *TracerStateDB) GetInTransaction() *types.Transaction {
 
 // Get execution context shard id
 func (tsdb *TracerStateDB) GetShardID() types.ShardId {
-	panic("not implemented")
+	return tsdb.shardId
 }
 
 // SaveVmState saves current VM state

--- a/nil/services/synccommittee/prover/tracer/tracer.go
+++ b/nil/services/synccommittee/prover/tracer/tracer.go
@@ -28,9 +28,13 @@ type RemoteTracerImpl struct {
 
 var _ RemoteTracer = new(RemoteTracerImpl)
 
+type BlockId struct {
+	ShardId types.ShardId
+	Id      transport.BlockReference
+}
+
 type TraceConfig struct {
-	ShardID      types.ShardId
-	BlockIDs     []transport.BlockReference
+	BlockIDs     []BlockId
 	BaseFileName string
 	MarshalMode  MarshalMode
 }
@@ -160,8 +164,8 @@ func GenerateTrace(ctx context.Context, rpcClient api.RpcClient, cfg *TraceConfi
 		return err
 	}
 	aggTraces := NewExecutionTraces()
-	for _, blockID := range cfg.BlockIDs {
-		err := remoteTracer.GetBlockTraces(ctx, aggTraces, cfg.ShardID, blockID)
+	for _, blockId := range cfg.BlockIDs {
+		err := remoteTracer.GetBlockTraces(ctx, aggTraces, blockId.ShardId, blockId.Id)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### Overview
- Handle proof batch of blocks as single task on proof-provider level
- Add option "disable-l1" for sync committee
### Data structures changes
- `Task`: add `BlockIds`, `ShardIds`
- tracer `Config`: add `ShardIDs`

Collect traces for blocks from different shards