### PR TITLE
[jsonrpc] implement web3_clientVersion

### DIFF
--- a/nil/client/client.go
+++ b/nil/client/client.go
@@ -30,6 +30,7 @@ type BatchRequest interface {
 type Client interface {
 	RawClient
 	DbClient
+	Web3Client
 
 	CreateBatchRequest() BatchRequest
 	BatchCall(ctx context.Context, req BatchRequest) ([]any, error)

--- a/nil/client/direct_client.go
+++ b/nil/client/direct_client.go
@@ -22,6 +22,7 @@ type DirectClient struct {
 	ethApi   jsonrpc.EthAPI
 	debugApi jsonrpc.DebugAPI
 	dbApi    jsonrpc.DbAPI
+	web3Api  jsonrpc.Web3API
 }
 
 var _ Client = (*DirectClient)(nil)
@@ -30,11 +31,13 @@ func NewEthClient(ctx context.Context, db db.ReadOnlyDB, localApi *rawapi.NodeAp
 	ethApi := jsonrpc.NewEthAPI(ctx, localApi, db, true, false)
 	debugApi := jsonrpc.NewDebugAPI(localApi, logger)
 	dbApi := jsonrpc.NewDbAPI(db, logger)
+	web3Api := jsonrpc.NewWeb3API(localApi)
 
 	return &DirectClient{
 		ethApi:   ethApi,
 		debugApi: debugApi,
 		dbApi:    dbApi,
+		web3Api:  web3Api,
 	}, nil
 }
 
@@ -305,4 +308,8 @@ func (c *DirectClient) PlainTextCall(_ context.Context, requestBody []byte) (jso
 
 func (c *DirectClient) GetDebugContract(ctx context.Context, contractAddr types.Address, blockId any) (*jsonrpc.DebugRPCContract, error) {
 	panic("Not supported")
+}
+
+func (c *DirectClient) ClientVersion(ctx context.Context) (string, error) {
+	return c.web3Api.ClientVersion(ctx)
 }

--- a/nil/client/rpc/client.go
+++ b/nil/client/rpc/client.go
@@ -79,6 +79,7 @@ const (
 	Debug_getBlockByHash                 = "debug_getBlockByHash"
 	Debug_getBlockByNumber               = "debug_getBlockByNumber"
 	Debug_getContract                    = "debug_getContract"
+	Web3_clientVersion                   = "web3_clientVersion"
 )
 
 const (
@@ -558,12 +559,16 @@ func (c *Client) GetTransactionCount(ctx context.Context, address types.Address,
 	return types.Seqno(val), nil
 }
 
-func toUint64(raw json.RawMessage) (uint64, error) {
-	input := strings.TrimSpace(string(raw))
-	if len(input) >= 2 && input[0] == '"' && input[len(input)-1] == '"' {
-		input = input[1 : len(input)-1]
+func toString(raw json.RawMessage) string {
+	res := strings.TrimSpace(string(raw))
+	if len(res) >= 2 && res[0] == '"' && res[len(res)-1] == '"' {
+		res = res[1 : len(res)-1]
 	}
-	return strconv.ParseUint(input, 0, 64)
+	return res
+}
+
+func toUint64(raw json.RawMessage) (uint64, error) {
+	return strconv.ParseUint(toString(raw), 0, 64)
 }
 
 func (c *Client) GetBlockTransactionCount(ctx context.Context, shardId types.ShardId, blockId any) (uint64, error) {
@@ -682,6 +687,14 @@ func (c *Client) GetNumShards(ctx context.Context) (uint64, error) {
 	}
 
 	return toUint64(res)
+}
+
+func (c *Client) ClientVersion(ctx context.Context) (string, error) {
+	res, err := c.call(ctx, Web3_clientVersion)
+	if err != nil {
+		return "", err
+	}
+	return toString(res), nil
 }
 
 func (c *Client) DeployContract(

--- a/nil/client/web3_client.go
+++ b/nil/client/web3_client.go
@@ -1,0 +1,10 @@
+package client
+
+import (
+	"context"
+)
+
+type Web3Client interface {
+	// ClientVersion retrieves the current version of the client.
+	ClientVersion(ctx context.Context) (string, error)
+}

--- a/nil/common/version/version.go
+++ b/nil/common/version/version.go
@@ -77,7 +77,7 @@ func HasGitInfo() bool {
 	return GetVersionInfo().GitCommit != unknownVersion
 }
 
-func BuildVersionString(appTitle string) string {
+func buildVersionString(tmpl, appTitle string) string {
 	ver := GetVersionInfo().GitTag
 	if ver == "" {
 		ver = unknownVersion
@@ -93,7 +93,7 @@ func BuildVersionString(appTitle string) string {
 		ver = parts[1]
 	}
 
-	return FormatVersion(versionTmpl, map[string]any{
+	return FormatVersion(tmpl, map[string]any{
 		"Title":    appTitle,
 		"Version":  ver,
 		"OS":       runtime.GOOS,
@@ -101,6 +101,14 @@ func BuildVersionString(appTitle string) string {
 		"Commit":   GetVersionInfo().GitCommit,
 		"Revision": GetGitRevCount(),
 	})
+}
+
+func BuildVersionString(appTitle string) string {
+	return buildVersionString(versionTmpl, appTitle)
+}
+
+func BuildClientVersion(appTitle string) string {
+	return buildVersionString(clientVersionTmpl, appTitle)
 }
 
 func GetGitRevCount() string {
@@ -124,3 +132,5 @@ var versionTmpl = `{{ .Title }}
  OS/Arch:	{{ .OS }}/{{ .Arch }}
  Git commit:	{{ .Commit }}
  Revision:	{{ .Revision }}`
+
+var clientVersionTmpl = "{{ .Title }}/{{ .Version }}/{{ .OS }}-{{ .Arch }}/{{ .Commit }}/{{ .Revision }}"

--- a/nil/services/nilservice/service.go
+++ b/nil/services/nilservice/service.go
@@ -73,6 +73,7 @@ func startRpcServer(ctx context.Context, cfg *Config, rawApi rawapi.NodeApi, db 
 	defer cancel()
 
 	debugImpl := jsonrpc.NewDebugAPI(rawApi, logger)
+	web3Impl := jsonrpc.NewWeb3API(rawApi)
 
 	apiList := []transport.API{
 		{
@@ -85,6 +86,12 @@ func startRpcServer(ctx context.Context, cfg *Config, rawApi rawapi.NodeApi, db 
 			Namespace: "debug",
 			Public:    true,
 			Service:   jsonrpc.DebugAPI(debugImpl),
+			Version:   "1.0",
+		},
+		{
+			Namespace: "web3",
+			Public:    true,
+			Service:   jsonrpc.Web3API(web3Impl),
 			Version:   "1.0",
 		},
 	}

--- a/nil/services/rpc/jsonrpc/web3_api.go
+++ b/nil/services/rpc/jsonrpc/web3_api.go
@@ -1,0 +1,29 @@
+package jsonrpc
+
+import (
+	"context"
+
+	"github.com/NilFoundation/nil/nil/services/rpc/rawapi"
+)
+
+// Web3API provides interfaces for the web3_ RPC commands
+type Web3API interface {
+	ClientVersion(_ context.Context) (string, error)
+}
+
+type Web3APIImpl struct {
+	rawApi rawapi.NodeApi
+}
+
+var _ Web3API = &Web3APIImpl{}
+
+func NewWeb3API(rawApi rawapi.NodeApi) *Web3APIImpl {
+	return &Web3APIImpl{
+		rawApi: rawApi,
+	}
+}
+
+// ClientVersion implements web3_clientVersion. Returns the current client version.
+func (api *Web3APIImpl) ClientVersion(ctx context.Context) (string, error) {
+	return api.rawApi.ClientVersion(ctx)
+}

--- a/nil/services/rpc/rawapi/api.go
+++ b/nil/services/rpc/rawapi/api.go
@@ -34,6 +34,8 @@ type NodeApiRo interface {
 	GasPrice(ctx context.Context, shardId types.ShardId) (types.Value, error)
 	GetShardIdList(ctx context.Context) ([]types.ShardId, error)
 	GetNumShards(ctx context.Context) (uint64, error)
+
+	ClientVersion(ctx context.Context) (string, error)
 }
 
 type NodeApi interface {
@@ -62,6 +64,8 @@ type ShardApiRo interface {
 	GasPrice(ctx context.Context) (types.Value, error)
 	GetShardIdList(ctx context.Context) ([]types.ShardId, error)
 	GetNumShards(ctx context.Context) (uint64, error)
+
+	ClientVersion(ctx context.Context) (string, error)
 
 	setAsP2pRequestHandlersIfAllowed(ctx context.Context, networkManager *network.Manager, readonly bool, logger zerolog.Logger) error
 	setNodeApi(nodeApi NodeApi)

--- a/nil/services/rpc/rawapi/client.go
+++ b/nil/services/rpc/rawapi/client.go
@@ -179,6 +179,10 @@ func (api *ShardApiAccessor) SendTransaction(ctx context.Context, transaction []
 	return sendRequestAndGetResponseWithCallerMethodName[txnpool.DiscardReason](ctx, api, "SendTransaction", transaction)
 }
 
+func (api *ShardApiAccessor) ClientVersion(ctx context.Context) (string, error) {
+	return sendRequestAndGetResponseWithCallerMethodName[string](ctx, api, "ClientVersion")
+}
+
 func (api *ShardApiAccessor) setNodeApi(nodeApi NodeApi) {
 	api.onSetNodeApi(nodeApi)
 }

--- a/nil/services/rpc/rawapi/local_web3.go
+++ b/nil/services/rpc/rawapi/local_web3.go
@@ -1,0 +1,11 @@
+package rawapi
+
+import (
+	"context"
+
+	"github.com/NilFoundation/nil/nil/common/version"
+)
+
+func (api *LocalShardApi) ClientVersion(ctx context.Context) (string, error) {
+	return version.BuildClientVersion("=;Nil"), nil
+}

--- a/nil/services/rpc/rawapi/node.go
+++ b/nil/services/rpc/rawapi/node.go
@@ -265,3 +265,17 @@ func (api *NodeApiOverShardApis) SendTransaction(ctx context.Context, shardId ty
 	}
 	return result, nil
 }
+
+func (api *NodeApiOverShardApis) ClientVersion(ctx context.Context) (string, error) {
+	methodName := methodNameChecked("ClientVersion")
+	shardId := types.MainShardId
+	shardApi, ok := api.Apis[shardId]
+	if !ok {
+		return "", makeShardNotFoundError(methodName, shardId)
+	}
+	result, err := shardApi.ClientVersion(ctx)
+	if err != nil {
+		return "", makeCallError(methodName, shardId, err)
+	}
+	return result, nil
+}

--- a/nil/services/rpc/rawapi/pb/conversion.go
+++ b/nil/services/rpc/rawapi/pb/conversion.go
@@ -386,6 +386,26 @@ func (br *Uint64Response) UnpackProtoMessage() (uint64, error) {
 	}
 }
 
+// StringResponse converters
+func (br *StringResponse) PackProtoMessage(value string, err error) error {
+	br.Result = &StringResponse_Value{Value: value}
+	if err != nil {
+		br.Result = &StringResponse_Error{Error: new(Error).PackProtoMessage(err)}
+	}
+	return nil
+}
+
+func (br *StringResponse) UnpackProtoMessage() (string, error) {
+	switch br.Result.(type) {
+	case *StringResponse_Error:
+		return "", br.GetError().UnpackProtoMessage()
+	case *StringResponse_Value:
+		return br.GetValue(), nil
+	default:
+		return "", errors.New("unexpected response type")
+	}
+}
+
 func (br *BalanceResponse) PackProtoMessage(balance types.Value, err error) error {
 	if err != nil {
 		br.Result = &BalanceResponse_Error{Error: new(Error).PackProtoMessage(err)}

--- a/nil/services/rpc/rawapi/proto/common.proto
+++ b/nil/services/rpc/rawapi/proto/common.proto
@@ -50,6 +50,13 @@ message Uint64Response {
   }
 }
 
+message StringResponse {
+  oneof result {
+    Error error = 1;
+    string value = 2;
+  }
+}
+
 message Log {
   Address address = 1;
   repeated Hash topics = 2;

--- a/nil/services/rpc/rawapi/server.go
+++ b/nil/services/rpc/rawapi/server.go
@@ -35,6 +35,8 @@ type NetworkTransportProtocolRo interface {
 	GasPrice() pb.GasPriceResponse
 	GetShardIdList() pb.ShardIdListResponse
 	GetNumShards() pb.Uint64Response
+
+	ClientVersion() pb.StringResponse
 }
 
 // NetworkTransportProtocol is a helper interface for associating the argument and result types of Api methods

--- a/nil/tests/rpc_service/rpc_service_test.go
+++ b/nil/tests/rpc_service/rpc_service_test.go
@@ -205,10 +205,11 @@ func (s *SuiteRpcService) TestRpcError() {
 }
 
 func (s *SuiteRpcService) TestBatch() {
+	apis := `{"db":"1.0","debug":"1.0","eth":"1.0","faucet":"1.0","rpc":"1.0","web3":"1.0"}`
 	testcases := map[string]string{
 		"[]": `{"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"empty batch"}}`,
-		`[{"jsonrpc":"2.0","id": 1, "method":"rpc_modules","params":[]}]`:                                                                `[{"jsonrpc":"2.0","id":1,"result":{"db":"1.0","debug":"1.0","eth":"1.0","faucet":"1.0","rpc":"1.0"}}]`,
-		`[{"jsonrpc":"2.0","id": 1, "method":"rpc_modules","params":[]}, {"jsonrpc":"2.0","id": 2, "method":"rpc_modules","params":[]}]`: `[{"jsonrpc":"2.0","id":1,"result":{"db":"1.0","debug":"1.0","eth":"1.0","faucet":"1.0","rpc":"1.0"}}, {"jsonrpc":"2.0","id":2,"result":{"db":"1.0","debug":"1.0","faucet":"1.0","eth":"1.0","rpc":"1.0"}}]`,
+		`[{"jsonrpc":"2.0","id": 1, "method":"rpc_modules","params":[]}]`:                                                                `[{"jsonrpc":"2.0","id":1,"result":` + apis + `}]`,
+		`[{"jsonrpc":"2.0","id": 1, "method":"rpc_modules","params":[]}, {"jsonrpc":"2.0","id": 2, "method":"rpc_modules","params":[]}]`: `[{"jsonrpc":"2.0","id":1,"result":` + apis + `}, {"jsonrpc":"2.0","id":2,"result":` + apis + `}]`,
 		`[{"jsonrpc":"2.0", "method":"rpc_modules","params":[]}]`:                                                                        `[{"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"invalid request"}}]`,
 		`[{"jsonrpc":"2.0", "method":"eth_getBlockByNumber", "params": [0, "100500", false], "id": 1}]`:                                  `[{"jsonrpc":"2.0","id":1,"result":null}]`,
 	}
@@ -253,6 +254,12 @@ func (s *SuiteRpcService) TestBatch() {
 	}
 	_, err = s.Client.BatchCall(s.Context, batch)
 	s.Require().ErrorContains(err, "batch limit 100 exceeded")
+}
+
+func (s *SuiteRpcService) TestClientVersion() {
+	res, err := s.Client.ClientVersion(s.Context)
+	s.Require().NoError(err)
+	s.Require().Contains(res, "=;Nil")
 }
 
 func TestSuiteRpcService(t *testing.T) {


### PR DESCRIPTION
After this patch it will be possible to retrieve a version of current validator node.

Closes #541