### PR TITLE
Fix decoding of revert messages and deploy transactions

### DIFF
--- a/nil/internal/execution/account_state.go
+++ b/nil/internal/execution/account_state.go
@@ -163,6 +163,9 @@ func (as *AccountState) GetState(key common.Hash) (common.Hash, error) {
 
 	newVal, err := as.GetCommittedState(key)
 	if err != nil {
+		if errors.Is(err, db.ErrKeyNotFound) {
+			return common.EmptyHash, nil
+		}
 		return common.EmptyHash, err
 	}
 	as.State[key] = newVal
@@ -309,9 +312,6 @@ func (as *AccountState) setState(key common.Hash, value common.Hash) {
 // GetCommittedState retrieves a value from the committed account storage trie.
 func (as *AccountState) GetCommittedState(key common.Hash) (common.Hash, error) {
 	res, err := as.StorageTree.Fetch(key)
-	if errors.Is(err, db.ErrKeyNotFound) {
-		return common.EmptyHash, nil
-	}
 	if err != nil {
 		return common.EmptyHash, err
 	}

--- a/nil/internal/execution/state.go
+++ b/nil/internal/execution/state.go
@@ -1059,12 +1059,14 @@ func (es *ExecutionState) HandleTransaction(ctx context.Context, txn *types.Tran
 	}
 	// We don't need bounce transaction for request, because it will be sent within the response transaction.
 	if res.Error != nil && !responseWasSent {
-		revString := decodeRevertTransaction(res.ReturnData)
-		if revString != "" {
-			if types.IsVmError(res.Error) {
-				res.Error = types.NewVmVerboseError(res.Error.Code(), revString)
-			} else {
-				res.Error = types.NewVerboseError(res.Error.Code(), revString)
+		if res.Error.Code() == types.ErrorExecutionReverted {
+			revString := decodeRevertTransaction(res.ReturnData)
+			if revString != "" {
+				if types.IsVmError(res.Error) {
+					res.Error = types.NewVmVerboseError(res.Error.Code(), revString)
+				} else {
+					res.Error = types.NewVerboseError(res.Error.Code(), revString)
+				}
 			}
 		}
 		if txn.IsBounce() {

--- a/nil/internal/execution/state.go
+++ b/nil/internal/execution/state.go
@@ -736,7 +736,6 @@ func (es *ExecutionState) CreateContract(addr types.Address) error {
 }
 
 // Contract is regarded as existent if any of these three conditions is met:
-// - the nonce is non-zero
 // - the code is non-empty
 // - the storage is non-empty
 func (es *ExecutionState) ContractExists(address types.Address) (bool, error) {
@@ -748,12 +747,7 @@ func (es *ExecutionState) ContractExists(address types.Address) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	seqno, err := es.GetSeqno(address)
-	if err != nil {
-		return false, err
-	}
-	return seqno != 0 ||
-		(contractHash != common.EmptyHash) || // non-empty code
+	return (contractHash != common.EmptyHash) || // non-empty code
 		(storageRoot != common.EmptyHash), nil // non-empty storage
 }
 

--- a/nil/internal/vm/evm.go
+++ b/nil/internal/vm/evm.go
@@ -469,6 +469,7 @@ func (evm *EVM) create(caller ContractRef, codeAndHash types.Code, gas uint64, v
 		if !errors.Is(err, ErrExecutionReverted) {
 			contract.UseGas(contract.Gas, evm.Config.Tracer, tracing.GasChangeCallFailedExecution)
 		}
+		ret = nil
 	}
 
 	return ret, address, contract.Gas, err


### PR DESCRIPTION
- Decoding message from return data must be performed only for `ErrExecutionReverted` errors.
- Enable deploying to accounts with `seqno` != 0. Because even failed transactions are incrementing it. 
- Do not save non-existent values read at the time of execution to StateTree. It has a drawback that non-existing values are not cached now, but if we cache them, then they will be written to the state and change it even if there were no `SSTORE` instruction. Here is a ticket on this issue #546.

Closes #543