### PR TITLE
Sync Committee: Block Storage Refactoring

### DIFF
--- a/nil/services/synccommittee/internal/storage/block_storage.go
+++ b/nil/services/synccommittee/internal/storage/block_storage.go
@@ -2,13 +2,8 @@ package storage
 
 import (
 	"context"
-	"encoding/binary"
-	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"iter"
-	"time"
 
 	"github.com/NilFoundation/nil/nil/common"
 	"github.com/NilFoundation/nil/nil/common/logging"
@@ -19,84 +14,6 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/rs/zerolog"
 )
-
-const (
-	// blocksTable stores blocks received from the RPC.
-	// Key: scTypes.BlockId (block's own id), Value: blockEntry.
-	blocksTable db.TableName = "blocks"
-
-	// batchesTable stores blocks batches produced by the Sync Committee.
-	// Key: scTypes.BatchId, Value: batchEntry.
-	batchesTable db.TableName = "batches"
-
-	// batchParentIdxTable is used for indexing batches by their parent ids.
-	// Key: scTypes.BatchId (batch's parent id), Value: scTypes.BatchId (batch's own id);
-	batchParentIdxTable db.TableName = "blocks_parent_hash_idx"
-
-	// latestFetchedTable stores reference to the latest main shard block.
-	// Key: mainShardKey, Value: scTypes.MainBlockRef.
-	latestFetchedTable db.TableName = "latest_fetched"
-
-	// latestBatchIdTable stores identifier of the latest saved batch.
-	// Key: mainShardKey, Value: scTypes.BatchId.
-	latestBatchIdTable db.TableName = "latest_batch_id"
-
-	// stateRootTable stores the latest ProvedStateRoot (single value).
-	// Key: mainShardKey, Value: common.Hash.
-	stateRootTable db.TableName = "state_root"
-
-	// nextToProposeTable stores parent's hash of the next block to propose (single value).
-	// Key: mainShardKey, Value: common.Hash.
-	nextToProposeTable db.TableName = "next_to_propose_parent_hash"
-
-	// storedBatchesCountTable stores the count of batches that have been persisted in the database.
-	// Key: mainShardKey, Value: uint32.
-	storedBatchesCountTable db.TableName = "stored_batches_count"
-)
-
-var mainShardKey = makeShardKey(types.MainShardId)
-
-type batchEntry struct {
-	Id                  scTypes.BatchId  `json:"batchId"`
-	ParentId            *scTypes.BatchId `json:"parentBatchId,omitempty"`
-	MainParentBlockHash common.Hash      `json:"mainParentHash"`
-
-	MainBlockId  scTypes.BlockId   `json:"mainBlockId"`
-	ExecBlockIds []scTypes.BlockId `json:"execBlockIds"`
-
-	IsProved  bool      `json:"isProved,omitempty"`
-	CreatedAt time.Time `json:"createdAt"`
-}
-
-func newBatchEntry(batch *scTypes.BlockBatch, createdAt time.Time) *batchEntry {
-	execBlockIds := make([]scTypes.BlockId, 0, len(batch.ChildBlocks))
-	for _, childBlock := range batch.ChildBlocks {
-		execBlockIds = append(execBlockIds, scTypes.IdFromBlock(childBlock))
-	}
-
-	return &batchEntry{
-		Id:                  batch.Id,
-		ParentId:            batch.ParentId,
-		MainParentBlockHash: batch.MainShardBlock.ParentHash,
-		MainBlockId:         scTypes.IdFromBlock(batch.MainShardBlock),
-		ExecBlockIds:        execBlockIds,
-		CreatedAt:           createdAt,
-	}
-}
-
-type blockEntry struct {
-	Block     jsonrpc.RPCBlock `json:"block"`
-	BatchId   scTypes.BatchId  `json:"batchId"`
-	FetchedAt time.Time        `json:"fetchedAt"`
-}
-
-func newBlockEntry(block *jsonrpc.RPCBlock, containingBatch *scTypes.BlockBatch, fetchedAt time.Time) *blockEntry {
-	return &blockEntry{
-		Block:     *block,
-		BatchId:   containingBatch.Id,
-		FetchedAt: fetchedAt,
-	}
-}
 
 type BlockStorageMetrics interface {
 	RecordBatchProved(ctx context.Context)
@@ -123,6 +40,15 @@ type BlockStorage struct {
 	config  BlockStorageConfig
 	clock   clockwork.Clock
 	metrics BlockStorageMetrics
+
+	ops struct {
+		batchOp
+		batchCountOp
+		batchLatestOp
+		blockOp
+		blockLatestFetchedOp
+		stateRootOp
+	}
 }
 
 func NewBlockStorage(
@@ -154,20 +80,7 @@ func (bs *BlockStorage) TryGetProvedStateRoot(ctx context.Context) (*common.Hash
 	}
 	defer tx.Rollback()
 
-	return bs.getProvedStateRoot(tx)
-}
-
-func (bs *BlockStorage) getProvedStateRoot(tx db.RoTx) (*common.Hash, error) {
-	hashBytes, err := tx.Get(stateRootTable, mainShardKey)
-	if errors.Is(err, db.ErrKeyNotFound) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	hash := common.BytesToHash(hashBytes)
-	return &hash, nil
+	return bs.ops.getProvedStateRoot(tx)
 }
 
 func (bs *BlockStorage) SetProvedStateRoot(ctx context.Context, stateRoot common.Hash) error {
@@ -181,8 +94,7 @@ func (bs *BlockStorage) SetProvedStateRoot(ctx context.Context, stateRoot common
 	}
 	defer tx.Rollback()
 
-	err = tx.Put(stateRootTable, mainShardKey, stateRoot.Bytes())
-	if err != nil {
+	if err := bs.ops.putProvedStateRoot(tx, stateRoot); err != nil {
 		return err
 	}
 
@@ -199,55 +111,7 @@ func (bs *BlockStorage) TryGetLatestBatchId(ctx context.Context) (*scTypes.Batch
 		return nil, err
 	}
 	defer tx.Rollback()
-	return bs.getLatestBatchIdTx(tx)
-}
-
-func (bs *BlockStorage) getLatestBatchIdTx(tx db.RoTx) (*scTypes.BatchId, error) {
-	bytes, err := tx.Get(latestBatchIdTable, mainShardKey)
-
-	switch {
-	case err == nil:
-		break
-	case errors.Is(err, db.ErrKeyNotFound):
-		return nil, nil
-	case errors.Is(err, context.Canceled):
-		return nil, err
-	default:
-		return nil, fmt.Errorf("failed to get latest batch id: %w", err)
-	}
-
-	if bytes == nil {
-		return nil, nil
-	}
-
-	var batchId scTypes.BatchId
-	if err := batchId.UnmarshalText(bytes); err != nil {
-		return nil, err
-	}
-	return &batchId, nil
-}
-
-func (bs *BlockStorage) putLatestBatchIdTx(tx db.RwTx, batchId *scTypes.BatchId) error {
-	var bytes []byte
-
-	if batchId != nil {
-		var err error
-		bytes, err = batchId.MarshalText()
-		if err != nil {
-			return err
-		}
-	}
-
-	err := tx.Put(latestBatchIdTable, mainShardKey, bytes)
-
-	switch {
-	case err == nil:
-		return nil
-	case errors.Is(err, context.Canceled):
-		return err
-	default:
-		return fmt.Errorf("failed to put latest batch id: %w", err)
-	}
+	return bs.ops.getLatestBatchId(tx)
 }
 
 func (bs *BlockStorage) TryGetLatestFetched(ctx context.Context) (*scTypes.MainBlockRef, error) {
@@ -257,7 +121,7 @@ func (bs *BlockStorage) TryGetLatestFetched(ctx context.Context) (*scTypes.MainB
 	}
 	defer tx.Rollback()
 
-	lastFetched, err := bs.getLatestFetchedMainTx(tx)
+	lastFetched, err := bs.ops.getLatestFetchedMain(tx)
 	if err != nil {
 		return nil, err
 	}
@@ -272,11 +136,24 @@ func (bs *BlockStorage) TryGetBlock(ctx context.Context, id scTypes.BlockId) (*j
 	}
 	defer tx.Rollback()
 
-	entry, err := bs.getBlockEntry(tx, id, false)
+	entry, err := bs.ops.getBlock(tx, id, false)
 	if err != nil || entry == nil {
 		return nil, err
 	}
 	return &entry.Block, nil
+}
+
+func (bs *BlockStorage) GetFreeSpaceBatchCount(ctx context.Context) (uint32, error) {
+	tx, err := bs.database.CreateRoTx(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback()
+	batchCount, err := bs.ops.getBatchesCount(tx)
+	if err != nil {
+		return 0, err
+	}
+	return bs.config.StoredBatchesLimit - batchCount, nil
 }
 
 func (bs *BlockStorage) SetBlockBatch(ctx context.Context, batch *scTypes.BlockBatch) error {
@@ -296,7 +173,7 @@ func (bs *BlockStorage) setBlockBatchImpl(ctx context.Context, batch *scTypes.Bl
 	}
 	defer tx.Rollback()
 
-	if err := bs.putBatchWithBlocksTx(tx, batch); err != nil {
+	if err := bs.putBatchWithBlocks(tx, batch); err != nil {
 		return err
 	}
 
@@ -304,77 +181,22 @@ func (bs *BlockStorage) setBlockBatchImpl(ctx context.Context, batch *scTypes.Bl
 		return err
 	}
 
-	if err := bs.updateLatestFetched(tx, batch.MainShardBlock); err != nil {
+	if err := bs.ops.updateLatestFetched(tx, batch.MainShardBlock); err != nil {
 		return err
 	}
 
-	latestBatchId, err := bs.getLatestBatchIdTx(tx)
-	if err != nil {
-		return err
-	}
-	if err := bs.validateLatestBatchId(batch, latestBatchId); err != nil {
-		return err
-	}
-
-	if err := bs.putLatestBatchIdTx(tx, &batch.Id); err != nil {
+	if err := bs.ops.updateLatestBatchId(tx, batch); err != nil {
 		return err
 	}
 
 	return bs.commit(tx)
 }
 
-func (bs *BlockStorage) validateLatestBatchId(batch *scTypes.BlockBatch, latestBatchId *scTypes.BatchId) error {
-	var isValid bool
-	switch {
-	case latestBatchId == nil:
-		isValid = batch.ParentId == nil
-	case batch.ParentId == nil:
-		isValid = false
-	default:
-		isValid = *latestBatchId == *batch.ParentId
-	}
-
-	if isValid {
-		return nil
-	}
-
-	return fmt.Errorf(
-		"%w: got batch with parentId=%s, latest batch id is %s",
-		scTypes.ErrBatchMismatch, batch.ParentId, latestBatchId,
-	)
-}
-
-func (bs *BlockStorage) updateLatestFetched(tx db.RwTx, block *jsonrpc.RPCBlock) error {
-	if block.ShardId != types.MainShardId {
-		return nil
-	}
-
-	latestFetched, err := bs.getLatestFetchedMainTx(tx)
-	if err != nil {
-		return err
-	}
-
-	if latestFetched.Equals(block) {
-		return nil
-	}
-
-	if err := latestFetched.ValidateChild(block); err != nil {
-		return fmt.Errorf("unable to update latest fetched block: %w", err)
-	}
-
-	newLatestFetched, err := scTypes.NewBlockRef(block)
-	if err != nil {
-		return err
-	}
-
-	return bs.putLatestFetchedBlockTx(tx, block.ShardId, newLatestFetched)
-}
-
 func (bs *BlockStorage) setProposeParentHash(tx db.RwTx, block *jsonrpc.RPCBlock) error {
 	if block.ShardId != types.MainShardId {
 		return nil
 	}
-	parentHash, err := bs.getParentOfNextToPropose(tx)
+	parentHash, err := bs.ops.getParentOfNextToPropose(tx)
 	if err != nil {
 		return err
 	}
@@ -391,7 +213,7 @@ func (bs *BlockStorage) setProposeParentHash(tx db.RwTx, block *jsonrpc.RPCBlock
 		Stringer("parentHash", block.ParentHash).
 		Msg("block parent hash is not set, updating it")
 
-	return bs.setParentOfNextToPropose(tx, block.ParentHash)
+	return bs.ops.setParentOfNextToPropose(tx, block.ParentHash)
 }
 
 func (bs *BlockStorage) SetBatchAsProved(ctx context.Context, batchId scTypes.BatchId) error {
@@ -412,7 +234,7 @@ func (bs *BlockStorage) setBatchAsProvedImpl(ctx context.Context, batchId scType
 	}
 	defer tx.Rollback()
 
-	entry, err := bs.getBatchTx(tx, batchId)
+	entry, err := bs.ops.getBatch(tx, batchId)
 	if err != nil {
 		return false, err
 	}
@@ -423,7 +245,7 @@ func (bs *BlockStorage) setBatchAsProvedImpl(ctx context.Context, batchId scType
 	}
 
 	entry.IsProved = true
-	if err := bs.putBatchTx(tx, entry); err != nil {
+	if err := bs.ops.putBatch(tx, entry); err != nil {
 		return false, err
 	}
 
@@ -441,7 +263,7 @@ func (bs *BlockStorage) TryGetNextProposalData(ctx context.Context) (*scTypes.Pr
 	}
 	defer tx.Rollback()
 
-	currentProvedStateRoot, err := bs.getProvedStateRoot(tx)
+	currentProvedStateRoot, err := bs.ops.getProvedStateRoot(tx)
 	if err != nil {
 		return nil, err
 	}
@@ -449,7 +271,7 @@ func (bs *BlockStorage) TryGetNextProposalData(ctx context.Context) (*scTypes.Pr
 		return nil, ErrStateRootNotInitialized
 	}
 
-	parentHash, err := bs.getParentOfNextToPropose(tx)
+	parentHash, err := bs.ops.getParentOfNextToPropose(tx)
 	if err != nil {
 		return nil, err
 	}
@@ -460,7 +282,7 @@ func (bs *BlockStorage) TryGetNextProposalData(ctx context.Context) (*scTypes.Pr
 	}
 
 	var proposalCandidate *batchEntry
-	for entry, err := range bs.getStoredBatchesSeq(tx) {
+	for entry, err := range bs.ops.getStoredBatchesSeq(tx) {
 		if err != nil {
 			return nil, err
 		}
@@ -483,7 +305,7 @@ func (bs *BlockStorage) createProposalDataTx(
 	proposalCandidate *batchEntry,
 	currentProvedStateRoot *common.Hash,
 ) (*scTypes.ProposalData, error) {
-	mainBlockEntry, err := bs.getBlockEntry(tx, proposalCandidate.MainBlockId, true)
+	mainBlockEntry, err := bs.ops.getBlock(tx, proposalCandidate.MainBlockId, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get main block with id=%s: %w", proposalCandidate.MainBlockId, err)
 	}
@@ -491,7 +313,7 @@ func (bs *BlockStorage) createProposalDataTx(
 	transactions := scTypes.BlockTransactions(&mainBlockEntry.Block)
 
 	for _, childId := range proposalCandidate.ExecBlockIds {
-		childEntry, err := bs.getBlockEntry(tx, childId, true)
+		childEntry, err := bs.ops.getBlock(tx, childId, true)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get child block with id=%s: %w", childId, err)
 		}
@@ -523,7 +345,7 @@ func (bs *BlockStorage) setBatchAsProposedImpl(ctx context.Context, id scTypes.B
 	}
 	defer tx.Rollback()
 
-	batch, err := bs.getBatchTx(tx, id)
+	batch, err := bs.ops.getBatch(tx, id)
 	if err != nil {
 		return err
 	}
@@ -532,7 +354,7 @@ func (bs *BlockStorage) setBatchAsProposedImpl(ctx context.Context, id scTypes.B
 		return fmt.Errorf("%w, id=%s", scTypes.ErrBatchNotProved, id)
 	}
 
-	mainShardEntry, err := bs.getBlockEntry(tx, batch.MainBlockId, true)
+	mainShardEntry, err := bs.ops.getBlock(tx, batch.MainBlockId, true)
 	if err != nil {
 		return err
 	}
@@ -541,15 +363,14 @@ func (bs *BlockStorage) setBatchAsProposedImpl(ctx context.Context, id scTypes.B
 		return err
 	}
 
-	if err := bs.deleteBatchWithBlocksTx(tx, batch); err != nil {
+	if err := bs.deleteBatchWithBlocks(tx, batch); err != nil {
 		return err
 	}
 
-	if err := tx.Put(stateRootTable, mainShardKey, mainShardEntry.Block.Hash.Bytes()); err != nil {
-		return fmt.Errorf("failed to put state root: %w", err)
+	if err := bs.ops.putProvedStateRoot(tx, mainShardEntry.Block.Hash); err != nil {
+		return err
 	}
-
-	if err := bs.setParentOfNextToPropose(tx, mainShardEntry.Block.Hash); err != nil {
+	if err := bs.ops.setParentOfNextToPropose(tx, mainShardEntry.Block.Hash); err != nil {
 		return err
 	}
 
@@ -560,31 +381,6 @@ func isValidProposalCandidate(batch *batchEntry, parentHash common.Hash) bool {
 	return batch.IsProved && batch.MainParentBlockHash == parentHash
 }
 
-// getParentOfNextToPropose retrieves parent's hash of the next block to propose
-func (bs *BlockStorage) getParentOfNextToPropose(tx db.RoTx) (*common.Hash, error) {
-	hashBytes, err := tx.Get(nextToProposeTable, mainShardKey)
-
-	if errors.Is(err, db.ErrKeyNotFound) {
-		return nil, nil
-	}
-
-	if err != nil {
-		return nil, fmt.Errorf("failed to get next to propose parent hash: %w", err)
-	}
-
-	hash := common.BytesToHash(hashBytes)
-	return &hash, nil
-}
-
-// setParentOfNextToPropose sets parent's hash of the next block to propose
-func (bs *BlockStorage) setParentOfNextToPropose(tx db.RwTx, hash common.Hash) error {
-	err := tx.Put(nextToProposeTable, mainShardKey, hash.Bytes())
-	if err != nil {
-		return fmt.Errorf("failed to put next to propose parent hash: %w", err)
-	}
-	return nil
-}
-
 func (bs *BlockStorage) validateMainShardEntry(tx db.RoTx, entry *blockEntry) error {
 	id := scTypes.IdFromBlock(&entry.Block)
 
@@ -592,7 +388,7 @@ func (bs *BlockStorage) validateMainShardEntry(tx db.RoTx, entry *blockEntry) er
 		return fmt.Errorf("block with id=%s is not from main shard", id.String())
 	}
 
-	parentHash, err := bs.getParentOfNextToPropose(tx)
+	parentHash, err := bs.ops.getParentOfNextToPropose(tx)
 	if err != nil {
 		return err
 	}
@@ -606,37 +402,6 @@ func (bs *BlockStorage) validateMainShardEntry(tx db.RoTx, entry *blockEntry) er
 			entry.Block.ParentHash.String(),
 			parentHash.String(),
 		)
-	}
-	return nil
-}
-
-func (bs *BlockStorage) getLatestFetchedMainTx(tx db.RoTx) (*scTypes.MainBlockRef, error) {
-	value, err := tx.Get(latestFetchedTable, mainShardKey)
-	if errors.Is(err, db.ErrKeyNotFound) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	var blockRef *scTypes.MainBlockRef
-	err = json.Unmarshal(value, &blockRef)
-	if err != nil {
-		return nil, fmt.Errorf("%w: %w", ErrSerializationFailed, err)
-	}
-	return blockRef, nil
-}
-
-func (bs *BlockStorage) putLatestFetchedBlockTx(tx db.RwTx, shardId types.ShardId, block *scTypes.MainBlockRef) error {
-	bytes, err := json.Marshal(block)
-	if err != nil {
-		return fmt.Errorf(
-			"%w: failed to encode block ref with hash=%s: %w", ErrSerializationFailed, block.Hash.String(), err,
-		)
-	}
-	err = tx.Put(latestFetchedTable, makeShardKey(shardId), bytes)
-	if err != nil {
-		return fmt.Errorf("failed to put block ref with hash=%s: %w", block.Hash.String(), err)
 	}
 	return nil
 }
@@ -671,7 +436,7 @@ func (bs *BlockStorage) resetBatchesPartialImpl(
 	}
 	defer tx.Rollback()
 
-	startingBatch, err := bs.getBatchTx(tx, firstBatchToPurge)
+	startingBatch, err := bs.ops.getBatch(tx, firstBatchToPurge)
 	if err != nil {
 		return nil, err
 	}
@@ -680,12 +445,12 @@ func (bs *BlockStorage) resetBatchesPartialImpl(
 		return nil, err
 	}
 
-	for batch, err := range bs.getBatchesSequence(tx, firstBatchToPurge) {
+	for batch, err := range bs.ops.getBatchesSequence(tx, firstBatchToPurge) {
 		if err != nil {
 			return nil, err
 		}
 
-		if err := bs.deleteBatchWithBlocksTx(tx, batch); err != nil {
+		if err := bs.deleteBatchWithBlocks(tx, batch); err != nil {
 			return nil, err
 		}
 
@@ -700,7 +465,7 @@ func (bs *BlockStorage) resetBatchesPartialImpl(
 }
 
 func (bs *BlockStorage) resetToParent(tx db.RwTx, batch *batchEntry) error {
-	mainBlockEntry, err := bs.getBlockEntry(tx, batch.MainBlockId, true)
+	mainBlockEntry, err := bs.ops.getBlock(tx, batch.MainBlockId, true)
 	if err != nil {
 		return err
 	}
@@ -709,59 +474,14 @@ func (bs *BlockStorage) resetToParent(tx db.RwTx, batch *batchEntry) error {
 	if err != nil {
 		return fmt.Errorf("failed to get main block parent ref: %w", err)
 	}
-	if err := bs.putLatestFetchedBlockTx(tx, types.MainShardId, refToParent); err != nil {
+	if err := bs.ops.putLatestFetchedBlock(tx, types.MainShardId, refToParent); err != nil {
 		return fmt.Errorf("failed to reset latest fetched block: %w", err)
 	}
-	if err := bs.putLatestBatchIdTx(tx, batch.ParentId); err != nil {
+	if err := bs.ops.putLatestBatchId(tx, batch.ParentId); err != nil {
 		return fmt.Errorf("failed to reset latest batch id: %w", err)
 	}
 
 	return nil
-}
-
-// getBatchesSequence iterates through a chain of batches, starting from the batch with the given id.
-// It uses batchParentIdxTable to retrieve parent-child connections between batches.
-func (bs *BlockStorage) getBatchesSequence(tx db.RoTx, startingId scTypes.BatchId) iter.Seq2[*batchEntry, error] {
-	return func(yield func(*batchEntry, error) bool) {
-		startBatch, err := bs.getBatchTx(tx, startingId)
-		if err != nil {
-			yield(nil, err)
-			return
-		}
-
-		if !yield(startBatch, nil) {
-			return
-		}
-
-		seenParentIds := make(map[scTypes.BatchId]bool)
-		nextParentId := startBatch.Id
-		for {
-			if seenParentIds[nextParentId] {
-				yield(nil, fmt.Errorf("cycle detected in the batch chain, parentId=%s", nextParentId))
-				return
-			}
-			seenParentIds[nextParentId] = true
-
-			nextIdBytes, err := tx.Get(batchParentIdxTable, nextParentId.Bytes())
-			if err != nil && !errors.Is(err, db.ErrKeyNotFound) {
-				yield(nil, fmt.Errorf("failed to get parent batch idx entry, parentId=%s: %w", nextParentId, err))
-				return
-			}
-			if nextIdBytes == nil {
-				break
-			}
-			nextBatchEntry, err := bs.getBatchBytesIdTx(tx, nextIdBytes, true)
-			if err != nil {
-				yield(nil, err)
-				return
-			}
-
-			if !yield(nextBatchEntry, nil) {
-				return
-			}
-			nextParentId = nextBatchEntry.Id
-		}
-	}
 }
 
 // ResetBatchesNotProved resets the block storage state:
@@ -782,11 +502,11 @@ func (bs *BlockStorage) resetBatchesNotProvedImpl(ctx context.Context) error {
 	}
 	defer tx.Rollback()
 
-	if err := bs.putLatestFetchedBlockTx(tx, types.MainShardId, nil); err != nil {
+	if err := bs.ops.putLatestFetchedBlock(tx, types.MainShardId, nil); err != nil {
 		return fmt.Errorf("failed to reset latest fetched block: %w", err)
 	}
 
-	for batch, err := range bs.getStoredBatchesSeq(tx) {
+	for batch, err := range bs.ops.getStoredBatchesSeq(tx) {
 		if err != nil {
 			return err
 		}
@@ -794,7 +514,7 @@ func (bs *BlockStorage) resetBatchesNotProvedImpl(ctx context.Context) error {
 			continue
 		}
 
-		if err := bs.deleteBatchWithBlocksTx(tx, batch); err != nil {
+		if err := bs.deleteBatchWithBlocks(tx, batch); err != nil {
 			return err
 		}
 	}
@@ -802,62 +522,30 @@ func (bs *BlockStorage) resetBatchesNotProvedImpl(ctx context.Context) error {
 	return bs.commit(tx)
 }
 
-func makeShardKey(shardId types.ShardId) []byte {
-	key := make([]byte, 4)
-	binary.LittleEndian.PutUint32(key, uint32(shardId))
-	return key
-}
-
-func (bs *BlockStorage) getBlockEntry(tx db.RoTx, id scTypes.BlockId, required bool) (*blockEntry, error) {
-	return bs.getBlockEntryBytesId(tx, id.Bytes(), required)
-}
-
-func (bs *BlockStorage) getBlockEntryBytesId(tx db.RoTx, idBytes []byte, required bool) (*blockEntry, error) {
-	value, err := tx.Get(blocksTable, idBytes)
-
-	switch {
-	case err == nil:
-		break
-	case errors.Is(err, db.ErrKeyNotFound) && required:
-		return nil, fmt.Errorf("%w, id=%s", scTypes.ErrBlockNotFound, hex.EncodeToString(idBytes))
-	case errors.Is(err, db.ErrKeyNotFound):
-		return nil, nil
-	default:
-		return nil, fmt.Errorf("failed to get block with id=%s: %w", hex.EncodeToString(idBytes), err)
-	}
-
-	entry, err := unmarshallEntry[blockEntry](idBytes, value)
-	if err != nil {
-		return nil, err
-	}
-
-	return entry, nil
-}
-
-func (bs *BlockStorage) putBatchWithBlocksTx(tx db.RwTx, batch *scTypes.BlockBatch) error {
-	if err := bs.addStoredCountTx(tx, 1); err != nil {
+func (bs *BlockStorage) putBatchWithBlocks(tx db.RwTx, batch *scTypes.BlockBatch) error {
+	if err := bs.ops.addStoredCount(tx, 1, bs.config); err != nil {
 		return err
 	}
 
-	if err := bs.putBatchParentIndexEntryTx(tx, batch); err != nil {
+	if err := bs.ops.putBatchParentIndexEntry(tx, batch); err != nil {
 		return err
 	}
 
 	currentTime := bs.clock.Now()
 
 	entry := newBatchEntry(batch, currentTime)
-	if err := bs.putBatchTx(tx, entry); err != nil {
+	if err := bs.ops.putBatch(tx, entry); err != nil {
 		return err
 	}
 
 	mainEntry := newBlockEntry(batch.MainShardBlock, batch, currentTime)
-	if err := bs.putBlockTx(tx, mainEntry); err != nil {
+	if err := bs.ops.putBlockTx(tx, mainEntry); err != nil {
 		return err
 	}
 
 	for _, childBlock := range batch.ChildBlocks {
 		childEntry := newBlockEntry(childBlock, batch, currentTime)
-		if err := bs.putBlockTx(tx, childEntry); err != nil {
+		if err := bs.ops.putBlockTx(tx, childEntry); err != nil {
 			return err
 		}
 	}
@@ -865,264 +553,24 @@ func (bs *BlockStorage) putBatchWithBlocksTx(tx db.RwTx, batch *scTypes.BlockBat
 	return nil
 }
 
-func (bs *BlockStorage) putBatchParentIndexEntryTx(tx db.RwTx, batch *scTypes.BlockBatch) error {
-	if batch.ParentId == nil {
-		return nil
-	}
-
-	err := tx.Put(batchParentIdxTable, batch.ParentId.Bytes(), batch.Id.Bytes())
-	if err != nil {
-		return fmt.Errorf(
-			"failed to put parent batch idx entry, batchId=%s, parentId=%s,: %w", batch.Id, batch.ParentId, err,
-		)
-	}
-
-	return nil
-}
-
-func (bs *BlockStorage) deleteBatchParentIndexEntryTx(tx db.RwTx, batch *batchEntry) error {
-	if batch.ParentId == nil {
-		return nil
-	}
-
-	err := tx.Delete(batchParentIdxTable, batch.ParentId.Bytes())
-
-	switch {
-	case err == nil:
-		return nil
-
-	case errors.Is(err, context.Canceled):
-		return err
-
-	case errors.Is(err, db.ErrKeyNotFound):
-		bs.logger.Warn().Err(err).
-			Stringer(logging.FieldBatchId, batch.Id).
-			Stringer("parentBatchId", batch.ParentId).
-			Msg("parent batch idx entry is not found")
-		return nil
-
-	default:
-		return fmt.Errorf("failed to delete parent batch idx entry, parentId=%s: %w", batch.ParentId, err)
-	}
-}
-
-func (bs *BlockStorage) putBatchTx(tx db.RwTx, entry *batchEntry) error {
-	value, err := marshallEntry(entry)
-	if err != nil {
-		return fmt.Errorf("%w, id=%s", err, entry.Id)
-	}
-
-	if err := tx.Put(batchesTable, entry.Id.Bytes(), value); err != nil {
-		return fmt.Errorf("failed to put batch with id=%s: %w", entry.Id, err)
-	}
-
-	return nil
-}
-
-func (bs *BlockStorage) getBatchTx(tx db.RoTx, id scTypes.BatchId) (*batchEntry, error) {
-	return bs.getBatchBytesIdTx(tx, id.Bytes(), true)
-}
-
-func (bs *BlockStorage) getBatchBytesIdTx(tx db.RoTx, idBytes []byte, required bool) (*batchEntry, error) {
-	value, err := tx.Get(batchesTable, idBytes)
-
-	switch {
-	case err == nil:
-		break
-
-	case errors.Is(err, context.Canceled):
-		return nil, err
-
-	case errors.Is(err, db.ErrKeyNotFound) && required:
-		return nil, fmt.Errorf("%w, id=%s", scTypes.ErrBatchNotFound, hex.EncodeToString(idBytes))
-
-	case errors.Is(err, db.ErrKeyNotFound):
-		return nil, nil
-
-	default:
-		return nil, fmt.Errorf("failed to get batch with id=%s: %w", hex.EncodeToString(idBytes), err)
-	}
-
-	entry, err := unmarshallEntry[batchEntry](idBytes, value)
-	if err != nil {
-		return nil, err
-	}
-
-	return entry, nil
-}
-
-func (bs *BlockStorage) deleteBatchWithBlocksTx(tx db.RwTx, batch *batchEntry) error {
-	if err := bs.addStoredCountTx(tx, -1); err != nil {
+func (bs *BlockStorage) deleteBatchWithBlocks(tx db.RwTx, batch *batchEntry) error {
+	if err := bs.ops.addStoredCount(tx, -1, bs.config); err != nil {
 		return err
 	}
 
-	if err := tx.Delete(batchesTable, batch.Id.Bytes()); err != nil {
-		return fmt.Errorf("failed to delete batch with id=%s: %w", batch.Id, err)
-	}
-
-	if err := bs.deleteBatchParentIndexEntryTx(tx, batch); err != nil {
+	if err := bs.ops.deleteBatch(tx, batch, bs.logger); err != nil {
 		return err
 	}
 
-	if err := bs.deleteBlock(tx, batch.MainBlockId); err != nil {
+	if err := bs.ops.deleteBlock(tx, batch.MainBlockId, bs.logger); err != nil {
 		return err
 	}
 
 	for _, childId := range batch.ExecBlockIds {
-		if err := bs.deleteBlock(tx, childId); err != nil {
+		if err := bs.ops.deleteBlock(tx, childId, bs.logger); err != nil {
 			return err
 		}
 	}
 
 	return nil
-}
-
-func (bs *BlockStorage) putBlockTx(tx db.RwTx, entry *blockEntry) error {
-	value, err := marshallEntry(entry)
-	if err != nil {
-		return fmt.Errorf("%w, hash=%s", err, entry.Block.Hash)
-	}
-
-	blockId := scTypes.IdFromBlock(&entry.Block)
-	if err := tx.Put(blocksTable, blockId.Bytes(), value); err != nil {
-		return fmt.Errorf("failed to put block %s: %w", blockId.String(), err)
-	}
-
-	return nil
-}
-
-func (bs *BlockStorage) deleteBlock(tx db.RwTx, blockId scTypes.BlockId) error {
-	err := tx.Delete(blocksTable, blockId.Bytes())
-
-	switch {
-	case err == nil:
-		return nil
-
-	case errors.Is(err, context.Canceled):
-		return err
-
-	case errors.Is(err, db.ErrKeyNotFound):
-		bs.logger.Warn().Err(err).
-			Stringer(logging.FieldShardId, blockId.ShardId).
-			Stringer(logging.FieldBlockHash, blockId.Hash).
-			Msg("block is not found (deleteBlock)")
-		return nil
-
-	default:
-		return fmt.Errorf("failed to delete block with id=%s: %w", blockId, err)
-	}
-}
-
-// getStoredBatchesSeq returns a sequence of stored batches in an arbitrary order.
-func (*BlockStorage) getStoredBatchesSeq(tx db.RoTx) iter.Seq2[*batchEntry, error] {
-	return func(yield func(*batchEntry, error) bool) {
-		txIter, err := tx.Range(batchesTable, nil, nil)
-		if err != nil {
-			yield(nil, err)
-			return
-		}
-		defer txIter.Close()
-
-		for txIter.HasNext() {
-			key, val, err := txIter.Next()
-			if err != nil {
-				yield(nil, err)
-				return
-			}
-			entry, err := unmarshallEntry[batchEntry](key, val)
-			if err != nil {
-				yield(nil, err)
-				return
-			}
-
-			if !yield(entry, nil) {
-				return
-			}
-		}
-	}
-}
-
-func (bs *BlockStorage) addStoredCountTx(tx db.RwTx, delta int32) error {
-	currentBatchesCount, err := bs.getBatchesCountTx(tx)
-	if err != nil {
-		return err
-	}
-
-	signed := int32(currentBatchesCount) + delta
-	if signed < 0 {
-		return fmt.Errorf(
-			"batches count cannot be negative: delta=%d, current blocks count=%d", delta, currentBatchesCount,
-		)
-	}
-
-	newBatchesCount := uint32(signed)
-	if newBatchesCount > bs.config.StoredBatchesLimit {
-		return fmt.Errorf(
-			"%w: delta is %d, current storage size is %d, capacity limit is %d",
-			ErrCapacityLimitReached, delta, currentBatchesCount, bs.config.StoredBatchesLimit,
-		)
-	}
-
-	return bs.putBatchesCountTx(tx, newBatchesCount)
-}
-
-func (bs *BlockStorage) GetFreeSpaceBatchCount(ctx context.Context) (uint32, error) {
-	tx, err := bs.database.CreateRoTx(ctx)
-	if err != nil {
-		return 0, err
-	}
-	defer tx.Rollback()
-	batchCount, err := bs.getBatchesCountTx(tx)
-	if err != nil {
-		return 0, err
-	}
-	return bs.config.StoredBatchesLimit - batchCount, nil
-}
-
-func (bs *BlockStorage) getBatchesCountTx(tx db.RoTx) (uint32, error) {
-	bytes, err := tx.Get(storedBatchesCountTable, mainShardKey)
-	switch {
-	case err == nil:
-		break
-	case errors.Is(err, db.ErrKeyNotFound):
-		return 0, nil
-	default:
-		return 0, fmt.Errorf("failed to get batches count: %w", err)
-	}
-
-	count := binary.LittleEndian.Uint32(bytes)
-	return count, nil
-}
-
-func (bs *BlockStorage) putBatchesCountTx(tx db.RwTx, newValue uint32) error {
-	bytes := make([]byte, 4)
-	binary.LittleEndian.PutUint32(bytes, newValue)
-
-	err := tx.Put(storedBatchesCountTable, mainShardKey, bytes)
-	if err != nil {
-		return fmt.Errorf("failed to put batches count: %w (newValue is %d)", err, newValue)
-	}
-	return nil
-}
-
-func marshallEntry[E any](entry *E) ([]byte, error) {
-	bytes, err := json.Marshal(entry)
-	if err != nil {
-		return nil, fmt.Errorf(
-			"%w: failed to marshall entry: %w", ErrSerializationFailed, err,
-		)
-	}
-	return bytes, nil
-}
-
-func unmarshallEntry[E any](key []byte, val []byte) (*E, error) {
-	entry := new(E)
-
-	if err := json.Unmarshal(val, entry); err != nil {
-		return nil, fmt.Errorf(
-			"%w: failed to unmarshall entry with id=%s: %w", ErrSerializationFailed, hex.EncodeToString(key), err,
-		)
-	}
-
-	return entry, nil
 }

--- a/nil/services/synccommittee/internal/storage/block_storage_entries.go
+++ b/nil/services/synccommittee/internal/storage/block_storage_entries.go
@@ -1,0 +1,86 @@
+package storage
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/NilFoundation/nil/nil/common"
+	"github.com/NilFoundation/nil/nil/internal/types"
+	"github.com/NilFoundation/nil/nil/services/rpc/jsonrpc"
+	scTypes "github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
+)
+
+var mainShardKey = makeShardKey(types.MainShardId)
+
+type batchEntry struct {
+	Id                  scTypes.BatchId  `json:"batchId"`
+	ParentId            *scTypes.BatchId `json:"parentBatchId,omitempty"`
+	MainParentBlockHash common.Hash      `json:"mainParentHash"`
+
+	MainBlockId  scTypes.BlockId   `json:"mainBlockId"`
+	ExecBlockIds []scTypes.BlockId `json:"execBlockIds"`
+
+	IsProved  bool      `json:"isProved,omitempty"`
+	CreatedAt time.Time `json:"createdAt"`
+}
+
+func newBatchEntry(batch *scTypes.BlockBatch, createdAt time.Time) *batchEntry {
+	execBlockIds := make([]scTypes.BlockId, 0, len(batch.ChildBlocks))
+	for _, childBlock := range batch.ChildBlocks {
+		execBlockIds = append(execBlockIds, scTypes.IdFromBlock(childBlock))
+	}
+
+	return &batchEntry{
+		Id:                  batch.Id,
+		ParentId:            batch.ParentId,
+		MainParentBlockHash: batch.MainShardBlock.ParentHash,
+		MainBlockId:         scTypes.IdFromBlock(batch.MainShardBlock),
+		ExecBlockIds:        execBlockIds,
+		CreatedAt:           createdAt,
+	}
+}
+
+type blockEntry struct {
+	Block     jsonrpc.RPCBlock `json:"block"`
+	BatchId   scTypes.BatchId  `json:"batchId"`
+	FetchedAt time.Time        `json:"fetchedAt"`
+}
+
+func newBlockEntry(block *jsonrpc.RPCBlock, containingBatch *scTypes.BlockBatch, fetchedAt time.Time) *blockEntry {
+	return &blockEntry{
+		Block:     *block,
+		BatchId:   containingBatch.Id,
+		FetchedAt: fetchedAt,
+	}
+}
+
+func marshallEntry[E any](entry *E) ([]byte, error) {
+	bytes, err := json.Marshal(entry)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"%w: failed to marshall entry: %w", ErrSerializationFailed, err,
+		)
+	}
+	return bytes, nil
+}
+
+func unmarshallEntry[E any](key []byte, val []byte) (*E, error) {
+	entry := new(E)
+
+	if err := json.Unmarshal(val, entry); err != nil {
+		return nil, fmt.Errorf(
+			"%w: failed to unmarshall entry with id=%s: %w", ErrSerializationFailed, hex.EncodeToString(key), err,
+		)
+	}
+
+	return entry, nil
+}
+
+func makeShardKey(shardId types.ShardId) []byte {
+	key := make([]byte, 4)
+	binary.LittleEndian.PutUint32(key, uint32(shardId))
+	return key
+}

--- a/nil/services/synccommittee/internal/storage/block_storage_op_batch.go
+++ b/nil/services/synccommittee/internal/storage/block_storage_op_batch.go
@@ -1,0 +1,199 @@
+package storage
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"iter"
+
+	"github.com/NilFoundation/nil/nil/common/logging"
+	"github.com/NilFoundation/nil/nil/internal/db"
+	scTypes "github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
+	"github.com/rs/zerolog"
+)
+
+const (
+	// batchesTable stores blocks batches produced by the Sync Committee.
+	// Key: scTypes.BatchId, Value: batchEntry.
+	batchesTable db.TableName = "batches"
+
+	// batchParentIdxTable is used for indexing batches by their parent ids.
+	// Key: scTypes.BatchId (batch's parent id), Value: scTypes.BatchId (batch's own id);
+	batchParentIdxTable db.TableName = "blocks_parent_hash_idx"
+)
+
+// batchOp represents the set of operations related to batches within the storage.
+type batchOp struct{}
+
+func (batchOp) putBatch(tx db.RwTx, entry *batchEntry) error {
+	value, err := marshallEntry(entry)
+	if err != nil {
+		return fmt.Errorf("%w, id=%s", err, entry.Id)
+	}
+
+	if err := tx.Put(batchesTable, entry.Id.Bytes(), value); err != nil {
+		return fmt.Errorf("failed to put batch with id=%s: %w", entry.Id, err)
+	}
+
+	return nil
+}
+
+func (t batchOp) getBatch(tx db.RoTx, id scTypes.BatchId) (*batchEntry, error) {
+	return t.getBatchBytesId(tx, id.Bytes(), true)
+}
+
+func (batchOp) getBatchBytesId(tx db.RoTx, idBytes []byte, required bool) (*batchEntry, error) {
+	value, err := tx.Get(batchesTable, idBytes)
+
+	switch {
+	case err == nil:
+		break
+
+	case errors.Is(err, context.Canceled):
+		return nil, err
+
+	case errors.Is(err, db.ErrKeyNotFound) && required:
+		return nil, fmt.Errorf("%w, id=%s", scTypes.ErrBatchNotFound, hex.EncodeToString(idBytes))
+
+	case errors.Is(err, db.ErrKeyNotFound):
+		return nil, nil
+
+	default:
+		return nil, fmt.Errorf("failed to get batch with id=%s: %w", hex.EncodeToString(idBytes), err)
+	}
+
+	entry, err := unmarshallEntry[batchEntry](idBytes, value)
+	if err != nil {
+		return nil, err
+	}
+
+	return entry, nil
+}
+
+// getBatchesSequence iterates through a chain of batches, starting from the batch with the given id.
+// It uses batchParentIdxTable to retrieve parent-child connections between batches.
+func (t batchOp) getBatchesSequence(tx db.RoTx, startingId scTypes.BatchId) iter.Seq2[*batchEntry, error] {
+	return func(yield func(*batchEntry, error) bool) {
+		startBatch, err := t.getBatch(tx, startingId)
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+
+		if !yield(startBatch, nil) {
+			return
+		}
+
+		seenParentIds := make(map[scTypes.BatchId]bool)
+		nextParentId := startBatch.Id
+		for {
+			if seenParentIds[nextParentId] {
+				yield(nil, fmt.Errorf("cycle detected in the batch chain, parentId=%s", nextParentId))
+				return
+			}
+			seenParentIds[nextParentId] = true
+
+			nextIdBytes, err := tx.Get(batchParentIdxTable, nextParentId.Bytes())
+			if err != nil && !errors.Is(err, db.ErrKeyNotFound) {
+				yield(nil, fmt.Errorf("failed to get parent batch idx entry, parentId=%s: %w", nextParentId, err))
+				return
+			}
+			if nextIdBytes == nil {
+				break
+			}
+			nextBatchEntry, err := t.getBatchBytesId(tx, nextIdBytes, true)
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+
+			if !yield(nextBatchEntry, nil) {
+				return
+			}
+			nextParentId = nextBatchEntry.Id
+		}
+	}
+}
+
+// getStoredBatchesSeq returns a sequence of stored batches in an arbitrary order.
+func (batchOp) getStoredBatchesSeq(tx db.RoTx) iter.Seq2[*batchEntry, error] {
+	return func(yield func(*batchEntry, error) bool) {
+		txIter, err := tx.Range(batchesTable, nil, nil)
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+		defer txIter.Close()
+
+		for txIter.HasNext() {
+			key, val, err := txIter.Next()
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+			entry, err := unmarshallEntry[batchEntry](key, val)
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+
+			if !yield(entry, nil) {
+				return
+			}
+		}
+	}
+}
+
+func (batchOp) putBatchParentIndexEntry(tx db.RwTx, batch *scTypes.BlockBatch) error {
+	if batch.ParentId == nil {
+		return nil
+	}
+
+	err := tx.Put(batchParentIdxTable, batch.ParentId.Bytes(), batch.Id.Bytes())
+	if err != nil {
+		return fmt.Errorf(
+			"failed to put parent batch idx entry, batchId=%s, parentId=%s,: %w", batch.Id, batch.ParentId, err,
+		)
+	}
+
+	return nil
+}
+
+func (t batchOp) deleteBatch(tx db.RwTx, batch *batchEntry, logger zerolog.Logger) error {
+	if err := tx.Delete(batchesTable, batch.Id.Bytes()); err != nil {
+		return fmt.Errorf("failed to delete batch with id=%s: %w", batch.Id, err)
+	}
+
+	if err := t.deleteBatchParentIndexEntry(tx, batch, logger); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (batchOp) deleteBatchParentIndexEntry(tx db.RwTx, batch *batchEntry, logger zerolog.Logger) error {
+	if batch.ParentId == nil {
+		return nil
+	}
+
+	err := tx.Delete(batchParentIdxTable, batch.ParentId.Bytes())
+
+	switch {
+	case err == nil:
+		return nil
+
+	case errors.Is(err, context.Canceled):
+		return err
+
+	case errors.Is(err, db.ErrKeyNotFound):
+		logger.Warn().Err(err).
+			Stringer(logging.FieldBatchId, batch.Id).
+			Stringer("parentBatchId", batch.ParentId).
+			Msg("parent batch idx entry is not found")
+		return nil
+
+	default:
+		return fmt.Errorf("failed to delete parent batch idx entry, parentId=%s: %w", batch.ParentId, err)
+	}
+}

--- a/nil/services/synccommittee/internal/storage/block_storage_op_batch_count.go
+++ b/nil/services/synccommittee/internal/storage/block_storage_op_batch_count.go
@@ -1,0 +1,68 @@
+package storage
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	"github.com/NilFoundation/nil/nil/internal/db"
+)
+
+const (
+	// storedBatchesCountTable stores the count of batches that have been persisted in the database.
+	// Key: mainShardKey, Value: uint32.
+	storedBatchesCountTable db.TableName = "stored_batches_count"
+)
+
+// batchCountOp represents the set of operations related to batch count in storage based on the given configuration.
+type batchCountOp struct{}
+
+func (t batchCountOp) addStoredCount(tx db.RwTx, delta int32, config BlockStorageConfig) error {
+	currentBatchesCount, err := t.getBatchesCount(tx)
+	if err != nil {
+		return err
+	}
+
+	signed := int32(currentBatchesCount) + delta
+	if signed < 0 {
+		return fmt.Errorf(
+			"batches count cannot be negative: delta=%d, current blocks count=%d", delta, currentBatchesCount,
+		)
+	}
+
+	newBatchesCount := uint32(signed)
+	if newBatchesCount > config.StoredBatchesLimit {
+		return fmt.Errorf(
+			"%w: delta is %d, current storage size is %d, capacity limit is %d",
+			ErrCapacityLimitReached, delta, currentBatchesCount, config.StoredBatchesLimit,
+		)
+	}
+
+	return t.putBatchesCount(tx, newBatchesCount)
+}
+
+func (batchCountOp) getBatchesCount(tx db.RoTx) (uint32, error) {
+	bytes, err := tx.Get(storedBatchesCountTable, mainShardKey)
+	switch {
+	case err == nil:
+		break
+	case errors.Is(err, db.ErrKeyNotFound):
+		return 0, nil
+	default:
+		return 0, fmt.Errorf("failed to get batches count: %w", err)
+	}
+
+	count := binary.LittleEndian.Uint32(bytes)
+	return count, nil
+}
+
+func (batchCountOp) putBatchesCount(tx db.RwTx, newValue uint32) error {
+	bytes := make([]byte, 4)
+	binary.LittleEndian.PutUint32(bytes, newValue)
+
+	err := tx.Put(storedBatchesCountTable, mainShardKey, bytes)
+	if err != nil {
+		return fmt.Errorf("failed to put batches count: %w (newValue is %d)", err, newValue)
+	}
+	return nil
+}

--- a/nil/services/synccommittee/internal/storage/block_storage_op_batch_latest.go
+++ b/nil/services/synccommittee/internal/storage/block_storage_op_batch_latest.go
@@ -1,0 +1,104 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/NilFoundation/nil/nil/internal/db"
+	scTypes "github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
+)
+
+const (
+	// latestBatchIdTable stores identifier of the latest saved batch.
+	// Key: mainShardKey, Value: scTypes.BatchId.
+	latestBatchIdTable db.TableName = "latest_batch_id"
+)
+
+// batchLatestOp represents the set of operations to manage the latest batch ID state in the storage.
+type batchLatestOp struct{}
+
+func (t batchLatestOp) updateLatestBatchId(tx db.RwTx, batch *scTypes.BlockBatch) error {
+	latestBatchId, err := t.getLatestBatchId(tx)
+	if err != nil {
+		return err
+	}
+	if err := t.validateLatestBatchId(batch, latestBatchId); err != nil {
+		return err
+	}
+
+	if err := t.putLatestBatchId(tx, &batch.Id); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (batchLatestOp) getLatestBatchId(tx db.RoTx) (*scTypes.BatchId, error) {
+	bytes, err := tx.Get(latestBatchIdTable, mainShardKey)
+
+	switch {
+	case err == nil:
+		break
+	case errors.Is(err, db.ErrKeyNotFound):
+		return nil, nil
+	case errors.Is(err, context.Canceled):
+		return nil, err
+	default:
+		return nil, fmt.Errorf("failed to get latest batch id: %w", err)
+	}
+
+	if bytes == nil {
+		return nil, nil
+	}
+
+	var batchId scTypes.BatchId
+	if err := batchId.UnmarshalText(bytes); err != nil {
+		return nil, err
+	}
+	return &batchId, nil
+}
+
+func (batchLatestOp) validateLatestBatchId(batch *scTypes.BlockBatch, latestBatchId *scTypes.BatchId) error {
+	var isValid bool
+	switch {
+	case latestBatchId == nil:
+		isValid = batch.ParentId == nil
+	case batch.ParentId == nil:
+		isValid = false
+	default:
+		isValid = *latestBatchId == *batch.ParentId
+	}
+
+	if isValid {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"%w: got batch with parentId=%s, latest batch id is %s",
+		scTypes.ErrBatchMismatch, batch.ParentId, latestBatchId,
+	)
+}
+
+func (batchLatestOp) putLatestBatchId(tx db.RwTx, batchId *scTypes.BatchId) error {
+	var bytes []byte
+
+	if batchId != nil {
+		var err error
+		bytes, err = batchId.MarshalText()
+		if err != nil {
+			return err
+		}
+	}
+
+	err := tx.Put(latestBatchIdTable, mainShardKey, bytes)
+
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, context.Canceled):
+		return err
+	default:
+		return fmt.Errorf("failed to put latest batch id: %w", err)
+	}
+}

--- a/nil/services/synccommittee/internal/storage/block_storage_op_block.go
+++ b/nil/services/synccommittee/internal/storage/block_storage_op_block.go
@@ -1,0 +1,84 @@
+package storage
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+
+	"github.com/NilFoundation/nil/nil/common/logging"
+	"github.com/NilFoundation/nil/nil/internal/db"
+	scTypes "github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
+	"github.com/rs/zerolog"
+)
+
+const (
+	// blocksTable stores blocks received from the RPC.
+	// Key: scTypes.BlockId (block's own id), Value: blockEntry.
+	blocksTable db.TableName = "blocks"
+)
+
+// blockOp represents the set of operations related to individual blocks within the storage.
+type blockOp struct{}
+
+func (bs blockOp) getBlock(tx db.RoTx, id scTypes.BlockId, required bool) (*blockEntry, error) {
+	return bs.getBlockBytesId(tx, id.Bytes(), required)
+}
+
+func (blockOp) getBlockBytesId(tx db.RoTx, idBytes []byte, required bool) (*blockEntry, error) {
+	value, err := tx.Get(blocksTable, idBytes)
+
+	switch {
+	case err == nil:
+		break
+	case errors.Is(err, db.ErrKeyNotFound) && required:
+		return nil, fmt.Errorf("%w, id=%s", scTypes.ErrBlockNotFound, hex.EncodeToString(idBytes))
+	case errors.Is(err, db.ErrKeyNotFound):
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("failed to get block with id=%s: %w", hex.EncodeToString(idBytes), err)
+	}
+
+	entry, err := unmarshallEntry[blockEntry](idBytes, value)
+	if err != nil {
+		return nil, err
+	}
+
+	return entry, nil
+}
+
+func (blockOp) putBlockTx(tx db.RwTx, entry *blockEntry) error {
+	value, err := marshallEntry(entry)
+	if err != nil {
+		return fmt.Errorf("%w, hash=%s", err, entry.Block.Hash)
+	}
+
+	blockId := scTypes.IdFromBlock(&entry.Block)
+	if err := tx.Put(blocksTable, blockId.Bytes(), value); err != nil {
+		return fmt.Errorf("failed to put block %s: %w", blockId.String(), err)
+	}
+
+	return nil
+}
+
+func (blockOp) deleteBlock(tx db.RwTx, blockId scTypes.BlockId, logger zerolog.Logger) error {
+	err := tx.Delete(blocksTable, blockId.Bytes())
+
+	switch {
+	case err == nil:
+		return nil
+
+	case errors.Is(err, context.Canceled):
+		return err
+
+	case errors.Is(err, db.ErrKeyNotFound):
+		logger.Warn().Err(err).
+			Stringer(logging.FieldShardId, blockId.ShardId).
+			Stringer(logging.FieldBlockHash, blockId.Hash).
+			Msg("block is not found (deleteBlock)")
+		return nil
+
+	default:
+		return fmt.Errorf("failed to delete block with id=%s: %w", blockId, err)
+	}
+}

--- a/nil/services/synccommittee/internal/storage/block_storage_op_blocks_latest_fetched.go
+++ b/nil/services/synccommittee/internal/storage/block_storage_op_blocks_latest_fetched.go
@@ -1,0 +1,78 @@
+package storage
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/NilFoundation/nil/nil/internal/db"
+	"github.com/NilFoundation/nil/nil/internal/types"
+	"github.com/NilFoundation/nil/nil/services/rpc/jsonrpc"
+	scTypes "github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
+)
+
+const (
+	// latestFetchedTable stores reference to the latest main shard block.
+	// Key: mainShardKey, Value: scTypes.MainBlockRef.
+	latestFetchedTable db.TableName = "latest_fetched"
+)
+
+// blockLatestFetchedOp represents the set of operations related to latest fetched blocks within the storage.
+type blockLatestFetchedOp struct{}
+
+func (blockLatestFetchedOp) getLatestFetchedMain(tx db.RoTx) (*scTypes.MainBlockRef, error) {
+	value, err := tx.Get(latestFetchedTable, mainShardKey)
+	if errors.Is(err, db.ErrKeyNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var blockRef *scTypes.MainBlockRef
+	err = json.Unmarshal(value, &blockRef)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrSerializationFailed, err)
+	}
+	return blockRef, nil
+}
+
+func (blockLatestFetchedOp) putLatestFetchedBlock(tx db.RwTx, shardId types.ShardId, block *scTypes.MainBlockRef) error {
+	bytes, err := json.Marshal(block)
+	if err != nil {
+		return fmt.Errorf(
+			"%w: failed to encode block ref with hash=%s: %w", ErrSerializationFailed, block.Hash.String(), err,
+		)
+	}
+	err = tx.Put(latestFetchedTable, makeShardKey(shardId), bytes)
+	if err != nil {
+		return fmt.Errorf("failed to put block ref with hash=%s: %w", block.Hash.String(), err)
+	}
+	return nil
+}
+
+func (t blockLatestFetchedOp) updateLatestFetched(tx db.RwTx, block *jsonrpc.RPCBlock) error {
+	if block.ShardId != types.MainShardId {
+		return nil
+	}
+
+	latestFetched, err := t.getLatestFetchedMain(tx)
+	if err != nil {
+		return err
+	}
+
+	if latestFetched.Equals(block) {
+		return nil
+	}
+
+	if err := latestFetched.ValidateChild(block); err != nil {
+		return fmt.Errorf("unable to update latest fetched block: %w", err)
+	}
+
+	newLatestFetched, err := scTypes.NewBlockRef(block)
+	if err != nil {
+		return err
+	}
+
+	return t.putLatestFetchedBlock(tx, block.ShardId, newLatestFetched)
+}

--- a/nil/services/synccommittee/internal/storage/block_storage_op_state_root.go
+++ b/nil/services/synccommittee/internal/storage/block_storage_op_state_root.go
@@ -1,0 +1,68 @@
+package storage
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/NilFoundation/nil/nil/common"
+	"github.com/NilFoundation/nil/nil/internal/db"
+)
+
+const (
+	// stateRootTable stores the latest ProvedStateRoot (single value).
+	// Key: mainShardKey, Value: common.Hash.
+	stateRootTable db.TableName = "state_root"
+
+	// nextToProposeTable stores parent's hash of the next block to propose (single value).
+	// Key: mainShardKey, Value: common.Hash.
+	nextToProposeTable db.TableName = "next_to_propose_parent_hash"
+)
+
+// stateRootOp represents the set of operations related to latest fetched blocks within the storage.
+type stateRootOp struct{}
+
+func (stateRootOp) putProvedStateRoot(tx db.RwTx, stateRoot common.Hash) error {
+	err := tx.Put(stateRootTable, mainShardKey, stateRoot.Bytes())
+	if err != nil {
+		return fmt.Errorf("failed to put proved state root: %w, value=%s", err, stateRoot)
+	}
+	return nil
+}
+
+func (stateRootOp) getProvedStateRoot(tx db.RoTx) (*common.Hash, error) {
+	hashBytes, err := tx.Get(stateRootTable, mainShardKey)
+	if errors.Is(err, db.ErrKeyNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	hash := common.BytesToHash(hashBytes)
+	return &hash, nil
+}
+
+// getParentOfNextToPropose retrieves parent's hash of the next block to propose
+func (stateRootOp) getParentOfNextToPropose(tx db.RoTx) (*common.Hash, error) {
+	hashBytes, err := tx.Get(nextToProposeTable, mainShardKey)
+
+	if errors.Is(err, db.ErrKeyNotFound) {
+		return nil, nil
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to get next to propose parent hash: %w", err)
+	}
+
+	hash := common.BytesToHash(hashBytes)
+	return &hash, nil
+}
+
+// setParentOfNextToPropose sets parent's hash of the next block to propose
+func (stateRootOp) setParentOfNextToPropose(tx db.RwTx, hash common.Hash) error {
+	err := tx.Put(nextToProposeTable, mainShardKey, hash.Bytes())
+	if err != nil {
+		return fmt.Errorf("failed to put next to propose parent hash: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
### Split block storage operations into dedicated components

* Introduced separate types (`batchOp`, `batchCountOp`, `stateRootOp`, etc.) to represent isolated sets of operations on different data structures: blocks, batches, secondary indices, etc;
* Reduced the size of `block_storage.go` file from ~1100 lines to ~600;
* No functional changes introduced