### PR TITLE
Add per-shard-pair incremental tx ids.

### DIFF
--- a/nil/internal/config/params.go
+++ b/nil/internal/config/params.go
@@ -241,10 +241,10 @@ func SetParamL1Block(c ConfigAccessor, params *ParamL1BlockInfo) error {
 	return setParamImpl(c, params)
 }
 
-func GetParamNShards(c ConfigAccessor) (uint32, error) {
+func GetParamNShards(c ConfigAccessor) (types.ShardId, error) {
 	param, err := getParamImpl[ParamGasPrice](c)
 	if err != nil {
 		return 0, err
 	}
-	return uint32(len(param.Shards)), nil
+	return types.ShardId(len(param.Shards)), nil
 }

--- a/nil/internal/execution/journal.go
+++ b/nil/internal/execution/journal.go
@@ -296,6 +296,11 @@ func (w *ExecutionStateRevertableWrapper) revertOutTransactionsChange(index int,
 	check.PanicIfNot(index == len(outTransactions)-1)
 
 	w.es.OutTransactions[txnHash] = outTransactions[:index]
+
+	// restore per-shard tx id
+	revertedTx := outTransactions[index]
+	check.PanicIfNot(w.es.ShardTxIds[revertedTx.To.ShardId()] == revertedTx.ShardPairTxId+1)
+	w.es.ShardTxIds[revertedTx.To.ShardId()] = revertedTx.ShardPairTxId
 }
 
 func (w *ExecutionStateRevertableWrapper) revertAsyncContextChange(addr types.Address, requestId types.TransactionIndex) {

--- a/nil/internal/types/transaction.go
+++ b/nil/internal/types/transaction.go
@@ -72,6 +72,23 @@ func (mi *TransactionIndex) SetBytes(b []byte) {
 	*mi = TransactionIndex(ssz.UnmarshallUint64(b))
 }
 
+func (mi *TransactionIndex) MarshalSSZ() ([]byte, error) {
+	return mi.Bytes(), nil
+}
+
+func (mi *TransactionIndex) UnmarshalSSZ(b []byte) error {
+	mi.SetBytes(b)
+	return nil
+}
+
+func (mi TransactionIndex) MarshalSSZTo(dest []byte) ([]byte, error) {
+	return append(dest, mi.Bytes()...), nil
+}
+
+func (mi TransactionIndex) SizeSSZ() int {
+	return 8
+}
+
 func BytesToTransactionIndex(b []byte) TransactionIndex {
 	var mi TransactionIndex
 	mi.SetBytes(b)
@@ -165,6 +182,9 @@ type Transaction struct {
 	BounceTo Address        `json:"bounceTo,omitempty" ch:"bounceTo"`
 	Value    Value          `json:"value,omitempty" ch:"value" ssz-size:"32"`
 	Token    []TokenBalance `json:"token,omitempty" ch:"token" ssz-max:"256"`
+
+	// For each pair of (src, dest) shards, we track the transaction index
+	ShardPairTxId TransactionIndex `json:"shardPairTxId,omitempty" ch:"shard_pair_tx_id"`
 
 	// These fields are needed for async requests
 	RequestId    uint64              `json:"requestId,omitempty" ch:"request_id"`

--- a/nil/internal/vm/precompiled.go
+++ b/nil/internal/vm/precompiled.go
@@ -305,7 +305,7 @@ func (c *sendRawTransaction) Run(state StateDB, input []byte, value *uint256.Int
 		return nil, types.NewVmVerboseError(types.ErrorPrecompileConfigGetParamFailed, err.Error())
 	}
 
-	if uint32(payload.To.ShardId()) >= nShards {
+	if payload.To.ShardId() >= nShards {
 		return nil, ErrShardIdIsTooBig
 	}
 


### PR DESCRIPTION
For each pair of (source, destination) shards, we keep track of the number of internal transactions ever sent from source to destination, and use it to assign incremental tx ids. This allows us to prove that we have processed all the transactions from a specific shard, in order, without missing any.

In this PR, we store outbound transaction counts in the block, as a mapping: `dstShardId ShardId -> txCount TransactionIndex`. We reuse the outbound transaction trie for this purpose, without storing zeroes. The transaction trie now stores two kinds of keys:
* TransactionIndex (uint64) keys for transaction data;
* ShardId (uint16) keys for transaction counts.

We don't store zero values, so the zerostate does not have to be changed in any way.