### PR TITLE
relayer: event listener impl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOBUILD = GOPRIVATE="$(GOPRIVATE)" $(GO) build $(GO_FLAGS)
 GO_DBG_BUILD = GOPRIVATE="$(GOPRIVATE)" $(GO) build -tags $(BUILD_TAGS),debug,assert -gcflags=all="-N -l"  # see delve docs
 GOTEST = GOPRIVATE="$(GOPRIVATE)" GODEBUG=cgocheck=0 $(GO) test -tags $(BUILD_TAGS),debug,assert,test $(GO_FLAGS) ./... -p 2
 
-SC_COMMANDS = sync_committee sync_committee_cli proof_provider prover nil_block_generator
+SC_COMMANDS = sync_committee sync_committee_cli proof_provider prover nil_block_generator relayer
 COMMANDS += nild nil nil_load_generator exporter cometa faucet journald_forwarder relay $(SC_COMMANDS)
 
 all: $(COMMANDS)

--- a/nil/Makefile.inc
+++ b/nil/Makefile.inc
@@ -4,6 +4,7 @@ root_client = nil/client
 root_vm = nil/internal/vm
 root_db = nil/internal/db
 root_rollup = nil/services/rollup
+root_relayer = nil/services/relayer
 
 .PHONY: generate_mocks
 generate_mocks: \
@@ -11,7 +12,8 @@ generate_mocks: \
 	$(root_vm)/state_generated_mock.go \
 	$(root_db)/rwtx_generated_mock.go \
 	$(root_db)/db_generated_mock.go \
-	$(root_rollup)/l1_fetcher_generated_mock.go
+	$(root_rollup)/l1_fetcher_generated_mock.go \
+	$(root_relayer)/gen_l1_mocks
 
 $(root_client)/client_generated_mock.go: $(root_client)/client.go ssz_types
 	cd $(root_client) && go generate
@@ -27,3 +29,6 @@ $(root_db)/db_generated_mock.go: $(root_db)/kv.go ssz_types
 
 $(root_rollup)/l1_fetcher_generated_mock.go: $(root_rollup)/l1_fetcher.go
 	cd $(root_rollup) && go generate l1_fetcher.go
+
+$(root_relayer)/gen_l1_mocks: $(root_relayer)/internal/l1/generate.go
+	cd $(root_relayer)/internal/l1 && go generate generate.go

--- a/nil/cmd/relayer/main.go
+++ b/nil/cmd/relayer/main.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/NilFoundation/nil/nil/common/check"
+	"github.com/NilFoundation/nil/nil/common/logging"
+	"github.com/NilFoundation/nil/nil/internal/db"
+	"github.com/NilFoundation/nil/nil/internal/profiling"
+	"github.com/NilFoundation/nil/nil/services/relayer"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/jonboulle/clockwork"
+	"github.com/spf13/cobra"
+)
+
+type EthRpcConfig struct {
+	Endpoint string
+	Timeout  time.Duration
+}
+
+type Config struct {
+	DbPath         string
+	L1ClientConfig EthRpcConfig
+	*relayer.RelayerConfig
+}
+
+func main() {
+	check.PanicIfErr(execute())
+}
+
+func execute() error {
+	rootCmd := &cobra.Command{
+		Use:   os.Args[0],
+		Short: "Run nil L1<->L2 relayer",
+	}
+
+	logLevel := rootCmd.Flags().String("log-level", "info", "app log level")
+	rootCmd.PreRun = func(cmd *cobra.Command, args []string) {
+		logging.SetupGlobalLogger(*logLevel)
+	}
+
+	runCfg := Config{
+		RelayerConfig: relayer.DefaultRelayerConfig(),
+	}
+	runCmd := &cobra.Command{
+		Use:   "run",
+		Short: "Run relayer service",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runService(cmd.Context(), &runCfg)
+		},
+	}
+	addRunCommandFlags(runCmd, &runCfg)
+
+	rootCmd.AddCommand(runCmd)
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer cancel()
+
+	return rootCmd.ExecuteContext(ctx)
+}
+
+func addRunCommandFlags(runCmd *cobra.Command, cfg *Config) {
+	runCmd.Flags().StringVar(&cfg.DbPath, "db-path", "relayer.db", "path to database")
+	runCmd.Flags().StringVar(&cfg.L1ClientConfig.Endpoint, "l1-endpoint", "", "URL for ETH L1 client")
+	runCmd.Flags().DurationVar(&cfg.L1ClientConfig.Timeout,
+		"l1-timeout", time.Second, "Max timeout for ETH client to timeout")
+
+	runCmd.Flags().StringVar(
+		&cfg.RelayerConfig.EventListenerConfig.BridgeMessengerContractAddress,
+		"l1-contract-addr",
+		"",
+		"Address of L1BridgeMessenger contract to fetch events from",
+	)
+	runCmd.Flags().StringVar(
+		&cfg.RelayerConfig.EventListenerConfig.BridgeMessengerContractAddress,
+		"l2-contract-addr",
+		"",
+		"Address of L2BridgeMessenger contract to forward events to",
+	)
+
+	runCmd.Flags().IntVar(
+		&cfg.RelayerConfig.EventListenerConfig.BatchSize,
+		"l1-fetcher-batch-size",
+		cfg.RelayerConfig.EventListenerConfig.BatchSize,
+		"Block range len used in event listener to fetch historical data",
+	)
+
+	runCmd.Flags().DurationVar(
+		&cfg.RelayerConfig.EventListenerConfig.PollInterval,
+		"l1-fetcher-poll-interval",
+		cfg.RelayerConfig.EventListenerConfig.PollInterval,
+		"Pause which l1 fetcher takes between fetching historical data batches",
+	)
+}
+
+func runService(ctx context.Context, cfg *Config) error {
+	profiling.Start(profiling.DefaultPort)
+
+	database, err := openDB(cfg.DbPath)
+	if err != nil {
+		return fmt.Errorf("failed to open database: %w", err)
+	}
+	defer database.Close()
+
+	l1Client, err := connectToEthClient(ctx, cfg.L1ClientConfig.Endpoint, cfg.L1ClientConfig.Timeout)
+	if err != nil {
+		return err
+	}
+
+	sysClock := clockwork.NewRealClock()
+
+	svc, err := relayer.New(ctx, database, sysClock, cfg.RelayerConfig, l1Client)
+	if err != nil {
+		return fmt.Errorf("failed to initialize relayer service: %w", err)
+	}
+
+	err = svc.Run(ctx)
+	if errors.Is(err, context.Canceled) {
+		return nil
+	}
+	return err
+}
+
+func openDB(dbPath string) (db.DB, error) {
+	badger, err := db.NewBadgerDb(dbPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create new BadgerDB: %w", err)
+	}
+	return badger, nil
+}
+
+func connectToEthClient(ctx context.Context, url string, timeout time.Duration) (*ethclient.Client, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	ethClient, err := ethclient.DialContext(ctx, url)
+	if err != nil {
+		return nil, fmt.Errorf("connecting to ETH RPC node: %w", err)
+	}
+	return ethClient, nil
+}

--- a/nil/internal/db/kv.go
+++ b/nil/internal/db/kv.go
@@ -50,6 +50,10 @@ type Iter interface {
 	Close()
 }
 
+type Sequence interface {
+	Next() (uint64, error)
+}
+
 type ReadOnlyDB interface {
 	CreateRoTx(ctx context.Context) (RoTx, error)
 	CreateRoTxAt(ctx context.Context, ts Timestamp) (RoTx, error)
@@ -60,6 +64,7 @@ type DB interface {
 	ReadOnlyDB
 
 	CreateRwTx(ctx context.Context) (RwTx, error)
+	GetSequence(ctx context.Context, key []byte, bandwidth uint64) (Sequence, error)
 
 	DropAll() error
 	LogGC(ctx context.Context, discardRation float64, gcFrequency time.Duration) error

--- a/nil/internal/readthroughdb/read_through.go
+++ b/nil/internal/readthroughdb/read_through.go
@@ -161,6 +161,10 @@ func (db *ReadThroughDb) Fetch(ctx context.Context, reader io.Reader) error {
 	panic("Not supported")
 }
 
+func (db *ReadThroughDb) GetSequence(ctx context.Context, key []byte, bandwidth uint64) (db.Sequence, error) {
+	panic("Not supported")
+}
+
 func (db *ReadThroughDb) DropAll() error {
 	return db.db.DropAll()
 }

--- a/nil/services/relayer/internal/l1/contract_wrapper.go
+++ b/nil/services/relayer/internal/l1/contract_wrapper.go
@@ -1,0 +1,77 @@
+package l1
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+type L1Contract interface {
+	SubscribeToEvents(ctx context.Context, sink chan<- *L1MessageSent) (event.Subscription, error)
+	GetEventsFromBlockRange(ctx context.Context, from uint64, to *uint64) ([]*L1MessageSent, error)
+}
+
+type l1ContractWrapper struct {
+	impl   *L1
+	l2Addr common.Address
+}
+
+var _ L1Contract = (*l1ContractWrapper)(nil)
+
+func NewL1ContractWrapper(ethClient EthClient,
+	l1ContractAddr, l2ConractAddr string,
+) (*l1ContractWrapper, error) {
+	addr := common.HexToAddress(l1ContractAddr)
+	impl, err := NewL1(addr, ethClient)
+	if err != nil {
+		return nil, err
+	}
+
+	return &l1ContractWrapper{
+		impl:   impl,
+		l2Addr: common.HexToAddress(l2ConractAddr),
+	}, nil
+}
+
+func (w *l1ContractWrapper) SubscribeToEvents(
+	ctx context.Context,
+	sink chan<- *L1MessageSent,
+) (event.Subscription, error) {
+	return w.impl.WatchMessageSent(
+		&bind.WatchOpts{Context: ctx},
+		sink,
+		nil,                        // any sender (for now)
+		[]common.Address{w.l2Addr}, // destination is the contract this relayer is bound to
+		nil,                        // any nonce
+	)
+}
+
+func (w *l1ContractWrapper) GetEventsFromBlockRange(
+	ctx context.Context,
+	from uint64,
+	to *uint64,
+) ([]*L1MessageSent, error) {
+	iter, err := w.impl.FilterMessageSent(
+		&bind.FilterOpts{
+			Start: from,
+			End:   to,
+		},
+		nil,                        // any sender (for now)
+		[]common.Address{w.l2Addr}, // destination is the contract this relayer is bound to
+		nil,                        // any nonce
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// oclaw: it is not expected to be too much events here, so getting rid of iterator for simplicity
+	// can be changed though
+	var ret []*L1MessageSent
+	for iter.Next() {
+		ret = append(ret, iter.Event)
+	}
+
+	return ret, iter.Error()
+}

--- a/nil/services/relayer/internal/l1/errors.go
+++ b/nil/services/relayer/internal/l1/errors.go
@@ -1,0 +1,18 @@
+package l1
+
+import "errors"
+
+var (
+	ErrKeyExists            = errors.New("object is already stored into the database")
+	ErrSerializationFailed  = errors.New("failed to (de)serialize object")
+	ErrSubscriptionIsBroken = errors.New("l1 subscription is broken")
+)
+
+func ignoreErrors(target error, toIgnore ...error) error {
+	for _, err := range toIgnore {
+		if errors.Is(target, err) {
+			return nil
+		}
+	}
+	return target
+}

--- a/nil/services/relayer/internal/l1/eth_client.go
+++ b/nil/services/relayer/internal/l1/eth_client.go
@@ -1,0 +1,11 @@
+package l1
+
+import (
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+)
+
+type EthClient interface {
+	bind.ContractBackend
+	bind.ContractFilterer
+	bind.ContractTransactor
+}

--- a/nil/services/relayer/internal/l1/event_listener.go
+++ b/nil/services/relayer/internal/l1/event_listener.go
@@ -1,0 +1,387 @@
+package l1
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/NilFoundation/nil/nil/common"
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/jonboulle/clockwork"
+	"github.com/rs/zerolog"
+	"golang.org/x/sync/errgroup"
+)
+
+type EventListenerConfig struct {
+	BridgeMessengerContractAddress string
+
+	// settings for historical events fetcher
+	BatchSize    int
+	PollInterval time.Duration
+
+	EmitEventCapacity int
+}
+
+func DefaultEventListenerConfig() *EventListenerConfig {
+	return &EventListenerConfig{
+		BatchSize:         100,
+		PollInterval:      time.Millisecond * 100,
+		EmitEventCapacity: 0, // recommended for production usage
+	}
+}
+
+func (cfg *EventListenerConfig) Validate() error {
+	if cfg.BridgeMessengerContractAddress == "" {
+		return errors.New("empty L1BridgeMessenger contract addr")
+	}
+	if cfg.BatchSize == 0 {
+		return errors.New("empty batch size for fetching old events")
+	}
+	if cfg.PollInterval == 0 {
+		return errors.New("empty poll interval for fetching old events")
+	}
+	return nil
+}
+
+type EventListener struct {
+	rawEthClient    EthClient
+	contractBinding L1Contract
+	clock           clockwork.Clock
+
+	config       *EventListenerConfig
+	eventStorage *EventStorage
+
+	state struct {
+		emitter chan struct{} // signals when new event is put to storage
+
+		// last block event from which is put to storage
+		currentBlockNumber uint64
+		currentBlockHash   ethcommon.Hash
+	}
+
+	logger zerolog.Logger
+}
+
+func NewEventListener(
+	config *EventListenerConfig,
+	clock clockwork.Clock,
+	ethClient EthClient,
+	contractClient L1Contract,
+	storage *EventStorage,
+	logger zerolog.Logger,
+) (*EventListener, error) {
+	el := &EventListener{
+		rawEthClient:    ethClient,
+		contractBinding: contractClient,
+		clock:           clock,
+		config:          config,
+		eventStorage:    storage,
+		logger:          logger,
+	}
+
+	el.state.emitter = make(chan struct{}, config.EmitEventCapacity)
+
+	return el, nil
+}
+
+func (el *EventListener) Name() string {
+	return "l1-event-listener"
+}
+
+func (el *EventListener) Run(ctx context.Context, started chan<- struct{}) error {
+	if err := el.config.Validate(); err != nil {
+		return err
+	}
+
+	close(started)
+
+	retrier := common.NewRetryRunner(
+		common.RetryConfig{
+			ShouldRetry: common.LimitRetries(10),
+			NextDelay:   common.DelayExponential(100*time.Millisecond, time.Second*10),
+		},
+		el.logger,
+	)
+
+	// event listener has to be interrupted in case of subscription is broken
+	return retrier.Do(ctx, func(ctx context.Context) error {
+		el.logger.Info().Msg("initializing event listener")
+		return el.run(ctx)
+	})
+}
+
+func (el *EventListener) run(ctx context.Context) error {
+	var (
+		oldEventCh = make(chan *L1MessageSent, el.config.BatchSize)
+		// large buffer to keep accumulating new events while fetching last (eth Client anyway uses large internal buf)
+		newEventCh = make(chan *L1MessageSent, el.config.BatchSize*10)
+	)
+
+	el.state.currentBlockNumber = 0
+	el.state.currentBlockHash = ethcommon.Hash{}
+
+	eg, gCtx := errgroup.WithContext(ctx)
+
+	eg.Go(func() error {
+		return el.subscriber(gCtx, newEventCh)
+	})
+
+	eg.Go(func() error {
+		return el.fetcher(gCtx, oldEventCh)
+	})
+
+	eg.Go(func() error {
+		return el.eventProcessor(gCtx, oldEventCh, newEventCh)
+	})
+
+	err := eg.Wait()
+	el.logger.Debug().Err(err).Msg("l1 event listener done")
+	return err
+}
+
+// Can be used by reading routine to look for updates without further delay
+func (el *EventListener) EventReceived() <-chan struct{} {
+	return el.state.emitter
+}
+
+// Routine responsible for:
+// - subscription to the contract events
+// - tracking of the subscription status
+func (el *EventListener) subscriber(ctx context.Context, eventCh chan<- *L1MessageSent) error {
+	defer close(eventCh)
+
+	el.logger.Info().Msg("started subscriber")
+
+	sub, err := el.contractBinding.SubscribeToEvents(ctx, eventCh)
+	if err != nil {
+		el.logger.Error().
+			Str("contract_addr", el.config.BridgeMessengerContractAddress).
+			Err(err).
+			Msg("failed to subscribe to updates from L1 contract")
+		return err
+
+		// TODO(oclaw) metrics
+	}
+	defer sub.Unsubscribe()
+
+	el.logger.Info().
+		Str("contract_addr", el.config.BridgeMessengerContractAddress).
+		Msg("subscribed to new events")
+
+	select {
+	case <-ctx.Done():
+		el.logger.Debug().Msg("subscriber canceled")
+		return ctx.Err()
+	case err, ok := <-sub.Err():
+		if ok {
+			el.logger.Error().
+				Str("contract_addr", el.config.BridgeMessengerContractAddress).
+				Err(err).
+				Msg("L1 subscription is broken")
+
+			// TODO(oclaw) metrics
+			return fmt.Errorf("%w: %w", ErrSubscriptionIsBroken, err)
+		}
+		el.logger.Debug().Msg("subscription channel is closed")
+	}
+
+	return nil
+}
+
+// Routine responsible for fetching historical blocks in range [lastProcessedBlock; latest)
+// until it is executed incoming event processing is shutdown
+func (el *EventListener) fetcher(ctx context.Context, eventCh chan<- *L1MessageSent) error {
+	defer close(eventCh) // no more events will be posted to the channel after routine finished its work
+
+	el.logger.Info().Msg("started fetcher")
+
+	// try fetching as long as possible, force exit after large enough attempt number
+	retrier := common.NewRetryRunner(
+		common.RetryConfig{
+			ShouldRetry: common.LimitRetries(100),
+			NextDelay:   common.DelayExponential(time.Second, time.Second*15),
+		},
+		el.logger,
+	)
+
+	return retrier.Do(ctx, func(ctx context.Context) error {
+		err := el.fetchPastEvents(ctx, eventCh)
+		if err != nil {
+			el.logger.Error().Err(err).Msg("historical event fetching failed")
+			// TODO (oclaw) metrics
+		}
+		return err
+	})
+
+	// TODO(oclaw) metrics (this routine is not expected to run for too long, we should now if something is stuck here)
+}
+
+func (el *EventListener) fetchPastEvents(ctx context.Context, eventCh chan<- *L1MessageSent) error {
+	header, err := el.rawEthClient.HeaderByNumber(ctx, nil) // nil block number == fetch of the latest block from L1
+	if err != nil {
+		return err
+	}
+	latestBlock := header.Number.Uint64()
+
+	lastProcessedBlock, err := el.eventStorage.GetLastProcessedBlock(ctx)
+	if err != nil {
+		return err
+	}
+
+	if lastProcessedBlock != nil {
+		el.setCurrentProcessingBlock(lastProcessedBlock.BlockNumber, lastProcessedBlock.BlockHash)
+	} else {
+		el.setCurrentProcessingBlock(latestBlock, header.Hash())
+	}
+
+	el.logger.Info().
+		Uint64("latest_block_num", latestBlock).
+		Uint64("latest_processed_block_num", el.state.currentBlockNumber).
+		Msg("connected to Etherium")
+
+	if el.state.currentBlockNumber >= latestBlock {
+		el.logger.Info().Msg("no need to fetch old events")
+		return nil
+	}
+
+	ticker := el.clock.NewTicker(el.config.PollInterval)
+	batchSize := uint64(el.config.BatchSize)
+	for fromBlock := el.state.currentBlockNumber + 1; fromBlock <= latestBlock; fromBlock += batchSize {
+		select {
+		case <-ticker.Chan():
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+
+		toBlock := min(latestBlock, fromBlock+batchSize-1)
+
+		el.logger.Info().
+			Uint64("block_range_start", fromBlock).
+			Uint64("block_range_end", toBlock).
+			Msg("fetching historical events from block range")
+
+		events, err := el.contractBinding.GetEventsFromBlockRange(ctx, fromBlock, &toBlock)
+		if err != nil {
+			return err
+		}
+
+		for _, event := range events {
+			eventCh <- event
+		}
+	}
+	return nil
+}
+
+func (el *EventListener) eventProcessor(
+	ctx context.Context,
+	oldEventChan chan *L1MessageSent,
+	newEventChan chan *L1MessageSent,
+) error {
+	el.logger.Info().Msg("started event processor")
+
+	processedOldEvents := 0
+	for event := range oldEventChan {
+		if err := el.processEvent(ctx, event); err != nil {
+			return err
+		}
+		processedOldEvents++
+	}
+
+	el.logger.Info().
+		Int("old_processed_events", processedOldEvents).
+		Int("incoming_events_buf", len(newEventChan)).
+		Msg("finished processing old events")
+
+	for {
+		select {
+		case event, ok := <-newEventChan:
+			if !ok {
+				return nil // subscription is inactive now
+			}
+
+			if err := el.processEvent(ctx, event); err != nil {
+				return err
+			}
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+func (el *EventListener) processEvent(ctx context.Context, ethEvent *L1MessageSent) error {
+	event := el.convertEvent(ethEvent)
+
+	// all retryable errors should be handled inside storage, otherwise we should interrupt service work
+	err := el.eventStorage.StoreEvent(ctx, event)
+	if err := ignoreErrors(err, ErrKeyExists); err != nil {
+		return err
+	}
+
+	if el.state.currentBlockNumber != ethEvent.Raw.BlockNumber {
+		el.logger.Info().
+			Uint64("block_number", el.state.currentBlockNumber).
+			Uint64("new_block_number", ethEvent.Raw.BlockNumber).
+			Msg("finished processing events from block")
+		if err := el.onNewBlockBegan(ctx, ethEvent); err != nil {
+			return err
+		}
+	}
+
+	// non-blocking write to notify reader
+	select {
+	case el.state.emitter <- struct{}{}:
+	default:
+		el.logger.Trace().Msg("emit event dropped")
+	}
+
+	return nil
+}
+
+func (el *EventListener) convertEvent(ethEvent *L1MessageSent) *Event {
+	event := &Event{
+		Hash:        ethEvent.MessageHash,
+		BlockNumber: ethEvent.Raw.BlockNumber,
+		BlockHash:   ethEvent.Raw.BlockHash,
+
+		Sender:             ethEvent.MessageSender,
+		Target:             ethEvent.MessageTarget,
+		Value:              ethEvent.MessageValue,
+		Message:            ethEvent.Message,
+		Type:               ethEvent.MessageType,
+		CreatedAt:          ethEvent.MessageCreatedAt,
+		ExpiryTime:         ethEvent.MessageExpiryTime,
+		L2FeeRefundAddress: ethEvent.L2FeeRefundAddress,
+		FeeCreditData: FeeCreditData{
+			NilGasLimit:          ethEvent.FeeCreditData.NilGasLimit,
+			MaxFeePerGas:         ethEvent.FeeCreditData.MaxFeePerGas,
+			MaxPriorityFeePerGas: ethEvent.FeeCreditData.MaxPriorityFeePerGas,
+			FeeCredit:            ethEvent.FeeCreditData.FeeCredit,
+		},
+	}
+	return event
+}
+
+// should be called only from eventProcessor
+func (el *EventListener) onNewBlockBegan(ctx context.Context, newBlockInfo *L1MessageSent) error {
+	// save previous not empty block info to the database
+	if el.state.currentBlockNumber != 0 {
+		procBlk := &ProcessedBlock{
+			BlockNumber: el.state.currentBlockNumber,
+			BlockHash:   el.state.currentBlockHash,
+		}
+
+		if err := el.eventStorage.SetLastProcessedBlock(ctx, procBlk); err != nil {
+			return err
+		}
+	}
+
+	el.setCurrentProcessingBlock(newBlockInfo.Raw.BlockNumber, newBlockInfo.Raw.BlockHash)
+
+	return nil
+}
+
+func (el *EventListener) setCurrentProcessingBlock(number uint64, hash ethcommon.Hash) {
+	el.state.currentBlockNumber = number
+	el.state.currentBlockHash = hash
+}

--- a/nil/services/relayer/internal/l1/event_listener_test.go
+++ b/nil/services/relayer/internal/l1/event_listener_test.go
@@ -1,0 +1,403 @@
+package l1
+
+import (
+	"context"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/NilFoundation/nil/nil/internal/db"
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/jonboulle/clockwork"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/suite"
+)
+
+type EventListenerTestSuite struct {
+	suite.Suite
+
+	// high level dependencies
+	database db.DB
+	storage  *EventStorage
+	logger   zerolog.Logger
+	clock    clockwork.Clock
+
+	// testing entity
+	listener *EventListener
+
+	// mocks
+	ethClientMock  *EthClientMock
+	l1ContractMock *L1ContractMock
+
+	// testing lifecycle stuff
+	ctx      context.Context
+	canceler context.CancelFunc
+
+	listenerCtx      context.Context
+	listenerCanceler context.CancelFunc
+
+	listenerStopped chan struct{}
+}
+
+func TestEventListener(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(EventListenerTestSuite))
+}
+
+func (s *EventListenerTestSuite) SetupTest() {
+	var err error
+
+	s.ctx, s.canceler = context.WithCancel(context.Background())
+	s.logger = zerolog.New(zerolog.NewConsoleWriter())
+
+	s.database, err = db.NewBadgerDbInMemory()
+	s.Require().NoError(err, "failed to initialize test db")
+
+	s.clock = clockwork.NewRealClock()
+	s.ethClientMock = &EthClientMock{}
+	s.l1ContractMock = &L1ContractMock{}
+
+	s.storage, err = NewEventStorage(s.ctx, s.database, s.clock, nil, s.logger)
+	s.Require().NoError(err, "failed to initialize event storage")
+
+	cfg := DefaultEventListenerConfig()
+	cfg.PollInterval = time.Millisecond
+	cfg.BridgeMessengerContractAddress = "0xDEADBEEF"
+	cfg.EmitEventCapacity = 100 // do avoid event dropping
+
+	s.listener, err = NewEventListener(cfg, s.clock, s.ethClientMock, s.l1ContractMock, s.storage, s.logger)
+	s.Require().NoError(err, "failed to create listener")
+}
+
+func (s *EventListenerTestSuite) runListener() {
+	s.listenerCtx, s.listenerCanceler = context.WithCancel(s.ctx)
+
+	listenerStarted := make(chan struct{})
+	s.listenerStopped = make(chan struct{})
+	go func() {
+		defer close(s.listenerStopped)
+		err := s.listener.Run(s.listenerCtx, listenerStarted)
+		if err != nil {
+			s.ErrorIs(err, context.Canceled)
+		}
+	}()
+
+	<-listenerStarted
+}
+
+func (s *EventListenerTestSuite) stopListener() {
+	if s.listenerCanceler != nil {
+		s.listenerCanceler()
+	}
+	<-s.listenerStopped
+}
+
+func (s *EventListenerTestSuite) waitForEvents(eventCount int) chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		for range eventCount {
+			<-s.listener.EventReceived()
+		}
+		close(done)
+	}()
+	return done
+}
+
+func (s *EventListenerTestSuite) TearDownTest() {
+	s.canceler()
+	<-s.listenerStopped
+}
+
+func (s *EventListenerTestSuite) TestEmptyRun() {
+	// some default block value
+	s.ethClientMock.HeaderByNumberFunc = func(ctx context.Context, number *big.Int) (*ethtypes.Header, error) {
+		return &ethtypes.Header{Number: big.NewInt(1024)}, nil
+	}
+
+	// default subscription initializer
+	s.l1ContractMock.SubscribeToEventsFunc = func(
+		ctx context.Context,
+		sink chan<- *L1MessageSent,
+	) (event.Subscription, error) {
+		return event.NewSubscription(func(<-chan struct{}) error {
+			return nil
+		}), nil
+	}
+
+	s.runListener()
+}
+
+func (s *EventListenerTestSuite) TestFetchHistoricalEvents() {
+	// test case:
+	// set latest block to 1024
+	// set last processed block to 800
+	// return events for blocks 801, 901, 1001 (using fetcher's request mock)
+	// ensure their content and order in storage
+	// repeat the test from the beginning (with modified database)
+
+	s.ethClientMock.HeaderByNumberFunc = func(ctx context.Context, number *big.Int) (*ethtypes.Header, error) {
+		return &ethtypes.Header{Number: big.NewInt(1024)}, nil
+	}
+	s.l1ContractMock.SubscribeToEventsFunc = func(
+		ctx context.Context,
+		sink chan<- *L1MessageSent,
+	) (event.Subscription, error) {
+		return event.NewSubscription(func(<-chan struct{}) error {
+			return nil
+		}), nil
+	}
+
+	expectedRanges := []struct {
+		from, to uint64
+	}{
+		{801, 900},
+		{901, 1000},
+		{1001, 1024},
+	}
+
+	testIteration := func() {
+		defer s.stopListener()
+
+		callNumber := 0
+		s.l1ContractMock.GetEventsFromBlockRangeFunc = func(
+			ctx context.Context,
+			from uint64,
+			to *uint64,
+		) ([]*L1MessageSent, error) {
+			s.Equal(from, expectedRanges[callNumber].from, "bad call number %d", callNumber)
+			if s.NotNil(to) {
+				s.Equal(*to, expectedRanges[callNumber].to, "bad call number %d", callNumber)
+			}
+			callNumber++
+
+			// for each range return single event for its first block
+			return []*L1MessageSent{
+				{
+					MessageHash: getMsgHash(msgSourceFetcher, callNumber+1),
+					Raw: types.Log{
+						BlockNumber: from,
+						BlockHash:   ethcommon.BytesToHash([]byte{1, 2, 3, 4}),
+					},
+				},
+			}, nil
+		}
+
+		err := s.storage.SetLastProcessedBlock(s.ctx, &ProcessedBlock{
+			BlockNumber: 800, // [800; 1024) blocks are expected to be fetched
+			BlockHash:   ethcommon.BytesToHash([]byte{1, 2, 3, 4}),
+		})
+		s.Require().NoError(err)
+
+		eventCount := len(expectedRanges)
+
+		awaiter := s.waitForEvents(eventCount)
+		s.runListener()
+		<-awaiter
+
+		err = s.storage.IterateEventsByBatch(s.ctx, 100, func(events []*Event) error {
+			s.Len(events, eventCount)
+			for i, event := range events {
+				s.EqualValues(expectedRanges[i].from, event.BlockNumber)
+				s.EqualValues(i, event.SequenceNumber)
+			}
+			return nil
+		})
+		s.Require().NoError(err, "failed to iterate saved events")
+
+		processedBlock, err := s.storage.GetLastProcessedBlock(s.ctx)
+		s.Require().NoError(err)
+
+		// we still might receive some updates from last block so last processed now is the one before las
+		s.EqualValues(901, processedBlock.BlockNumber)
+	}
+
+	testIteration()
+
+	// Run sequence again setting last block to the same 800
+	// Target is to check that ordering is not changed (and nothing is stuck on repeat)
+	s.Run("Idempotent", func() {
+		testIteration()
+	})
+}
+
+func (s *EventListenerTestSuite) TestFetchEventsFromSubscription() {
+	// test case:
+	// set latest block to 1024
+	// push events for subscription to blocks 1025, 1026, 1027
+	// ensure their content and order in storage
+	// repeat the test from the beginning (with modified database)
+
+	s.ethClientMock.HeaderByNumberFunc = func(ctx context.Context, number *big.Int) (*ethtypes.Header, error) {
+		return &ethtypes.Header{Number: big.NewInt(1024)}, nil
+	}
+
+	testIteration := func() {
+		defer s.stopListener()
+
+		// mock subscription to provide new events
+		s.l1ContractMock.SubscribeToEventsFunc = func(
+			ctx context.Context,
+			sink chan<- *L1MessageSent,
+		) (event.Subscription, error) {
+			sub := event.NewSubscription(func(<-chan struct{}) error {
+				<-ctx.Done()
+				return nil
+			})
+
+			go func() {
+				for i := 1; i < 4; i++ {
+					sink <- &L1MessageSent{
+						MessageHash: getMsgHash(msgSourceSubscription, i),
+						Raw: types.Log{
+							BlockNumber: 1024 + uint64(i),
+							BlockHash:   ethcommon.BytesToHash([]byte{1, 2, 3, byte(i)}),
+						},
+					}
+				}
+			}()
+
+			return sub, nil
+		}
+
+		eventCount := 3
+
+		awaiter := s.waitForEvents(eventCount)
+		s.runListener()
+		<-awaiter
+
+		err := s.storage.IterateEventsByBatch(s.ctx, 100, func(events []*Event) error {
+			s.Len(events, eventCount)
+			for i, event := range events {
+				s.EqualValues(1024+i+1, event.BlockNumber)
+				s.EqualValues(i, event.SequenceNumber)
+			}
+			return nil
+		})
+		s.Require().NoError(err, "failed to iterate saved events")
+
+		lastProcessedBlock, err := s.storage.GetLastProcessedBlock(s.ctx)
+		s.Require().NoError(err)
+
+		s.EqualValues(1026, lastProcessedBlock.BlockNumber)
+	}
+
+	testIteration()
+
+	s.Run("Idempotent", func() {
+		testIteration()
+	})
+}
+
+func (s *EventListenerTestSuite) TestSmoke() {
+	// test case:
+	// set current block number to 1024
+	// set last processed block number to 800
+	// run whole listener, simultaneously push events to fetcher and subscriber
+	// ensure that all events are stored in the given order (first from fetcher, then from subscriber)
+
+	s.ethClientMock.HeaderByNumberFunc = func(ctx context.Context, number *big.Int) (*ethtypes.Header, error) {
+		return &ethtypes.Header{Number: big.NewInt(1024)}, nil
+	}
+
+	s.l1ContractMock.SubscribeToEventsFunc = func(
+		ctx context.Context,
+		sink chan<- *L1MessageSent,
+	) (event.Subscription, error) {
+		sub := event.NewSubscription(func(<-chan struct{}) error {
+			<-ctx.Done()
+			return nil
+		})
+
+		go func() {
+			for i := 1; i < 4; i++ {
+				sink <- &L1MessageSent{
+					MessageHash: getMsgHash(msgSourceSubscription, i),
+					Raw: types.Log{
+						BlockNumber: 1024 + uint64(i),
+						BlockHash:   ethcommon.BytesToHash([]byte{1, 2, 3, byte(i)}),
+					},
+				}
+			}
+		}()
+
+		return sub, nil
+	}
+
+	expectedRanges := []struct {
+		from, to uint64
+	}{
+		{801, 900},
+		{901, 1000},
+		{1001, 1024},
+	}
+
+	callNumber := 0
+	s.l1ContractMock.GetEventsFromBlockRangeFunc = func(
+		ctx context.Context,
+		from uint64,
+		to *uint64,
+	) ([]*L1MessageSent, error) {
+		s.Equal(from, expectedRanges[callNumber].from, "bad call number %d", callNumber)
+		if s.NotNil(to) {
+			s.Equal(*to, expectedRanges[callNumber].to, "bad call number %d", callNumber)
+		}
+		callNumber++
+
+		// for each range return single event for its first block
+		return []*L1MessageSent{
+			{
+				MessageHash: getMsgHash(msgSourceFetcher, callNumber+1),
+				Raw: types.Log{
+					BlockNumber: from,
+					BlockHash:   ethcommon.BytesToHash([]byte{1, 2, 3, 4}),
+				},
+			},
+		}, nil
+	}
+
+	err := s.storage.SetLastProcessedBlock(s.ctx, &ProcessedBlock{
+		BlockNumber: 800, // [800; 1024) blocks are expected to be fetched
+		BlockHash:   ethcommon.BytesToHash([]byte{1, 2, 3, 4}),
+	})
+	s.Require().NoError(err)
+
+	eventCount := 6
+	awaiter := s.waitForEvents(eventCount)
+	s.runListener()
+	<-awaiter
+
+	err = s.storage.IterateEventsByBatch(s.ctx, 100, func(events []*Event) error {
+		s.Require().Len(events, 6)
+
+		expectedBlockNumbers := [6]int{801, 901, 1001, 1025, 1026, 1027}
+		for i, n := range expectedBlockNumbers {
+			s.EqualValues(i, events[i].SequenceNumber)
+			s.EqualValues(n, events[i].BlockNumber)
+		}
+
+		return nil
+	})
+	s.Require().NoError(err)
+}
+
+type msgSource byte
+
+const (
+	msgSourceFetcher      msgSource = 0
+	msgSourceSubscription msgSource = 1
+)
+
+func getMsgHash(source msgSource, seqNo int) [32]byte {
+	var hash [32]byte
+	hash[0] = byte(source)
+	for i := range hash[1:] {
+		hash[i+1] = byte(seqNo)
+	}
+	return hash
+}
+
+// TODO(oclaw) add checks for shutdown
+// TODO(oclaw) add checks for event data filling

--- a/nil/services/relayer/internal/l1/finality_ensurer.go
+++ b/nil/services/relayer/internal/l1/finality_ensurer.go
@@ -1,0 +1,29 @@
+package l1
+
+import (
+	"context"
+	"errors"
+)
+
+type FinalityEnsurer struct {
+	// TODO poll storage from listener emits & by ticker
+	// fetch latest finalized block by ticker
+	// for each block which number <= last finalized block number:
+	//   - if it is included in chain - put it into the L2 event storage
+	//   - if it is not in chain - ignore & add log
+	//   - drop record from L1 evnet storage
+	//   - emit event
+	emitter chan struct{}
+}
+
+func (fe *FinalityEnsurer) Name() string {
+	return "l1-block-finality-ensurer"
+}
+
+func (fe *FinalityEnsurer) Run(ctx context.Context, started chan<- struct{}) error {
+	return errors.New("not implemented")
+}
+
+func (fe *FinalityEnsurer) EventFinalized() <-chan struct{} {
+	return fe.emitter
+}

--- a/nil/services/relayer/internal/l1/generate.go
+++ b/nil/services/relayer/internal/l1/generate.go
@@ -1,0 +1,7 @@
+package l1
+
+// TODO(oclaw) do not copypaste ABI file, use one generated from actual L1BridgeMessenger.sol compilation
+//go:generate go run github.com/ethereum/go-ethereum/cmd/abigen --abi=l1_bridge_messenger_abi.json --pkg=l1 --out=./l1_bridge_messenger_contract_abi_generated.go
+
+//go:generate go run github.com/matryer/moq -out eth_client_generated_mock.go -rm -stub -with-resets . EthClient
+//go:generate go run github.com/matryer/moq -out l1_contract_generated_mock.go -rm -stub -with-resets . L1Contract

--- a/nil/services/relayer/internal/l1/l1_bridge_messenger_abi.json
+++ b/nil/services/relayer/internal/l1/l1_bridge_messenger_abi.json
@@ -1,0 +1,1538 @@
+[
+  {
+    "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "AccessControlBadConfirmation",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "neededRole",
+        "type": "bytes32"
+      }
+    ],
+    "name": "AccessControlUnauthorizedAccount",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "BridgeAlreadyAuthorized",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "BridgeNotAuthorized",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "messageHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "DepositMessageAlreadyCancelled",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DepositMessageAlreadyClaimed",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "messageHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "DepositMessageAlreadyExist",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "messageHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "DepositMessageDoesNotExist",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "messageHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "DepositMessageNotExpired",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DepositMessageStillInQueue",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "EnforcedPause",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ErrorCallerIsNotAdmin",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ErrorCallerIsNotProposer",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ErrorInvalidAmount",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ErrorInvalidClaimProof",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ErrorInvalidDefaultAdmin",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ErrorInvalidGasLimit",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ErrorInvalidHash",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ErrorInvalidOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ErrorZeroAddress",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ExpectedPause",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidBridgeInterface",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidInitialization",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidMaxMessageProcessingTime",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidMessageCancelDeltaTime",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "messageHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "MessageHashNotInQueue",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotAuthorizedToPopMessages",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotEnoughMessagesInQueue",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotEnoughMessagesInQueue",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotInitializing",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnableInvalidOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "OwnableUnauthorizedAccount",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "QueueIsEmpty",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ReentrancyGuardReentrantCall",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "messageHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "DepositMessageCancelled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "version",
+        "type": "uint64"
+      }
+    ],
+    "name": "Initialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "messageSender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "messageTarget",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "messageValue",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "messageNonce",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "message",
+        "type": "bytes"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "messageHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "enum NilConstants.MessageType",
+        "name": "messageType",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "messageCreatedAt",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "messageExpiryTime",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "l2FeeRefundAddress",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "nilGasLimit",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "maxFeePerGas",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "maxPriorityFeePerGas",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "feeCredit",
+            "type": "uint256"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct INilGasPriceOracle.FeeCreditData",
+        "name": "feeCreditData",
+        "type": "tuple"
+      }
+    ],
+    "name": "MessageSent",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Paused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "previousAdminRole",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "newAdminRole",
+        "type": "bytes32"
+      }
+    ],
+    "name": "RoleAdminChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleGranted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleRevoked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Unpaused",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "DEFAULT_ADMIN_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "addAdmin",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "bridge",
+        "type": "address"
+      }
+    ],
+    "name": "authorizeBridge",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "bridges",
+        "type": "address[]"
+      }
+    ],
+    "name": "authorizeBridges",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "messageHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "cancelDeposit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "messageHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "claimProof",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "claimFailedDeposit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_messageSender",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_messageTarget",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_value",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_messageNonce",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_message",
+        "type": "bytes"
+      }
+    ],
+    "name": "computeMessageHash",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "counterpartyBridgeMessenger",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "adminRole",
+        "type": "bytes32"
+      }
+    ],
+    "name": "createNewRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "depositMessages",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "target",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "nonce",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "expiryTime",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "isCancelled",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "isClaimed",
+        "type": "bool"
+      },
+      {
+        "internalType": "address",
+        "name": "l1DepositRefundAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "enum NilConstants.MessageType",
+        "name": "messageType",
+        "type": "uint8"
+      },
+      {
+        "internalType": "bytes",
+        "name": "message",
+        "type": "bytes"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "nilGasLimit",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "maxFeePerGas",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "maxPriorityFeePerGas",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "feeCredit",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct INilGasPriceOracle.FeeCreditData",
+        "name": "feeCreditData",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "depositNonce",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAllAdmins",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAllProposers",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAuthorizedBridges",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "msgHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getDepositMessage",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "sender",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "target",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "value",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "nonce",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "expiryTime",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bool",
+            "name": "isCancelled",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "isClaimed",
+            "type": "bool"
+          },
+          {
+            "internalType": "address",
+            "name": "l1DepositRefundAddress",
+            "type": "address"
+          },
+          {
+            "internalType": "enum NilConstants.MessageType",
+            "name": "messageType",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bytes",
+            "name": "message",
+            "type": "bytes"
+          },
+          {
+            "components": [
+              {
+                "internalType": "uint256",
+                "name": "nilGasLimit",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "maxFeePerGas",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "maxPriorityFeePerGas",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "feeCredit",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct INilGasPriceOracle.FeeCreditData",
+            "name": "feeCreditData",
+            "type": "tuple"
+          }
+        ],
+        "internalType": "struct IL1BridgeMessenger.DepositMessage",
+        "name": "depositMessage",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "msgHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getMessageType",
+    "outputs": [
+      {
+        "internalType": "enum NilConstants.MessageType",
+        "name": "messageType",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getNextDepositNonce",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getOwner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getRoleAdmin",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "getRoleMember",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getRoleMemberCount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getRoleMembers",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "grantAccess",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "grantProposerAccess",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "grantProposerAdminRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "grantRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "hasRole",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_defaultAdmin",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_l1NilRollup",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_maxProcessingTime",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_counterpartyBridgeMessenger",
+        "type": "address"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "proposerArg",
+        "type": "address"
+      }
+    ],
+    "name": "isAProposer",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "adminArg",
+        "type": "address"
+      }
+    ],
+    "name": "isAnAdmin",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "ownerArg",
+        "type": "address"
+      }
+    ],
+    "name": "isAnOwner",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maxProcessingTime",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "paused",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "messageCount",
+        "type": "uint256"
+      }
+    ],
+    "name": "popMessages",
+    "outputs": [
+      {
+        "internalType": "bytes32[]",
+        "name": "",
+        "type": "bytes32[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "removeAdmin",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      }
+    ],
+    "name": "renounceAccess",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "callerConfirmation",
+        "type": "address"
+      }
+    ],
+    "name": "renounceRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "revokeAccess",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "bridge",
+        "type": "address"
+      }
+    ],
+    "name": "revokeBridgeAuthorization",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "revokeProposerAccess",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "revokeProposerAdminRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "revokeRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "enum NilConstants.MessageType",
+        "name": "messageType",
+        "type": "uint8"
+      },
+      {
+        "internalType": "address",
+        "name": "messageTarget",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "message",
+        "type": "bytes"
+      },
+      {
+        "internalType": "address",
+        "name": "l1DepositRefundAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "l2FeeRefundAddress",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "nilGasLimit",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "maxFeePerGas",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "maxPriorityFeePerGas",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "feeCredit",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct INilGasPriceOracle.FeeCreditData",
+        "name": "feeCreditData",
+        "type": "tuple"
+      }
+    ],
+    "name": "sendMessage",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "enum NilConstants.MessageType",
+        "name": "messageType",
+        "type": "uint8"
+      },
+      {
+        "internalType": "address",
+        "name": "messageTarget",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "message",
+        "type": "bytes"
+      },
+      {
+        "internalType": "address",
+        "name": "l2FeeRefundAddress",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "nilGasLimit",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "maxFeePerGas",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "maxPriorityFeePerGas",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "feeCredit",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct INilGasPriceOracle.FeeCreditData",
+        "name": "feeCreditData",
+        "type": "tuple"
+      }
+    ],
+    "name": "sendMessage",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "_status",
+        "type": "bool"
+      }
+    ],
+    "name": "setPause",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes4",
+        "name": "interfaceId",
+        "type": "bytes4"
+      }
+    ],
+    "name": "supportsInterface",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnershipRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "stateMutability": "payable",
+    "type": "receive"
+  }
+]

--- a/nil/services/relayer/internal/l1/storage.go
+++ b/nil/services/relayer/internal/l1/storage.go
@@ -1,0 +1,253 @@
+package l1
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/NilFoundation/nil/nil/common"
+	"github.com/NilFoundation/nil/nil/internal/db"
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/jonboulle/clockwork"
+	"github.com/rs/zerolog"
+)
+
+const (
+	// pendingEventsTable stores events received from L1BridgeMessenger waiting to be finalized
+	// Key: Hash of the Event
+	pendingEventsTable = "pending_events"
+
+	// monotonic counter managing ordering between received events
+	pendingEventsSequencer = "pending_events_sequencer"
+
+	// lastProcessedBlockTable stores number (and some meta-info)
+	// for last block events from which were successfully stored to the local database (single value)
+	// Key: lastProcessedBlockKey
+	lastProcessedBlockTable = "last_processed_block"
+	lastProcessedBlockKey   = "last_processed_block_key"
+)
+
+type EventStorageMetrics interface {
+	// TODO(oclaw)
+}
+
+type EventStorage struct {
+	database        db.DB
+	retryRunner     common.RetryRunner
+	clock           clockwork.Clock
+	metrics         EventStorageMetrics
+	eventsSequencer db.Sequence
+}
+
+func NewEventStorage(
+	ctx context.Context,
+	database db.DB,
+	clock clockwork.Clock,
+	metrics EventStorageMetrics,
+	logger zerolog.Logger,
+) (*EventStorage, error) {
+	es := &EventStorage{
+		database: database,
+		retryRunner: common.NewRetryRunner(
+			common.RetryConfig{
+				ShouldRetry: common.ComposeRetryPolicies(
+					common.LimitRetries(10),
+					common.DoNotRetryIf(ErrKeyExists, ErrSerializationFailed),
+				),
+				NextDelay: common.DelayJitter(20*time.Millisecond, 100*time.Millisecond, logger),
+			},
+			logger,
+		),
+		clock:   clock,
+		metrics: metrics,
+	}
+	var err error
+	es.eventsSequencer, err = database.GetSequence(ctx, []byte(pendingEventsSequencer), 100)
+	if err != nil {
+		return nil, err
+	}
+
+	return es, nil
+}
+
+func (es *EventStorage) StoreEvent(ctx context.Context, evt *Event) error {
+	var emptyHash ethcommon.Hash
+	if evt.Hash == emptyHash {
+		return errors.New("cannot store event without hash")
+	}
+
+	return es.retryRunner.Do(ctx, func(ctx context.Context) error {
+		var err error
+		evt.SequenceNumber, err = es.eventsSequencer.Next()
+		if err != nil {
+			return err
+		}
+
+		writer := jsonDbWriter[*Event]{
+			table:   pendingEventsTable,
+			storage: es,
+			upsert:  false,
+		}
+
+		return writer.putTx(ctx, evt.Hash.Bytes(), evt)
+
+		// TODO (oclaw) metrics
+	})
+}
+
+func (es *EventStorage) IterateEventsByBatch(
+	ctx context.Context,
+	batchSize int,
+	callback func([]*Event) error,
+) error {
+	return es.retryRunner.Do(ctx, func(ctx context.Context) error {
+		tx, err := es.database.CreateRoTx(ctx)
+		if err != nil {
+			return err
+		}
+
+		iter, err := tx.Range(pendingEventsTable, nil, nil)
+		if err != nil {
+			return err
+		}
+
+		batch := make([]*Event, batchSize)
+		idx := 0
+		for iter.HasNext() {
+			_, val, err := iter.Next()
+			if err != nil {
+				return err
+			}
+			if err := json.Unmarshal(val, &batch[idx]); err != nil {
+				return fmt.Errorf("%w: %w", ErrSerializationFailed, err)
+			}
+
+			idx++
+			if idx >= batchSize {
+				if err := callback(batch); err != nil {
+					return err
+				}
+				idx = 0
+			}
+		}
+		if idx > 0 {
+			return callback(batch[:idx])
+		}
+
+		return nil
+	})
+}
+
+func (es *EventStorage) DeleteEvents(ctx context.Context, hashes []common.Hash) error {
+	return es.retryRunner.Do(ctx, func(ctx context.Context) error {
+		tx, err := es.database.CreateRwTx(ctx)
+		if err != nil {
+			return err
+		}
+		defer tx.Rollback()
+
+		for _, hash := range hashes {
+			if err := tx.Delete(pendingEventsTable, hash.Bytes()); err != nil && !errors.Is(err, db.ErrKeyNotFound) {
+				return err
+			}
+		}
+
+		return es.commit(tx)
+	})
+}
+
+func (es *EventStorage) GetLastProcessedBlock(ctx context.Context) (*ProcessedBlock, error) {
+	var ret *ProcessedBlock
+	err := es.retryRunner.Do(ctx, func(ctx context.Context) error {
+		tx, err := es.database.CreateRoTx(ctx)
+		if err != nil {
+			return err
+		}
+
+		data, err := tx.Get(lastProcessedBlockTable, []byte(lastProcessedBlockKey))
+		if errors.Is(err, db.ErrKeyNotFound) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+
+		var blk ProcessedBlock
+		if err := json.Unmarshal(data, &blk); err != nil {
+			return fmt.Errorf("%w: %w", ErrSerializationFailed, err)
+		}
+
+		ret = &blk
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+func (es *EventStorage) SetLastProcessedBlock(ctx context.Context, blk *ProcessedBlock) error {
+	var emptyHash ethcommon.Hash
+	if blk.BlockHash == emptyHash {
+		return errors.New("empty last processed block hash")
+	}
+	if blk.BlockNumber == 0 {
+		return errors.New("empty last processed block number")
+	}
+
+	return es.retryRunner.Do(ctx, func(ctx context.Context) error {
+		writer := jsonDbWriter[*ProcessedBlock]{
+			table:   lastProcessedBlockTable,
+			storage: es,
+			upsert:  true,
+		}
+		return writer.putTx(ctx, []byte(lastProcessedBlockKey), blk)
+
+		// TODO(oclaw) metrics
+	})
+}
+
+func (*EventStorage) commit(tx db.RwTx) error {
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+	return nil
+}
+
+type jsonDbWriter[T any] struct {
+	table   db.TableName
+	storage *EventStorage
+	upsert  bool
+}
+
+func (jdwr *jsonDbWriter[T]) putTx(ctx context.Context, key []byte, value T) error {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrSerializationFailed, err)
+	}
+
+	tx, err := jdwr.storage.database.CreateRwTx(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	if !jdwr.upsert {
+		exists, err := tx.Exists(jdwr.table, key)
+		if err != nil {
+			return err
+		}
+		if exists {
+			return fmt.Errorf("%w: table=%s key=%v", ErrKeyExists, jdwr.table, key)
+		}
+	}
+
+	if err := tx.Put(jdwr.table, key, data); err != nil {
+		return err
+	}
+
+	return jdwr.storage.commit(tx)
+}

--- a/nil/services/relayer/internal/l1/types.go
+++ b/nil/services/relayer/internal/l1/types.go
@@ -1,0 +1,46 @@
+package l1
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type Event struct {
+	// ID
+	Hash common.Hash `json:"eventHash"` // from MessageHash field
+
+	// Block related info
+	BlockNumber uint64      `json:"blkNum"`
+	BlockHash   common.Hash `json:"blkHash"`
+
+	// Used for proper ordering events while sending to L2
+	// Assigned locally (and sequentially for each fetched from the L1 event)
+	// Does not guarantee order for events collected by different relayer instances
+	SequenceNumber uint64 `json:"sequenceNumber"`
+
+	// Payload
+	Sender             common.Address `json:"sender"`
+	Target             common.Address `json:"target"`
+	Value              *big.Int       `json:"value"`
+	Nonce              *big.Int       `json:"nonce"`
+	Message            []byte         `json:"message"`
+	Type               uint8          `json:"messageType"`
+	CreatedAt          *big.Int       `json:"createdAt"`
+	ExpiryTime         *big.Int       `json:"expiryTime"`
+	L2FeeRefundAddress common.Address `json:"l2FeeRefundAddress"`
+	FeeCreditData      FeeCreditData  `json:"feeCreditData"`
+}
+
+type FeeCreditData struct {
+	NilGasLimit          *big.Int `json:"nilGasLimit"`
+	MaxFeePerGas         *big.Int `json:"maxFeePerGas"`
+	MaxPriorityFeePerGas *big.Int `json:"maxPriorityFeePerGas"`
+	FeeCredit            *big.Int `json:"feeCredit"`
+}
+
+type ProcessedBlock struct {
+	BlockHash   common.Hash `json:"blkHash"`
+	BlockNumber uint64      `json:"blkNum"`
+	// TODO add all needed fields needed for last processed block info storage
+}

--- a/nil/services/relayer/internal/l2/transaction_sender.go
+++ b/nil/services/relayer/internal/l2/transaction_sender.go
@@ -1,0 +1,21 @@
+package l2
+
+import (
+	"context"
+	"errors"
+)
+
+type TransactionSender struct {
+	// TODO poll ready events from finality ensurer || ticker
+	// Sign event with key (add key provider)
+	// Publish event to L2BridgeMessenger contract
+	// Drop event from L2 event storage
+}
+
+func (ts *TransactionSender) Name() string {
+	return "l2-transaction-sender"
+}
+
+func (ts *TransactionSender) Run(ctx context.Context, started chan<- struct{}) error {
+	return errors.New("not implemented")
+}

--- a/nil/services/relayer/service.go
+++ b/nil/services/relayer/service.go
@@ -1,0 +1,85 @@
+package relayer
+
+import (
+	"context"
+
+	"github.com/NilFoundation/nil/nil/common/logging"
+	"github.com/NilFoundation/nil/nil/internal/db"
+	"github.com/NilFoundation/nil/nil/services/relayer/internal/l1"
+	"github.com/jonboulle/clockwork"
+	"golang.org/x/sync/errgroup"
+)
+
+type RelayerConfig struct {
+	EventListenerConfig           *l1.EventListenerConfig
+	L2BridgeMessengerContractAddr string
+}
+
+func DefaultRelayerConfig() *RelayerConfig {
+	return &RelayerConfig{
+		EventListenerConfig: l1.DefaultEventListenerConfig(),
+	}
+}
+
+type RelayerService struct {
+	L1EventListener *l1.EventListener
+}
+
+func New(
+	ctx context.Context,
+	database db.DB,
+	clock clockwork.Clock,
+	config *RelayerConfig,
+	l1Client l1.EthClient,
+) (*RelayerService, error) {
+	logger := logging.NewLogger("relayer")
+
+	l1Storage, err := l1.NewEventStorage(
+		ctx,
+		database,
+		clock,
+		nil, // TODO(oclaw) metrics
+		logger,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	l1Contract, err := l1.NewL1ContractWrapper(
+		l1Client,
+		config.EventListenerConfig.BridgeMessengerContractAddress,
+		config.L2BridgeMessengerContractAddr,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	l1EventListener, err := l1.NewEventListener(
+		config.EventListenerConfig,
+		clock,
+		l1Client,
+		l1Contract,
+		l1Storage,
+		logger,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RelayerService{
+		L1EventListener: l1EventListener,
+		// TODO(oclaw) L1 finality ensurer
+		// TODO(oclaw) L2 transaction sender
+	}, nil
+}
+
+func (rs *RelayerService) Run(ctx context.Context) error {
+	eg, gCtx := errgroup.WithContext(ctx)
+
+	eventListenerStarted := make(chan struct{})
+	eg.Go(func() error {
+		return rs.L1EventListener.Run(gCtx, eventListenerStarted)
+	})
+
+	return eg.Wait()
+}


### PR DESCRIPTION
**For scared ones**: 1.5k LoC of changes here are just .abi.json content for the L1BridgeMessenger contract that should be generated automatically in future :)

This PR adds an initial version of the relayer service. 

By spec the service is responsible for:
- Fetching ongoing and historical events from the L1BridgeMessenger contract deployed to the L1 (`EventListener` component)
- Monitoring L1 block finalization (`FinalityEnsurer` component)
- Signing and forwarding finalized L1 events to the L2 (`TransactionSender` component)

Initial version of the service is a `sync_committee_relayer` binary with `EventListener` component implementation

Here is brief description of the component functionality:
- Connect to L1
- Check which historical events has to be fetched (based on stored last processed block number) and fetch them
- Subscribe to new events receiving
- Save every fetched event to the database (BadgerDB) with updating reference to the last processed block number