### PR TITLE
Add a nixos container that can run full cluster

### DIFF
--- a/explorer_backend/services/sqlite.ts
+++ b/explorer_backend/services/sqlite.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import BetterSqlite3 from "better-sqlite3";
 
-const db: BetterSqlite3.Database = new BetterSqlite3("./database.db");
+const db: BetterSqlite3.Database = new BetterSqlite3(process.env.EXPLORER_DB || "./database.db");
 
 export { db };
 

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,8 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     nil-released = {
-      url = "github:NilFoundation/nil?rev=8f57aa19f88af84bb14a640a4c571c0f1610a2af";
+      url =
+        "github:NilFoundation/nil?rev=8f57aa19f88af84bb14a640a4c571c0f1610a2af";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-utils.follows = "flake-utils";
@@ -22,9 +23,7 @@
         versionFull = "${version}-${rev}";
         pkgs = import nixpkgs {
           inherit system;
-          overlays = [
-            (import ./nix/overlay.nix)
-          ];
+          overlays = [ (import ./nix/overlay.nix) ];
         };
       in
       rec {
@@ -33,18 +32,27 @@
           nil = (pkgs.callPackage ./nix/nil.nix { solc = solc; });
           niljs = (pkgs.callPackage ./nix/niljs.nix { solc = solc; });
           clijs = (pkgs.callPackage ./nix/clijs.nix { nil = nil; });
-          nildocs = (pkgs.callPackage ./nix/nildocs.nix { nil = nil; solc = solc; });
+          nildocs = (pkgs.callPackage ./nix/nildocs.nix {
+            nil = nil;
+            solc = solc;
+          });
           default = nil;
           formatters = (pkgs.callPackage ./nix/formatters.nix { });
-          update_public_repo = (pkgs.callPackage ./nix/update_public_repo.nix { });
-          nilcli = (pkgs.callPackage ./nix/nilcli.nix { nil = nil; versionFull = versionFull; });
-          nilsmartcontracts = (pkgs.callPackage ./nix/nilsmartcontracts.nix { });
+          update_public_repo =
+            (pkgs.callPackage ./nix/update_public_repo.nix { });
+          nilcli = (pkgs.callPackage ./nix/nilcli.nix {
+            nil = nil;
+            versionFull = versionFull;
+          });
+          nilsmartcontracts =
+            (pkgs.callPackage ./nix/nilsmartcontracts.nix { });
           nilexplorer = (pkgs.callPackage ./nix/nilexplorer.nix { });
           walletextension = (pkgs.callPackage ./nix/walletextension.nix { });
           uniswap = (pkgs.callPackage ./nix/uniswap.nix { });
           docsaibackend = (pkgs.callPackage ./nix/docsaibackend.nix { });
           l1-contracts = (pkgs.callPackage ./nix/l1-contracts.nix { });
-          rollup-bridge-contracts = (pkgs.callPackage ./nix/rollup-bridge-contracts.nix { });
+          rollup-bridge-contracts =
+            (pkgs.callPackage ./nix/rollup-bridge-contracts.nix { });
         };
         checks = rec {
           nil = (pkgs.callPackage ./nix/nil.nix {
@@ -54,9 +62,18 @@
           });
 
           # split tests into groups
-          ibft = nil.override { testGroup = "ibft"; parallelTesting = true; };
-          heavy = nil.override { testGroup = "heavy"; parallelTesting = true; };
-          others = nil.override { testGroup = "others"; parallelTesting = true; };
+          ibft = nil.override {
+            testGroup = "ibft";
+            parallelTesting = true;
+          };
+          heavy = nil.override {
+            testGroup = "heavy";
+            parallelTesting = true;
+          };
+          others = nil.override {
+            testGroup = "others";
+            parallelTesting = true;
+          };
 
           niljs = (pkgs.callPackage ./nix/niljs.nix {
             nil = packages.nil;
@@ -72,9 +89,8 @@
             enableTesting = true;
             solc = packages.solc;
           });
-          nilexplorer = (pkgs.callPackage ./nix/nilexplorer.nix {
-            enableTesting = true;
-          });
+          nilexplorer =
+            (pkgs.callPackage ./nix/nilexplorer.nix { enableTesting = true; });
           walletextension = (pkgs.callPackage ./nix/walletextension.nix {
             nil = packages.nil;
             enableTesting = true;
@@ -84,49 +100,64 @@
             enableTesting = true;
           });
         };
-        bundlers =
-          rec {
-            deb = pkg:
-              pkgs.stdenv.mkDerivation {
-                name = "deb-package-${pkg.pname}";
-                buildInputs = [ pkgs.fpm ];
 
-                unpackPhase = "true";
-                buildPhase = ''
-                  export HOME=$PWD
+        bundlers = rec {
+          deb = pkg:
+            pkgs.stdenv.mkDerivation {
+              name = "deb-package-${pkg.pname}";
+              buildInputs = [ pkgs.fpm ];
 
-                  mkdir -p ./usr
-                  mkdir -p ./usr/share/${packages.nildocs.pname}
-                  mkdir -p ./usr/share/${packages.nilexplorer.name}
-                  mkdir -p ./usr/share/${packages.docsaibackend.name}
-                  mkdir -p ./usr/share/${packages.l1-contracts.name}
-                  mkdir -p ./usr/share/${packages.rollup-bridge-contracts.name}
+              unpackPhase = "true";
+              buildPhase = ''
+                export HOME=$PWD
 
-                  cp -r ${pkg}/bin ./usr/
-                  cp -r ${pkg}/share ./usr/
-                  cp -r ${packages.nildocs.outPath}/* ./usr/share/${packages.nildocs.pname}
-                  cp -r ${packages.nilexplorer.outPath}/* ./usr/share/${packages.nilexplorer.name}
-                  cp -r ${packages.docsaibackend.outPath}/* ./usr/share/${packages.nilexplorer.name}
-                  cp -r ${packages.l1-contracts.outPath}/* ./usr/share/${packages.l1-contracts.name}
-                  cp -r ${packages.rollup-bridge-contracts.outPath}/{.,}* ./usr/share/${packages.rollup-bridge-contracts.name}
+                mkdir -p ./usr
+                mkdir -p ./usr/share/${packages.nildocs.pname}
+                mkdir -p ./usr/share/${packages.nilexplorer.name}
+                mkdir -p ./usr/share/${packages.docsaibackend.name}
+                mkdir -p ./usr/share/${packages.l1-contracts.name}
+                mkdir -p ./usr/share/${packages.rollup-bridge-contracts.name}
 
-                  chmod -R u+rw,g+r,o+r ./usr
-                  chmod -R u+rwx,g+rx,o+rx ./usr/bin
-                  chmod -R u+rwx,g+rx,o+rx ./usr/share/${packages.nildocs.pname}
-                  chmod -R u+rwx,g+rx,o+rx ./usr/share/${packages.nilexplorer.name}
-                  chmod -R u+rwx,g+rx,o+rx ./usr/share/${packages.docsaibackend.name}
+                cp -r ${pkg}/bin ./usr/
+                cp -r ${pkg}/share ./usr/
+                cp -r ${packages.nildocs.outPath}/* ./usr/share/${packages.nildocs.pname}
+                cp -r ${packages.nilexplorer.outPath}/* ./usr/share/${packages.nilexplorer.name}
+                cp -r ${packages.docsaibackend.outPath}/* ./usr/share/${packages.nilexplorer.name}
+                cp -r ${packages.l1-contracts.outPath}/* ./usr/share/${packages.l1-contracts.name}
+                cp -r ${packages.rollup-bridge-contracts.outPath}/{.,}* ./usr/share/${packages.rollup-bridge-contracts.name}
 
-                  bash ${./scripts/binary_patch_version.sh} ./usr/bin/nild ${versionFull}
-                  bash ${./scripts/binary_patch_version.sh} ./usr/bin/nil ${versionFull}
-                  bash ${./scripts/binary_patch_version.sh} ./usr/bin/cometa ${versionFull}
-                  ${pkgs.fpm}/bin/fpm -s dir -t deb --name ${pkg.pname} -v ${version} --deb-use-file-permissions usr
-                '';
-                installPhase = ''
-                  mkdir -p $out
-                  cp -r *.deb $out
-                '';
-              };
-            default = deb;
-          };
-      }));
+                chmod -R u+rw,g+r,o+r ./usr
+                chmod -R u+rwx,g+rx,o+rx ./usr/bin
+                chmod -R u+rwx,g+rx,o+rx ./usr/share/${packages.nildocs.pname}
+                chmod -R u+rwx,g+rx,o+rx ./usr/share/${packages.nilexplorer.name}
+                chmod -R u+rwx,g+rx,o+rx ./usr/share/${packages.docsaibackend.name}
+
+                bash ${
+                  ./scripts/binary_patch_version.sh
+                } ./usr/bin/nild ${versionFull}
+                bash ${
+                  ./scripts/binary_patch_version.sh
+                } ./usr/bin/nil ${versionFull}
+                bash ${
+                  ./scripts/binary_patch_version.sh
+                } ./usr/bin/cometa ${versionFull}
+                ${pkgs.fpm}/bin/fpm -s dir -t deb --name ${pkg.pname} -v ${version} --deb-use-file-permissions usr
+              '';
+              installPhase = ''
+                mkdir -p $out
+                cp -r *.deb $out
+              '';
+            };
+          default = deb;
+        };
+      }))
+
+    // {
+
+      nixosConfigurations.container = nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        modules = [ ./nix/container.nix ];
+
+      };
+    };
 }

--- a/nil/cmd/exporter/internal/exporter.go
+++ b/nil/cmd/exporter/internal/exporter.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sync/atomic"
 	"time"
@@ -269,9 +268,6 @@ func (e *exporter) startDriverExport(ctx context.Context) error {
 			// read available blocks
 			for len(e.blocksChan) > 0 && len(blockBuffer) < BlockBufferSize {
 				blockBuffer = append(blockBuffer, <-e.blocksChan)
-			}
-			if len(e.blocksChan) > 0 {
-				return errors.New("block buffer is full")
 			}
 
 			if len(blockBuffer) == 0 {

--- a/nix/container.nix
+++ b/nix/container.nix
@@ -1,0 +1,256 @@
+{ pkgs, lib, config, ... }:
+with lib;
+let
+  solc = (pkgs.callPackage ./solc.nix { });
+  nil = (pkgs.callPackage ./nil.nix { solc = solc; });
+  explorer = (pkgs.callPackage ./nilexplorer.nix { });
+  devnetConfig = {
+    nild_config_dir = "etc/nild";
+    nild_credentials_dir = "etc/nild";
+    nild_p2p_base_tcp_port = 30303;
+    nil_wipe_on_update = true;
+    nil_rpc_port = 8529;
+    pprof_base_tcp_port = 6060;
+    nShards = 5;
+    nil_config = [
+      {
+        id = 0;
+        shards = [ 0 1 ];
+        splitShards = true;
+        dhtBootstrapPeersIdx = [ 0 2 3 ];
+      }
+      {
+        id = 1;
+        shards = [ 0 2 ];
+        splitShards = true;
+        dhtBootstrapPeersIdx = [ 0 1 3 ];
+      }
+      {
+        id = 2;
+        shards = [ 0 3 ];
+        splitShards = true;
+        dhtBootstrapPeersIdx = [ 0 1 2 ];
+      }
+      {
+        id = 3;
+        shards = [ 0 4 ];
+        splitShards = true;
+        dhtBootstrapPeersIdx = [ 0 1 2 ];
+      }
+    ];
+    nil_archive_config = [{
+      id = 0;
+      shards = [ 0 1 2 3 4 ];
+      bootstrapPeersIdx = [ 0 1 2 3 ];
+      dhtBootstrapPeersIdx = [ 0 1 2 3 ];
+    }];
+    nil_rpc_config = [{
+      id = 0;
+      dhtBootstrapPeersIdx = [ 0 1 2 3 ];
+      archiveNodeIndices = [ 0 ];
+    }];
+  };
+
+  format = pkgs.formats.yaml { };
+
+  configFiles = pkgs.stdenv.mkDerivation {
+    name = "devnet-configs";
+    src = format.generate "devnet.yaml" devnetConfig;
+    dontUnpack = true;
+    buildInputs = [ nil ];
+    buildPhase = ''
+      mkdir etc
+      nild gen-configs --basedir var/lib "$src"
+
+      base="$(pwd)"
+      find etc/nild/ -type f -name "*.yaml" -exec sed -i "s#$base/etc/nild#/etc/nild#g" {} +
+      find etc/nild/ -type f -name "*.yaml" -exec sed -i "s#$base/var/lib#/var/lib#g" {} +
+    '';
+    installPhase = ''
+      mkdir -p $out/etc
+      cp -r etc/nild/* $out/etc
+    '';
+  };
+
+  runtime_config = pkgs.writeText "runtime_config.toml" ''
+    DOCUMENTATION_URL = "https://docs.nil.foundation/nil/intro"
+    GITHUB_URL = "https://github.com/NilFoundation/nil-hardhat-example"
+    API_URL = "/explorer-api"
+    COMETA_SERVICE_API_URL = "https://api.devnet.nil.foundation/api"
+    RPC_TELEGRAM_BOT = "https://t.me/NilDevnetTokenBot"
+    RPC_API_URL = "/api"
+    PLAYGROUND_DOCS_URL = "https://docs.nil.foundation"
+    PLAYGROUND_NILJS_URL = "https://github.com/NilFoundation/nil.js"
+    PLAYGROUND_MULTI_TOKEN_URL = "https://docs.nil.foundation/nil/getting-started/essentials/tokens"
+    PLAYGROUND_SUPPORT_URL = "https://t.me/+PT-6HyWK_LBmMmIx"
+    PLAYGROUND_FEEDBACK_URL = "https://form.typeform.com/to/pDEAcSqd"
+    API_REQUESTS_ENABLE_BATCHING = "true"
+    RECENT_PROJECTS_STORAGE_LIMIT = 5
+  '';
+
+in
+{
+  boot.isContainer = true;
+
+  networking.firewall.allowedTCPPorts = [ 80 ];
+
+  environment.systemPackages = [ nil configFiles pkgs.vim ];
+
+  environment.etc."nild".source = "${configFiles}/etc";
+
+  environment.etc."explorer_backend/runtime-config.toml".source =
+    runtime_config;
+
+  environment.etc."exporter/exporter.yaml".text = ''
+    clickhouse-password: ""
+    clickhouse-endpoint: 127.0.0.1:9000
+    clickhouse-login: "default"
+    clickhouse-database: "nil_database"
+    api-endpoint: http://127.0.0.1:8529
+  '';
+
+  users.users.nil = {
+    isSystemUser = true;
+    group = "nil";
+  };
+  users.groups.nil = { };
+
+  systemd.services = builtins.listToAttrs
+    (map
+      (cfg: {
+        name = "nil-${toString cfg.id}";
+        value = {
+          description = "nil-${toString cfg.id} service";
+          after = [ "network.target" ];
+          wantedBy = [ "multi-user.target" ];
+          serviceConfig = {
+            ExecStart =
+              "${nil}/bin/nild run -c /etc/nild/nil-${toString cfg.id}/nild.yaml";
+            Restart = "always";
+            User = "nil";
+            Group = "nil";
+            WorkingDirectory = "/var/lib/nil-${toString cfg.id}";
+            StateDirectory = "nil-${toString cfg.id}";
+            RuntimeDirectory = "nil-${toString cfg.id}";
+
+          };
+        };
+      })
+      devnetConfig.nil_config) //
+
+  (builtins.listToAttrs (map
+    (cfg: {
+      name = "nil-rpc-${toString cfg.id}";
+      value = {
+        description = "nil-rpc-${toString cfg.id} service";
+        after = [ "network.target" ];
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          ExecStart = "${nil}/bin/nild rpc -c /etc/nild/nil-rpc-${
+              toString cfg.id
+            }/nild.yaml";
+          Restart = "always";
+          User = "nil";
+          Group = "nil";
+          WorkingDirectory = "/var/lib/nil-rpc-${toString cfg.id}";
+          StateDirectory = "nil-rpc-${toString cfg.id}";
+          RuntimeDirectory = "nil-rpc-${toString cfg.id}";
+
+        };
+      };
+    })
+    devnetConfig.nil_rpc_config)) //
+
+  (builtins.listToAttrs (map
+    (cfg: {
+      name = "nil-archive-${toString cfg.id}";
+      value = {
+        description = "nil-archive-${toString cfg.id} service";
+        after = [ "network.target" ];
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          ExecStart = "${nil}/bin/nild archive -c /etc/nild/nil-archive-${
+              toString cfg.id
+            }/nild.yaml";
+          Restart = "always";
+          User = "nil";
+          Group = "nil";
+          WorkingDirectory = "/var/lib/nil-archive-${toString cfg.id}";
+          StateDirectory = "nil-archive-${toString cfg.id}";
+          RuntimeDirectory = "nil-archive-${toString cfg.id}";
+
+        };
+      };
+    })
+    devnetConfig.nil_archive_config)) //
+
+  {
+    exporter = {
+      description = "exporter service";
+      after = [ "network.target" "clickhouse.service" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        ExecStart =
+          "${nil}/bin/exporter -c /etc/exporter/exporter.yaml --allow-db-clear";
+        Restart = "always";
+        User = "nil";
+        Group = "nil";
+        WorkingDirectory = "/var/lib/exporter";
+        StateDirectory = "exporter";
+        RuntimeDirectory = "exporter";
+        ExecStartPre = ''
+          ${pkgs.clickhouse}/bin/clickhouse-client --query "CREATE DATABASE IF NOT EXISTS nil_database"'';
+      };
+    };
+  } // {
+    explorer_backend = {
+      description = "explorer_backend service";
+      after = [ "network.target" "clickhouse.service" ];
+      wantedBy = [ "multi-user.target" ];
+      path = [ "${pkgs.nodejs}" "${pkgs.bash}" ];
+      serviceConfig = {
+        ExecStart =
+          "${pkgs.nodejs}/bin/npm run start --prefix ${explorer}/explorer_backend";
+        Restart = "always";
+        User = "nil";
+        Group = "nil";
+        WorkingDirectory = "/var/lib/explorer_backend";
+        StateDirectory = "explorer_backend";
+        RuntimeDirectory = "explorer_backend";
+        Environment = [
+          "EXPLORER_DB=/var/lib/explorer_backend/explorer.db"
+          "DB_URL=http://127.0.0.1:8123"
+          "DB_USER=default"
+          "DB_NAME=nil_database"
+        ];
+      };
+    };
+  };
+
+  services.nginx = {
+    enable = true;
+    recommendedGzipSettings = true;
+    recommendedOptimisation = true;
+    recommendedProxySettings = true;
+    recommendedTlsSettings = true;
+    virtualHosts."default" = {
+      locations = {
+        "/api" = { proxyPass = "http://127.0.0.1:8529"; };
+        "/explorer-api" = {
+          proxyPass = "http://127.0.0.1:3000/api/";
+          extraConfig = ''
+            rewrite ^/explorer-api(/.*)$ /api$1 break;
+          '';
+        };
+        "/runtime-config.toml" = { root = "/etc/explorer_backend/"; };
+        "/" = {
+          root = "${explorer}/explorer_frontend/dist";
+          tryFiles = "$uri $uri/ /index.html";
+        };
+      };
+      default = true;
+    };
+  };
+
+  services.clickhouse = { enable = true; };
+}

--- a/nix/nilexplorer.nix
+++ b/nix/nilexplorer.nix
@@ -26,12 +26,7 @@ stdenv.mkDerivation rec {
 
   NODE_PATH = "$npmDeps";
 
-  nativeBuildInputs = [
-    nodejs
-    npmHooks.npmConfigHook
-    biome
-    python3
-  ];
+  nativeBuildInputs = [ nodejs npmHooks.npmConfigHook biome python3 ];
 
   dontConfigure = true;
 
@@ -45,6 +40,7 @@ stdenv.mkDerivation rec {
 
   buildPhase = ''
     patchShebangs explorer_frontend/node_modules
+    patchShebangs node_modules
 
     (cd smart-contracts; npm run build)
     (cd niljs; npm run build)
@@ -84,7 +80,10 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out
-    mv explorer_frontend/ $out/frontend
-    mv explorer_backend/ $out/backend
+    mv explorer_frontend/ $out/explorer_frontend
+    mv explorer_backend/ $out/explorer_backend
+    mv niljs $out/niljs
+    mv node_modules $out/node_modules
+    mv smart-contracts $out/smart-contracts
   '';
 }


### PR DESCRIPTION
This PR when merged will allow you to run cluster setup almost exactly like it does in production, in a matter of seconds. The word "container" here may be a bit misleading, because even though we do start a cgroup, it will run systemd, nild, nginx, and other things like a normal operating system (and unlike Docker for example).

Note, that you need NixOS installed and not just Nix package manager, because the `nixos-container` tool is not available with just Nix.

```
sudo nixos-container create devcontainer --flake .
sudo nixos-container start devcontainer
```

If you made changes to nild or configs and want to update the container in-place, you can do:

```
sudo nixos-container update devcontainer --flake .
```

As a follow-up, I will add ClickHouse, exporter, and all frontend parts to run in the container as well.