### PR TITLE
[telemetry] allow to specify endpoint for metrics

### DIFF
--- a/nil/internal/telemetry/internal/config.go
+++ b/nil/internal/telemetry/internal/config.go
@@ -3,5 +3,6 @@ package internal
 type Config struct {
 	ServiceName string `yaml:"serviceName,omitempty"`
 
-	ExportMetrics bool `yaml:"exportMetrics,omitempty"`
+	ExportMetrics bool   `yaml:"exportMetrics,omitempty"`
+	GrpcEndpoint  string `yaml:"grpcEndpoint,omitempty"`
 }

--- a/nil/internal/telemetry/internal/metric.go
+++ b/nil/internal/telemetry/internal/metric.go
@@ -18,7 +18,7 @@ func InitMetrics(ctx context.Context, config *Config) error {
 		return nil
 	}
 
-	exporter, err := newMetricGrpcExporter(ctx)
+	exporter, err := newMetricGrpcExporter(ctx, config)
 	if err != nil {
 		return fmt.Errorf("failed to initialize exporter: %w", err)
 	}
@@ -42,8 +42,12 @@ func ShutdownMetrics(ctx context.Context) {
 	_ = mp.Shutdown(context.WithoutCancel(ctx))
 }
 
-func newMetricGrpcExporter(ctx context.Context) (sdkmetric.Exporter, error) {
-	return otlpmetricgrpc.New(ctx, otlpmetricgrpc.WithInsecure())
+func newMetricGrpcExporter(ctx context.Context, config *Config) (sdkmetric.Exporter, error) {
+	opts := []otlpmetricgrpc.Option{otlpmetricgrpc.WithInsecure()}
+	if config.GrpcEndpoint != "" {
+		opts = append(opts, otlpmetricgrpc.WithEndpoint(config.GrpcEndpoint))
+	}
+	return otlpmetricgrpc.New(ctx, opts...)
 }
 
 func newMeterProvider(exporter sdkmetric.Exporter, config *Config) (*sdkmetric.MeterProvider, error) {


### PR DESCRIPTION
That can be very useful for local setup when signoz collector works inside docker but nild instaces run inside Vagrant.