### PR TITLE
[config] Remove legacy flags networkKeysPath and db.allowDrop

### DIFF
--- a/nil/cmd/nild/main.go
+++ b/nil/cmd/nild/main.go
@@ -67,11 +67,6 @@ func loadConfig() (*nildconfig.Config, error) {
 		return nil, err
 	}
 
-	// todo: remove this after migration to new config
-	if cfg.NetworkKeysPath != "" {
-		cfg.Network.KeysPath = cfg.NetworkKeysPath
-	}
-
 	return cfg, nil
 }
 
@@ -180,12 +175,6 @@ func parseArgs() *nildconfig.Config {
 
 	logging.SetupGlobalLogger(logLevel)
 	check.PanicIfErr(logging.SetLibp2pLogLevel(libp2pLogLevel))
-
-	// todo: remove it when we remove the old flag
-	// Support old flag for backward compatibility
-	if cfg.DB.AllowDrop {
-		cfg.Config.AllowDbDrop = cfg.DB.AllowDrop
-	}
 
 	if cfg.Replay.BlockIdLast == 0 {
 		cfg.Replay.BlockIdLast = cfg.Replay.BlockIdFirst

--- a/nil/internal/db/badger.go
+++ b/nil/internal/db/badger.go
@@ -25,9 +25,6 @@ type BadgerDBOptions struct {
 	Path         string        `yaml:"path"`
 	DiscardRatio float64       `yaml:"gcDiscardRatio,omitempty"`
 	GcFrequency  time.Duration `yaml:"gcFrequency,omitempty"`
-
-	// deprecated
-	AllowDrop bool `yaml:"allowDrop,omitempty"`
 }
 
 func NewDefaultBadgerDBOptions() *BadgerDBOptions {

--- a/nil/services/nilservice/config.go
+++ b/nil/services/nilservice/config.go
@@ -55,9 +55,6 @@ type Config struct {
 	ValidatorKeysPath    string                     `yaml:"validatorKeysPath,omitempty"`
 	ValidatorKeysManager *keys.ValidatorKeysManager `yaml:"-"`
 
-	// deprecated
-	NetworkKeysPath string `yaml:"networkKeysPath,omitempty"`
-
 	// HttpUrl is calculated from RPCPort
 	HttpUrl string `yaml:"-"`
 


### PR DESCRIPTION
The configs are regenerated each deploy anyway, so no need to keep compatibility.