### PR TITLE
chore(ci): add `help` target to display all targets documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,22 +11,22 @@ GOTEST = GOPRIVATE="$(GOPRIVATE)" GODEBUG=cgocheck=0 $(GO) test -tags $(BUILD_TA
 SC_COMMANDS = sync_committee sync_committee_cli proof_provider prover nil_block_generator
 COMMANDS += nild nil nil_load_generator exporter cometa faucet journald_forwarder relay $(SC_COMMANDS)
 
-all: $(COMMANDS)
+all: $(COMMANDS) ## Build all commands
 
 .PHONY: generated
-generated: ssz pb compile-contracts generate_mocks synccommittee_types tracer_constants
+generated: ssz pb compile-contracts generate_mocks synccommittee_types tracer_constants ## Generate all required code files
 
 .PHONY: test
-test: generated
+test: generated ## Run all tests
 	$(GOTEST) $(CMDARGS)
 
-%.cmd: generated
+%.cmd: generated ## Build individual command (replace % with command name)
 	@# Note: $* is replaced by the command name
 	@echo "Building $*"
 	@cd ./nil/cmd/$* && $(GOBUILD) -o $(GOBIN)/$*
 	@echo "Run \"$(GOBIN)/$*\" to launch $*."
 
-%.runcmd: %.cmd
+%.runcmd: %.cmd ## Run built command (replace % with command name)
 	@$(GOBIN)/$* $(CMDARGS)
 
 $(COMMANDS): %: generated %.cmd
@@ -42,7 +42,7 @@ include nil/go-ibft/messages/proto/Makefile.inc
 include nil/Makefile.inc
 
 .PHONY: ssz
-ssz: ssz_sszx ssz_db ssz_mpt ssz_types ssz_config ssz_execution
+ssz: ssz_sszx ssz_db ssz_mpt ssz_types ssz_config ssz_execution ## Generate the SSZ serialization code
 
 .PHONY: pb
 pb: pb_rawapi pb_ibft pb_synccommittee
@@ -54,35 +54,38 @@ CHECK_LOCKS_DIRECTORIES := ./nil/internal/network
 # CHECK_LOCKS_DIRECTORIES := $(shell find ./nil -type f -name "*.go" | xargs -I {} dirname {} | sort -u)
 
 .PHONY: compile-bins
-compile-bins:
+compile-bins: ## Compile contract binaries
 	cd nil/contracts && go generate generate.go
 
 $(BIN_FILES): | compile-bins
 
-compile-contracts: $(BIN_FILES)
+compile-contracts: $(BIN_FILES) ## Generate zero state compiled contracts code
 
-lint: generated
+lint: generated ## Run code linting and formatting
 	GOPROXY= go mod tidy
 	GOPROXY= go mod vendor
 	gofumpt -l -w .
 	gci write . --skip-generated --skip-vendor
 	golangci-lint run
 
-checklocks: generated
+checklocks: generated ## Check locks correctness
 	@export GOFLAGS="$$GOFLAGS -tags=test"; \
 	for dir in $(CHECK_LOCKS_DIRECTORIES); do \
 		echo ">> Checking locks correctness in $$dir"; \
 		go run gvisor.dev/gvisor/tools/checklocks/cmd/checklocks "$$dir" || exit 1; \
 	done
 
-rpcspec:
+rpcspec: ## Generate RPC specification
 	go run nil/cmd/spec_generator/spec_generator.go
 
-clean:
+clean: ## Clean build artifacts
 	go clean -cache
 	rm -fr build/*
 	rm -fr contracts/compiled/*
 
-solc:
+solc: ## Run solidity contracts compilation
 	$(eval ARGS ?= --help)
 	@GOPRIVATE="$(GOPRIVATE)" $(GO) run $(GO_FLAGS) nil/tools/solc/bin/main.go $(ARGS)
+
+help: ## Prints this help message
+	@grep -h -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -88,4 +88,4 @@ solc: ## Run solidity contracts compilation
 	@GOPRIVATE="$(GOPRIVATE)" $(GO) run $(GO_FLAGS) nil/tools/solc/bin/main.go $(ARGS)
 
 help: ## Prints this help message
-	@grep -h -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+	@grep -h -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
This PR add a  new  target `help` and documentation of every targets.

Run `make help` will output all targets documentation, which will help new developers contribute to this project easily.

![image](https://github.com/user-attachments/assets/c263c2b3-4648-4643-a1eb-52b497b7f367)

