### PR TITLE
[network] add datastore for DHT

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/ethereum/go-ethereum v1.14.13
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/icza/bitio v1.1.0
+	github.com/ipfs/go-datastore v0.8.2
 	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/klauspost/compress v1.18.0
 	github.com/prometheus/client_golang v1.21.0
@@ -131,7 +132,7 @@ require (
 	github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 // indirect
 	github.com/ipfs/boxo v0.28.0 // indirect
 	github.com/ipfs/go-cid v0.5.0 // indirect
-	github.com/ipfs/go-datastore v0.8.1 // indirect
+	github.com/ipfs/go-detect-race v0.0.1 // indirect
 	github.com/ipfs/go-log v1.0.5 // indirect
 	github.com/ipld/go-ipld-prime v0.21.0 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -287,8 +287,8 @@ github.com/ipfs/go-block-format v0.2.0 h1:ZqrkxBA2ICbDRbK8KJs/u0O3dlp6gmAuuXUJNi
 github.com/ipfs/go-block-format v0.2.0/go.mod h1:+jpL11nFx5A/SPpsoBn6Bzkra/zaArfSmsknbPMYgzM=
 github.com/ipfs/go-cid v0.5.0 h1:goEKKhaGm0ul11IHA7I6p1GmKz8kEYniqFopaB5Otwg=
 github.com/ipfs/go-cid v0.5.0/go.mod h1:0L7vmeNXpQpUS9vt+yEARkJ8rOg43DF3iPgn4GIN0mk=
-github.com/ipfs/go-datastore v0.8.1 h1:p4+tWJuopShJgB3kIK0MMvnH6CFPvi7g/S44f2/EHQA=
-github.com/ipfs/go-datastore v0.8.1/go.mod h1:W+pI1NsUsz3tcsAACMtfC+IZdnQTnC/7VfPoJBQuts0=
+github.com/ipfs/go-datastore v0.8.2 h1:Jy3wjqQR6sg/LhyY0NIePZC3Vux19nLtg7dx0TVqr6U=
+github.com/ipfs/go-datastore v0.8.2/go.mod h1:W+pI1NsUsz3tcsAACMtfC+IZdnQTnC/7VfPoJBQuts0=
 github.com/ipfs/go-detect-race v0.0.1 h1:qX/xay2W3E4Q1U7d9lNs1sU9nvguX0a7319XbyQ6cOk=
 github.com/ipfs/go-detect-race v0.0.1/go.mod h1:8BNT7shDZPo99Q74BpGMK+4D8Mn4j46UU0LZ723meps=
 github.com/ipfs/go-ipfs-util v0.0.3 h1:2RFdGez6bu2ZlZdI+rWfIdbQb1KudQp3VGwPtdNCmE0=

--- a/nil/cmd/relay/main.go
+++ b/nil/cmd/relay/main.go
@@ -64,7 +64,7 @@ func main() {
 	check.PanicIfErr(telemetry.Init(ctx, cfg.Telemetry))
 	defer telemetry.Shutdown(ctx)
 
-	nm, err := network.NewManager(ctx, cfg.Network)
+	nm, err := network.NewManager(ctx, cfg.Network, nil)
 	check.PanicIfErr(err)
 	defer nm.Close()
 

--- a/nil/internal/db/badger.go
+++ b/nil/internal/db/badger.go
@@ -59,8 +59,12 @@ var (
 	_ Iter = new(BadgerIter)
 )
 
+func MakeTablePrefix(table TableName) string {
+	return string(table) + ":"
+}
+
 func MakeKey(table TableName, key []byte) []byte {
-	return append([]byte(table+":"), key...)
+	return append([]byte(MakeTablePrefix(table)), key...)
 }
 
 func NewBadgerDb(pathToDb string) (*badgerDB, error) {

--- a/nil/internal/db/datastore.go
+++ b/nil/internal/db/datastore.go
@@ -1,0 +1,845 @@
+// Adapted version of https://github.com/ipfs/go-ds-badger4
+package db
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"sync"
+	"time"
+
+	badger "github.com/dgraph-io/badger/v4"
+	ds "github.com/ipfs/go-datastore"
+	dsq "github.com/ipfs/go-datastore/query"
+	"github.com/rs/zerolog/log"
+)
+
+var ErrClosed = errors.New("datastore closed")
+
+type Datastore struct {
+	DB *badger.DB
+
+	closeLk   sync.RWMutex
+	closed    bool
+	closeOnce sync.Once
+	closing   chan struct{}
+
+	gcDiscardRatio float64
+
+	syncWrites bool
+	ttl        time.Duration
+}
+
+// Implements the datastore.Batch interface, enabling batching support for
+// the badger Datastore.
+type batch struct {
+	ds         *Datastore
+	writeBatch *badger.WriteBatch
+}
+
+// Implements the datastore.Txn interface, enabling transaction support for
+// the badger Datastore.
+type txn struct {
+	ds  *Datastore
+	txn *badger.Txn
+
+	// Whether this transaction has been implicitly created as a result of a direct Datastore
+	// method invocation.
+	implicit bool
+}
+
+// Options are the badger datastore options, reexported here for convenience.
+type Options struct {
+	// Please refer to the Badger docs to see what this is for
+	GcDiscardRatio float64
+
+	// TTL sets the expiration time for all newly added keys. After expiration,
+	// the keys will no longer be retrievable and will be removed by garbage
+	// collection.
+	//
+	// The default value is 0, which means no TTL.
+	TTL time.Duration
+}
+
+// DefaultOptions are the default options for the badger datastore.
+var DefaultOptions Options
+
+// WithGcDiscardRatio returns a new Options value with GcDiscardRatio set to the given value.
+//
+// # Please refer to the Badger docs to see what this is for
+//
+// Default value is 0.2
+func (opt Options) WithGcDiscardRatio(ratio float64) Options {
+	opt.GcDiscardRatio = ratio
+	return opt
+}
+
+// WithTTL returns a new Options value with TTL set to the given value.
+//
+// TTL sets the expiration time for all newly added keys. After expiration,
+// the keys will no longer be retrievable and will be removed by garbage
+// collection.
+//
+// Default value is 0, which means no TTL.
+func (opt Options) WithTTL(ttl time.Duration) Options {
+	opt.TTL = ttl
+	return opt
+}
+
+func init() {
+	DefaultOptions = Options{
+		GcDiscardRatio: 0.2,
+	}
+}
+
+var (
+	_ ds.Datastore           = (*Datastore)(nil)
+	_ ds.PersistentDatastore = (*Datastore)(nil)
+	_ ds.TxnDatastore        = (*Datastore)(nil)
+	_ ds.Txn                 = (*txn)(nil)
+	_ ds.TTLDatastore        = (*Datastore)(nil)
+	_ ds.GCDatastore         = (*Datastore)(nil)
+	_ ds.Batching            = (*Datastore)(nil)
+)
+
+// NewDatastore creates a new badger datastore.
+func NewDatastore(kv *badger.DB, options *Options) (*Datastore, error) {
+	if options == nil {
+		options = &DefaultOptions
+	}
+
+	return &Datastore{
+		DB:             kv,
+		closing:        make(chan struct{}),
+		gcDiscardRatio: options.GcDiscardRatio,
+		syncWrites:     kv.Opts().SyncWrites,
+		ttl:            options.TTL,
+	}, nil
+}
+
+// NewTransaction starts a new transaction. The resulting transaction object
+// can be mutated without incurring changes to the underlying Datastore until
+// the transaction is Committed.
+func (d *Datastore) NewTransaction(ctx context.Context, readOnly bool) (ds.Txn, error) {
+	d.closeLk.RLock()
+	defer d.closeLk.RUnlock()
+	if d.closed {
+		return nil, ErrClosed
+	}
+
+	return &txn{d, d.DB.NewTransaction(!readOnly), false}, nil
+}
+
+// newImplicitTransaction creates a transaction marked as 'implicit'.
+// Implicit transactions are created by Datastore methods performing single operations.
+func (d *Datastore) newImplicitTransaction(readOnly bool) *txn {
+	return &txn{d, d.DB.NewTransaction(!readOnly), true}
+}
+
+func (d *Datastore) Put(ctx context.Context, key ds.Key, value []byte) error {
+	d.closeLk.RLock()
+	defer d.closeLk.RUnlock()
+	if d.closed {
+		return ErrClosed
+	}
+
+	txn := d.newImplicitTransaction(false)
+	defer txn.discard()
+
+	if d.ttl > 0 {
+		if err := txn.putWithTTL(key, value, d.ttl); err != nil {
+			return err
+		}
+	} else {
+		if err := txn.put(key, value); err != nil {
+			return err
+		}
+	}
+
+	return txn.commit()
+}
+
+func (d *Datastore) Sync(ctx context.Context, prefix ds.Key) error {
+	d.closeLk.RLock()
+	defer d.closeLk.RUnlock()
+	if d.closed {
+		return ErrClosed
+	}
+
+	if d.syncWrites {
+		return nil
+	}
+
+	return d.DB.Sync()
+}
+
+func (d *Datastore) PutWithTTL(ctx context.Context, key ds.Key, value []byte, ttl time.Duration) error {
+	d.closeLk.RLock()
+	defer d.closeLk.RUnlock()
+	if d.closed {
+		return ErrClosed
+	}
+
+	txn := d.newImplicitTransaction(false)
+	defer txn.discard()
+
+	if err := txn.putWithTTL(key, value, ttl); err != nil {
+		return err
+	}
+
+	return txn.commit()
+}
+
+func (d *Datastore) SetTTL(ctx context.Context, key ds.Key, ttl time.Duration) error {
+	d.closeLk.RLock()
+	defer d.closeLk.RUnlock()
+	if d.closed {
+		return ErrClosed
+	}
+
+	txn := d.newImplicitTransaction(false)
+	defer txn.discard()
+
+	if err := txn.setTTL(key, ttl); err != nil {
+		return err
+	}
+
+	return txn.commit()
+}
+
+func (d *Datastore) GetExpiration(ctx context.Context, key ds.Key) (time.Time, error) {
+	d.closeLk.RLock()
+	defer d.closeLk.RUnlock()
+	if d.closed {
+		return time.Time{}, ErrClosed
+	}
+
+	txn := d.newImplicitTransaction(false)
+	defer txn.discard()
+
+	return txn.getExpiration(key)
+}
+
+func (d *Datastore) Get(ctx context.Context, key ds.Key) (value []byte, err error) {
+	d.closeLk.RLock()
+	defer d.closeLk.RUnlock()
+	if d.closed {
+		return nil, ErrClosed
+	}
+
+	txn := d.newImplicitTransaction(true)
+	defer txn.discard()
+
+	return txn.get(key)
+}
+
+func (d *Datastore) Has(ctx context.Context, key ds.Key) (bool, error) {
+	d.closeLk.RLock()
+	defer d.closeLk.RUnlock()
+	if d.closed {
+		return false, ErrClosed
+	}
+
+	txn := d.newImplicitTransaction(true)
+	defer txn.discard()
+
+	return txn.has(key)
+}
+
+func (d *Datastore) GetSize(ctx context.Context, key ds.Key) (size int, err error) {
+	d.closeLk.RLock()
+	defer d.closeLk.RUnlock()
+	if d.closed {
+		return -1, ErrClosed
+	}
+
+	txn := d.newImplicitTransaction(true)
+	defer txn.discard()
+
+	return txn.getSize(key)
+}
+
+func (d *Datastore) Delete(ctx context.Context, key ds.Key) error {
+	d.closeLk.RLock()
+	defer d.closeLk.RUnlock()
+
+	txn := d.newImplicitTransaction(false)
+	defer txn.discard()
+
+	err := txn.delete(key)
+	if err != nil {
+		return err
+	}
+
+	return txn.commit()
+}
+
+func (d *Datastore) Query(ctx context.Context, q dsq.Query) (dsq.Results, error) {
+	d.closeLk.RLock()
+	defer d.closeLk.RUnlock()
+	if d.closed {
+		return nil, ErrClosed
+	}
+
+	txn := d.newImplicitTransaction(true)
+	// We cannot defer txn.Discard() here, as the txn must remain active while the iterator is open.
+	// https://github.com/dgraph-io/badger/commit/b1ad1e93e483bbfef123793ceedc9a7e34b09f79
+	// The closing logic in the query function takes care of discarding the implicit transaction.
+	return txn.query(q)
+}
+
+// DiskUsage implements the PersistentDatastore interface.
+// It returns the sum of lsm and value log files sizes in bytes.
+func (d *Datastore) DiskUsage(ctx context.Context) (uint64, error) {
+	d.closeLk.RLock()
+	defer d.closeLk.RUnlock()
+	if d.closed {
+		return 0, ErrClosed
+	}
+	lsm, vlog := d.DB.Size()
+
+	// Print disk layout information on debug
+	log.Debug().Msgf("\n\nDisk usage stats\nLSM: %d, ValueLog: %d\n", lsm, vlog)
+	log.Debug().Msgf("\n%s\n\n", d.DB.LevelsToString())
+
+	return uint64(lsm + vlog), nil
+}
+
+func (d *Datastore) Close() error {
+	d.closeOnce.Do(func() {
+		close(d.closing)
+	})
+	d.closeLk.Lock()
+	defer d.closeLk.Unlock()
+	if d.closed {
+		return ErrClosed
+	}
+	d.closed = true
+	return d.DB.Close()
+}
+
+// Batch creates a new Batch object. This provides a way to do many writes, when
+// there may be too many to fit into a single transaction.
+func (d *Datastore) Batch(ctx context.Context) (ds.Batch, error) {
+	d.closeLk.RLock()
+	defer d.closeLk.RUnlock()
+	if d.closed {
+		return nil, ErrClosed
+	}
+
+	b := &batch{d, d.DB.NewWriteBatch()}
+	// Ensure that incomplete transaction resources are cleaned up in case
+	// batch is abandoned.
+	runtime.SetFinalizer(b, func(b *batch) {
+		b.cancel()
+		log.Error().Msg("batch not committed or canceled")
+	})
+
+	return b, nil
+}
+
+func (d *Datastore) CollectGarbage(ctx context.Context) (err error) {
+	// The idea is to keep calling DB.RunValueLogGC() till Badger no longer has any log files
+	// to GC(which would be indicated by an error, please refer to Badger GC docs).
+	for err == nil {
+		err = d.gcOnce()
+	}
+
+	if errors.Is(err, badger.ErrNoRewrite) {
+		err = nil
+	}
+
+	return err
+}
+
+func (d *Datastore) gcOnce() error {
+	d.closeLk.RLock()
+	defer d.closeLk.RUnlock()
+	if d.closed {
+		return ErrClosed
+	}
+	return d.DB.RunValueLogGC(d.gcDiscardRatio)
+}
+
+var _ ds.Batch = (*batch)(nil)
+
+func (b *batch) Put(ctx context.Context, key ds.Key, value []byte) error {
+	b.ds.closeLk.RLock()
+	defer b.ds.closeLk.RUnlock()
+	if b.ds.closed {
+		return ErrClosed
+	}
+
+	if b.ds.ttl > 0 {
+		return b.putWithTTL(key, value, b.ds.ttl)
+	}
+
+	return b.put(key, value)
+}
+
+func (b *batch) put(key ds.Key, value []byte) error {
+	return b.writeBatch.Set(key.Bytes(), value)
+}
+
+func (b *batch) putWithTTL(key ds.Key, value []byte, ttl time.Duration) error {
+	return b.writeBatch.SetEntry(badger.NewEntry(key.Bytes(), value).WithTTL(ttl))
+}
+
+func (b *batch) Delete(ctx context.Context, key ds.Key) error {
+	b.ds.closeLk.RLock()
+	defer b.ds.closeLk.RUnlock()
+	if b.ds.closed {
+		return ErrClosed
+	}
+
+	return b.delete(key)
+}
+
+func (b *batch) delete(key ds.Key) error {
+	return b.writeBatch.Delete(key.Bytes())
+}
+
+func (b *batch) Commit(ctx context.Context) error {
+	b.ds.closeLk.RLock()
+	defer b.ds.closeLk.RUnlock()
+	if b.ds.closed {
+		return ErrClosed
+	}
+
+	return b.commit()
+}
+
+func (b *batch) commit() error {
+	err := b.writeBatch.Flush()
+	if err != nil {
+		// Discard incomplete transaction held by b.writeBatch
+		b.cancel()
+		return err
+	}
+	runtime.SetFinalizer(b, nil)
+	return nil
+}
+
+func (b *batch) Cancel() error {
+	b.ds.closeLk.RLock()
+	defer b.ds.closeLk.RUnlock()
+	if b.ds.closed {
+		return ErrClosed
+	}
+
+	b.cancel()
+	return nil
+}
+
+func (b *batch) cancel() {
+	b.writeBatch.Cancel()
+	runtime.SetFinalizer(b, nil)
+}
+
+var (
+	_ ds.Datastore    = (*txn)(nil)
+	_ ds.TTLDatastore = (*txn)(nil)
+)
+
+func (t *txn) Put(ctx context.Context, key ds.Key, value []byte) error {
+	t.ds.closeLk.RLock()
+	defer t.ds.closeLk.RUnlock()
+	if t.ds.closed {
+		return ErrClosed
+	}
+
+	if t.ds.ttl > 0 {
+		return t.putWithTTL(key, value, t.ds.ttl)
+	}
+
+	return t.put(key, value)
+}
+
+func (t *txn) put(key ds.Key, value []byte) error {
+	return t.txn.Set(key.Bytes(), value)
+}
+
+func (t *txn) Sync(ctx context.Context, prefix ds.Key) error {
+	t.ds.closeLk.RLock()
+	defer t.ds.closeLk.RUnlock()
+	if t.ds.closed {
+		return ErrClosed
+	}
+
+	return nil
+}
+
+func (t *txn) PutWithTTL(ctx context.Context, key ds.Key, value []byte, ttl time.Duration) error {
+	t.ds.closeLk.RLock()
+	defer t.ds.closeLk.RUnlock()
+	if t.ds.closed {
+		return ErrClosed
+	}
+	return t.putWithTTL(key, value, ttl)
+}
+
+func (t *txn) putWithTTL(key ds.Key, value []byte, ttl time.Duration) error {
+	return t.txn.SetEntry(badger.NewEntry(key.Bytes(), value).WithTTL(ttl))
+}
+
+func (t *txn) GetExpiration(ctx context.Context, key ds.Key) (time.Time, error) {
+	t.ds.closeLk.RLock()
+	defer t.ds.closeLk.RUnlock()
+	if t.ds.closed {
+		return time.Time{}, ErrClosed
+	}
+
+	return t.getExpiration(key)
+}
+
+func (t *txn) getExpiration(key ds.Key) (time.Time, error) {
+	item, err := t.txn.Get(key.Bytes())
+	if errors.Is(err, badger.ErrKeyNotFound) {
+		return time.Time{}, ds.ErrNotFound
+	} else if err != nil {
+		return time.Time{}, err
+	}
+	return time.Unix(int64(item.ExpiresAt()), 0), nil
+}
+
+func (t *txn) SetTTL(ctx context.Context, key ds.Key, ttl time.Duration) error {
+	t.ds.closeLk.RLock()
+	defer t.ds.closeLk.RUnlock()
+	if t.ds.closed {
+		return ErrClosed
+	}
+
+	return t.setTTL(key, ttl)
+}
+
+func (t *txn) setTTL(key ds.Key, ttl time.Duration) error {
+	item, err := t.txn.Get(key.Bytes())
+	if err != nil {
+		return err
+	}
+	return item.Value(func(data []byte) error {
+		return t.putWithTTL(key, data, ttl)
+	})
+}
+
+func (t *txn) Get(ctx context.Context, key ds.Key) ([]byte, error) {
+	t.ds.closeLk.RLock()
+	defer t.ds.closeLk.RUnlock()
+	if t.ds.closed {
+		return nil, ErrClosed
+	}
+
+	return t.get(key)
+}
+
+func (t *txn) get(key ds.Key) ([]byte, error) {
+	item, err := t.txn.Get(key.Bytes())
+	if errors.Is(err, badger.ErrKeyNotFound) {
+		err = ds.ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return item.ValueCopy(nil)
+}
+
+func (t *txn) Has(ctx context.Context, key ds.Key) (bool, error) {
+	t.ds.closeLk.RLock()
+	defer t.ds.closeLk.RUnlock()
+	if t.ds.closed {
+		return false, ErrClosed
+	}
+
+	return t.has(key)
+}
+
+func (t *txn) has(key ds.Key) (bool, error) {
+	_, err := t.txn.Get(key.Bytes())
+	switch {
+	case errors.Is(err, badger.ErrKeyNotFound):
+		return false, nil
+	case err == nil:
+		return true, nil
+	default:
+		return false, err
+	}
+}
+
+func (t *txn) GetSize(ctx context.Context, key ds.Key) (int, error) {
+	t.ds.closeLk.RLock()
+	defer t.ds.closeLk.RUnlock()
+	if t.ds.closed {
+		return -1, ErrClosed
+	}
+
+	return t.getSize(key)
+}
+
+func (t *txn) getSize(key ds.Key) (int, error) {
+	item, err := t.txn.Get(key.Bytes())
+	switch {
+	case err == nil:
+		return int(item.ValueSize()), nil
+	case errors.Is(err, badger.ErrKeyNotFound):
+		return -1, ds.ErrNotFound
+	default:
+		return -1, err
+	}
+}
+
+func (t *txn) Delete(ctx context.Context, key ds.Key) error {
+	t.ds.closeLk.RLock()
+	defer t.ds.closeLk.RUnlock()
+	if t.ds.closed {
+		return ErrClosed
+	}
+
+	return t.delete(key)
+}
+
+func (t *txn) delete(key ds.Key) error {
+	return t.txn.Delete(key.Bytes())
+}
+
+func (t *txn) Query(ctx context.Context, q dsq.Query) (dsq.Results, error) {
+	t.ds.closeLk.RLock()
+	defer t.ds.closeLk.RUnlock()
+	if t.ds.closed {
+		return nil, ErrClosed
+	}
+
+	return t.query(q)
+}
+
+func (t *txn) query(q dsq.Query) (dsq.Results, error) {
+	opt := badger.DefaultIteratorOptions
+	opt.PrefetchValues = !q.KeysOnly
+
+	prefix := ds.NewKey(q.Prefix).String()
+	if prefix != "/" {
+		opt.Prefix = []byte(prefix + "/")
+	}
+
+	// Handle ordering
+	if len(q.Orders) > 0 {
+		switch q.Orders[0].(type) {
+		case dsq.OrderByKey, *dsq.OrderByKey:
+		// We order by key by default.
+		case dsq.OrderByKeyDescending, *dsq.OrderByKeyDescending:
+			// Reverse order by key
+			opt.Reverse = true
+		default:
+			// Ok, we have a weird order we can't handle. Let's
+			// perform the _base_ query (prefix, filter, etc.), then
+			// handle sort/offset/limit later.
+
+			// Skip the stuff we can't apply.
+			baseQuery := q
+			baseQuery.Limit = 0
+			baseQuery.Offset = 0
+			baseQuery.Orders = nil
+
+			// perform the base query.
+			res, err := t.query(baseQuery)
+			if err != nil {
+				return nil, err
+			}
+
+			// fix the query
+			res = dsq.ResultsReplaceQuery(res, q)
+
+			// Remove the parts we've already applied.
+			naiveQuery := q
+			naiveQuery.Prefix = ""
+			naiveQuery.Filters = nil
+
+			// Apply the rest of the query
+			return dsq.NaiveQueryApply(naiveQuery, res), nil
+		}
+	}
+
+	it := t.txn.NewIterator(opt)
+	results := dsq.ResultsWithContext(q, func(ctx context.Context, output chan<- dsq.Result) {
+		t.ds.closeLk.RLock()
+		closedEarly := false
+		defer func() {
+			t.ds.closeLk.RUnlock()
+			if closedEarly {
+				select {
+				case output <- dsq.Result{
+					Error: ErrClosed,
+				}:
+				case <-ctx.Done():
+				}
+			}
+		}()
+		if t.ds.closed {
+			closedEarly = true
+			return
+		}
+
+		// this iterator is part of an implicit transaction, so when
+		// we're done we must discard the transaction. It's safe to
+		// discard the txn it because it contains the iterator only.
+		if t.implicit {
+			defer t.discard()
+		}
+
+		defer it.Close()
+
+		// All iterators must be started by rewinding.
+		it.Rewind()
+
+		// skip to the offset
+		for skipped := 0; skipped < q.Offset && it.Valid(); it.Next() {
+			// On the happy path, we have no filters and we can go
+			// on our way.
+			if len(q.Filters) == 0 {
+				skipped++
+				continue
+			}
+
+			// On the sad path, we need to apply filters before
+			// counting the item as "skipped" as the offset comes
+			// _after_ the filter.
+			item := it.Item()
+
+			matches := true
+			check := func(value []byte) error {
+				e := dsq.Entry{
+					Key:   string(item.Key()),
+					Value: value,
+					Size:  int(item.ValueSize()), // this function is basically free
+				}
+
+				// Only calculate expirations if we need them.
+				if q.ReturnExpirations {
+					e.Expiration = expires(item)
+				}
+				matches = filter(q.Filters, e)
+				return nil
+			}
+
+			// Maybe check with the value, only if we need it.
+			var err error
+			if q.KeysOnly {
+				err = check(nil)
+			} else {
+				err = item.Value(check)
+			}
+
+			if err != nil {
+				select {
+				case output <- dsq.Result{Error: err}:
+				case <-t.ds.closing: // datastore closing.
+					closedEarly = true
+					return
+				case <-ctx.Done(): // client told us to close early
+					return
+				}
+			}
+			if !matches {
+				skipped++
+			}
+		}
+
+		for sent := 0; (q.Limit <= 0 || sent < q.Limit) && it.Valid(); it.Next() {
+			item := it.Item()
+			e := dsq.Entry{Key: string(item.Key())}
+
+			// Maybe get the value
+			var result dsq.Result
+			if !q.KeysOnly {
+				b, err := item.ValueCopy(nil)
+				if err != nil {
+					result = dsq.Result{Error: err}
+				} else {
+					e.Value = b
+					e.Size = len(b)
+					result = dsq.Result{Entry: e}
+				}
+			} else {
+				e.Size = int(item.ValueSize())
+				result = dsq.Result{Entry: e}
+			}
+
+			if q.ReturnExpirations {
+				result.Expiration = expires(item)
+			}
+
+			// Finally, filter it (unless we're dealing with an error).
+			if result.Error == nil && filter(q.Filters, e) {
+				continue
+			}
+
+			select {
+			case output <- result:
+				sent++
+			case <-t.ds.closing: // datastore closing.
+				closedEarly = true
+				return
+			case <-ctx.Done(): // client told us to close early
+				return
+			}
+		}
+	})
+
+	return results, nil
+}
+
+func (t *txn) Commit(ctx context.Context) error {
+	t.ds.closeLk.RLock()
+	defer t.ds.closeLk.RUnlock()
+	if t.ds.closed {
+		return ErrClosed
+	}
+
+	return t.commit()
+}
+
+func (t *txn) commit() error {
+	return t.txn.Commit()
+}
+
+// Alias to commit
+func (t *txn) Close() error {
+	t.ds.closeLk.RLock()
+	defer t.ds.closeLk.RUnlock()
+	if t.ds.closed {
+		return ErrClosed
+	}
+	return t.close()
+}
+
+func (t *txn) close() error {
+	return t.txn.Commit()
+}
+
+func (t *txn) Discard(ctx context.Context) {
+	t.ds.closeLk.RLock()
+	defer t.ds.closeLk.RUnlock()
+	if t.ds.closed {
+		return
+	}
+
+	t.discard()
+}
+
+func (t *txn) discard() {
+	t.txn.Discard()
+}
+
+// filter returns _true_ if we should filter (skip) the entry
+func filter(filters []dsq.Filter, entry dsq.Entry) bool {
+	for _, f := range filters {
+		if !f.Filter(entry) {
+			return true
+		}
+	}
+	return false
+}
+
+func expires(item *badger.Item) time.Time {
+	return time.Unix(int64(item.ExpiresAt()), 0)
+}

--- a/nil/internal/db/datastore_test.go
+++ b/nil/internal/db/datastore_test.go
@@ -53,9 +53,7 @@ func newDS(t *testing.T, opts *Options) (*Datastore, func()) {
 	db, err := badger.Open(bOpts)
 	require.NoError(t, err)
 
-	d, err := NewDatastore(db, opts)
-	require.NoError(t, err)
-
+	d := NewDatastore(db, TableName(t.Name()), opts)
 	return d, func() {
 		d.Close()
 		os.RemoveAll(path)
@@ -371,9 +369,7 @@ func TestBatchingRequired(t *testing.T) {
 	db, err := badger.Open(bOpts)
 	require.NoError(t, err)
 
-	d, err := NewDatastore(db, nil)
-	require.NoError(t, err)
-
+	d := NewDatastore(db, TableName(t.Name()), nil)
 	defer func() {
 		d.Close()
 		os.RemoveAll(path)
@@ -621,8 +617,7 @@ func TestDiskUsage(t *testing.T) {
 	db, err := badger.Open(opts)
 	require.NoError(t, err)
 
-	d, err := NewDatastore(db, nil)
-	require.NoError(t, err)
+	d := NewDatastore(db, TableName(t.Name()), nil)
 
 	addTestCases(t, d, testcases)
 	d.Close()
@@ -630,8 +625,7 @@ func TestDiskUsage(t *testing.T) {
 	db, err = badger.Open(opts)
 	require.NoError(t, err)
 
-	d, err = NewDatastore(db, nil)
-	require.NoError(t, err)
+	d = NewDatastore(db, TableName(t.Name()), nil)
 
 	s, _ := d.DiskUsage(t.Context())
 	if s == 0 {
@@ -654,10 +648,7 @@ func TestTxnDiscard(t *testing.T) {
 	db, err := badger.Open(opts)
 	require.NoError(t, err)
 
-	d, err := NewDatastore(db, nil)
-	defer os.RemoveAll(path)
-	require.NoError(t, err)
-
+	d := NewDatastore(db, TableName(t.Name()), nil)
 	txn, err := d.NewTransaction(t.Context(), false)
 	require.NoError(t, err)
 	key := ds.NewKey("/test/thing")
@@ -688,8 +679,7 @@ func TestTxnCommit(t *testing.T) {
 	db, err := badger.Open(opts)
 	require.NoError(t, err)
 
-	d, err := NewDatastore(db, nil)
-	require.NoError(t, err)
+	d := NewDatastore(db, TableName(t.Name()), nil)
 
 	txn, err := d.NewTransaction(t.Context(), false)
 	require.NoError(t, err)
@@ -723,8 +713,7 @@ func TestTxnBatch(t *testing.T) {
 	db, err := badger.Open(opts)
 	require.NoError(t, err)
 
-	d, err := NewDatastore(db, nil)
-	require.NoError(t, err)
+	d := NewDatastore(db, TableName(t.Name()), nil)
 
 	txn, err := d.NewTransaction(t.Context(), false)
 	require.NoError(t, err)
@@ -778,8 +767,7 @@ func TestTTL(t *testing.T) {
 	db, err := badger.Open(opts)
 	require.NoError(t, err)
 
-	d, err := NewDatastore(db, nil)
-	require.NoError(t, err)
+	d := NewDatastore(db, TableName(t.Name()), nil)
 
 	txn, err := d.NewTransaction(t.Context(), false)
 	require.NoError(t, err)
@@ -925,9 +913,7 @@ func TestOptions(t *testing.T) {
 	db, err := badger.Open(bOpts)
 	require.NoError(t, err)
 
-	d, err := NewDatastore(db, &opts)
-	require.NoError(t, err)
-
+	d := NewDatastore(db, TableName(t.Name()), &opts)
 	if d.ttl != time.Minute {
 		t.Fatal("datastore ttl not set")
 	}
@@ -959,9 +945,7 @@ func TestClosedError(t *testing.T) {
 	db, err := badger.Open(bOpts)
 	require.NoError(t, err)
 
-	d, err := NewDatastore(db, &opts)
-	require.NoError(t, err)
-
+	d := NewDatastore(db, TableName(t.Name()), &opts)
 	dstx, err := d.NewTransaction(t.Context(), false)
 	require.NoError(t, err)
 

--- a/nil/internal/db/datastore_test.go
+++ b/nil/internal/db/datastore_test.go
@@ -1,0 +1,1102 @@
+package db
+
+import (
+	"bytes"
+	"crypto/rand"
+	"fmt"
+	"os"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/NilFoundation/nil/nil/tests/detectrace"
+	"github.com/dgraph-io/badger/v4"
+	ds "github.com/ipfs/go-datastore"
+	dsq "github.com/ipfs/go-datastore/query"
+	dstest "github.com/ipfs/go-datastore/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var testcases = map[string]string{
+	"/a":     "a",
+	"/a/b":   "ab",
+	"/a/b/c": "abc",
+	"/a/b/d": "a/b/d",
+	"/a/c":   "ac",
+	"/a/d":   "ad",
+	"/e":     "e",
+	"/f":     "f",
+	"/g":     "",
+}
+
+// returns datastore, and a function to call on exit.
+// (this garbage collects). So:
+//
+//	d, close := newDS(t, nil)
+//	defer close()
+func newDS(t *testing.T, opts *Options) (*Datastore, func()) {
+	t.Helper()
+
+	path := t.TempDir()
+
+	if opts == nil {
+		opts = &DefaultOptions
+	}
+
+	bOpts := badger.DefaultOptions(path)
+	// Limit memory usage for tests, mostly because they fail on 32-bit systems.
+	bOpts.ValueLogFileSize = 104857600 // 100 MiB as we have problems running tests on 32bit
+	bOpts.MemTableSize = 41943040      // 40 MiB
+	bOpts.NumMemtables = 1
+
+	db, err := badger.Open(bOpts)
+	require.NoError(t, err)
+
+	d, err := NewDatastore(db, opts)
+	require.NoError(t, err)
+
+	return d, func() {
+		d.Close()
+		os.RemoveAll(path)
+	}
+}
+
+func addTestCases(t *testing.T, d *Datastore, testcases map[string]string) {
+	t.Helper()
+
+	for k, v := range testcases {
+		dsk := ds.NewKey(k)
+		if err := d.Put(t.Context(), dsk, []byte(v)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for k, v := range testcases {
+		dsk := ds.NewKey(k)
+		v2, err := d.Get(t.Context(), dsk)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(v2) != v {
+			t.Errorf("%s values differ: %s != %s", k, v, v2)
+		}
+	}
+}
+
+func TestQuery(t *testing.T) {
+	t.Parallel()
+
+	d, done := newDS(t, nil)
+	defer done()
+
+	addTestCases(t, d, testcases)
+
+	rs, err := d.Query(t.Context(), dsq.Query{Prefix: "/a/"})
+	require.NoError(t, err)
+
+	expectMatches(t, []string{
+		"/a/b",
+		"/a/b/c",
+		"/a/b/d",
+		"/a/c",
+		"/a/d",
+	}, rs)
+
+	// test offset and limit
+
+	rs, err = d.Query(t.Context(), dsq.Query{Prefix: "/a/", Offset: 2, Limit: 2})
+	require.NoError(t, err)
+
+	expectMatches(t, []string{
+		"/a/b/d",
+		"/a/c",
+	}, rs)
+}
+
+func TestHas(t *testing.T) {
+	t.Parallel()
+
+	d, done := newDS(t, nil)
+	defer done()
+	addTestCases(t, d, testcases)
+
+	has, err := d.Has(t.Context(), ds.NewKey("/a/b/c"))
+	require.NoError(t, err)
+
+	if !has {
+		t.Error("Key should be found")
+	}
+
+	has, err = d.Has(t.Context(), ds.NewKey("/a/b/c/d"))
+	require.NoError(t, err)
+
+	if has {
+		t.Error("Key should not be found")
+	}
+}
+
+func TestGetSize(t *testing.T) {
+	t.Parallel()
+
+	d, done := newDS(t, nil)
+	defer done()
+	addTestCases(t, d, testcases)
+
+	size, err := d.GetSize(t.Context(), ds.NewKey("/a/b/c"))
+	if err != nil {
+		t.Error(err)
+	}
+
+	if size != len(testcases["/a/b/c"]) {
+		t.Error("")
+	}
+
+	_, err = d.GetSize(t.Context(), ds.NewKey("/a/b/c/d"))
+	require.ErrorIs(t, err, ds.ErrNotFound)
+}
+
+func TestNotExistGet(t *testing.T) {
+	t.Parallel()
+
+	d, done := newDS(t, nil)
+	defer done()
+	addTestCases(t, d, testcases)
+
+	has, err := d.Has(t.Context(), ds.NewKey("/a/b/c/d"))
+	if err != nil {
+		t.Error(err)
+	}
+
+	if has {
+		t.Error("Key should not be found")
+	}
+
+	val, err := d.Get(t.Context(), ds.NewKey("/a/b/c/d"))
+	if val != nil {
+		t.Error("Key should not be found")
+	}
+	require.ErrorIs(t, err, ds.ErrNotFound)
+}
+
+func TestDelete(t *testing.T) {
+	t.Parallel()
+
+	d, done := newDS(t, nil)
+	defer done()
+	addTestCases(t, d, testcases)
+
+	has, err := d.Has(t.Context(), ds.NewKey("/a/b/c"))
+	if err != nil {
+		t.Error(err)
+	}
+	if !has {
+		t.Error("Key should be found")
+	}
+
+	err = d.Delete(t.Context(), ds.NewKey("/a/b/c"))
+	if err != nil {
+		t.Error(err)
+	}
+
+	has, err = d.Has(t.Context(), ds.NewKey("/a/b/c"))
+	require.NoError(t, err)
+	if has {
+		t.Error("Key should not be found")
+	}
+}
+
+func TestGetEmpty(t *testing.T) {
+	t.Parallel()
+
+	d, done := newDS(t, nil)
+	defer done()
+
+	err := d.Put(t.Context(), ds.NewKey("/a"), []byte{})
+	require.NoError(t, err)
+
+	v, err := d.Get(t.Context(), ds.NewKey("/a"))
+	require.NoError(t, err)
+
+	if len(v) != 0 {
+		t.Error("expected 0 len []byte form get")
+	}
+}
+
+func expectMatches(t *testing.T, expect []string, actualR dsq.Results) {
+	t.Helper()
+
+	actual, err := actualR.Rest()
+	require.NoError(t, err)
+
+	if len(actual) != len(expect) {
+		t.Error("not enough", expect, actual)
+	}
+	for _, k := range expect {
+		found := false
+		for _, e := range actual {
+			if e.Key == k {
+				found = true
+			}
+		}
+		if !found {
+			t.Error(k, "not found")
+		}
+	}
+}
+
+func TestBatching(t *testing.T) {
+	t.Parallel()
+
+	d, done := newDS(t, nil)
+	defer done()
+
+	b, err := d.Batch(t.Context())
+	require.NoError(t, err)
+
+	for k, v := range testcases {
+		err := b.Put(t.Context(), ds.NewKey(k), []byte(v))
+		require.NoError(t, err)
+	}
+
+	err = b.Commit(t.Context())
+	require.NoError(t, err)
+
+	for k, v := range testcases {
+		val, err := d.Get(t.Context(), ds.NewKey(k))
+		require.NoError(t, err)
+
+		if v != string(val) {
+			t.Fatal("got wrong data!")
+		}
+	}
+
+	// Test delete
+
+	b, err = d.Batch(t.Context())
+	require.NoError(t, err)
+
+	err = b.Delete(t.Context(), ds.NewKey("/a/b"))
+	require.NoError(t, err)
+
+	err = b.Delete(t.Context(), ds.NewKey("/a/b/c"))
+	require.NoError(t, err)
+
+	err = b.Commit(t.Context())
+	require.NoError(t, err)
+
+	rs, err := d.Query(t.Context(), dsq.Query{Prefix: "/"})
+	require.NoError(t, err)
+
+	expectMatches(t, []string{
+		"/a",
+		"/a/b/d",
+		"/a/c",
+		"/a/d",
+		"/e",
+		"/f",
+		"/g",
+	}, rs)
+
+	// Test cancel
+
+	b, err = d.Batch(t.Context())
+	require.NoError(t, err)
+
+	const key = "/xyz"
+
+	err = b.Put(t.Context(), ds.NewKey(key), []byte("/x/y/z"))
+	require.NoError(t, err)
+
+	// TODO: remove type assertion once datastore.Batch interface has Cancel
+	batch, ok := b.(*batch)
+	require.True(t, ok)
+	err = batch.Cancel()
+	require.NoError(t, err)
+
+	_, err = d.Get(t.Context(), ds.NewKey(key))
+	require.Error(t, err)
+
+	// Test with TTL
+
+	opts := DefaultOptions.WithTTL(time.Second)
+	d, done = newDS(t, &opts)
+	defer done()
+
+	b, err = d.Batch(t.Context())
+	require.NoError(t, err)
+
+	for k, v := range testcases {
+		err := b.Put(t.Context(), ds.NewKey(k), []byte(v))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	err = b.Commit(t.Context())
+	require.NoError(t, err)
+
+	// check data was set correctly
+	for k, v := range testcases {
+		val, err := d.Get(t.Context(), ds.NewKey(k))
+		require.NoError(t, err)
+
+		if v != string(val) {
+			t.Fatal("got wrong data!")
+		}
+	}
+
+	time.Sleep(time.Second)
+
+	// check data has expired
+	for k := range testcases {
+		has, err := d.Has(t.Context(), ds.NewKey(k))
+		require.NoError(t, err)
+		if has {
+			t.Fatal("record with ttl did not expire")
+		}
+	}
+}
+
+func TestBatchingRequired(t *testing.T) {
+	t.Parallel()
+
+	path := t.TempDir()
+
+	bOpts := badger.DefaultOptions(path)
+	bOpts.ValueLogFileSize = 104857600 // 100 MiB as we have problems running tests on 32bit
+	bOpts.MemTableSize = 41943040      // 40 MiB
+	bOpts.NumMemtables = 1
+
+	db, err := badger.Open(bOpts)
+	require.NoError(t, err)
+
+	d, err := NewDatastore(db, nil)
+	require.NoError(t, err)
+
+	defer func() {
+		d.Close()
+		os.RemoveAll(path)
+	}()
+
+	const valSize = 1000
+
+	// Check that transaction fails when there are too many writes. This is
+	// not testing batching logic, but is here to prove that batching works
+	// where a transaction fails.
+	t.Logf("putting %d byte values until transaction overflows", valSize)
+	tx, err := d.NewTransaction(t.Context(), false)
+	require.NoError(t, err)
+
+	var puts int
+	for ; puts < 10000000; puts++ {
+		buf := make([]byte, valSize)
+		_, randErr := rand.Read(buf)
+		require.NoError(t, randErr)
+		err = tx.Put(t.Context(), ds.NewKey(fmt.Sprintf("/key%d", puts)), buf)
+		if err != nil {
+			break
+		}
+		puts++
+	}
+	require.Errorf(t, err, "transaction cannot handle %d puts", puts)
+	tx.Discard(t.Context())
+
+	// Check that batch succeeds with the same number of writes that caused a
+	// transaction to fail.
+	t.Logf("putting %d %d byte values using batch", puts, valSize)
+	b, err := d.Batch(t.Context())
+	require.NoError(t, err)
+	for i := range puts {
+		buf := make([]byte, valSize)
+		_, err := rand.Read(buf)
+		require.NoError(t, err)
+		err = b.Put(t.Context(), ds.NewKey(fmt.Sprintf("/key%d", i)), buf)
+		require.NoError(t, err)
+	}
+
+	err = b.Commit(t.Context())
+	require.NoError(t, err)
+}
+
+// Tests from basic_tests from go-datastore
+
+func TestBasicPutGet(t *testing.T) {
+	t.Parallel()
+
+	d, done := newDS(t, nil)
+	defer done()
+
+	k := ds.NewKey("foo")
+	val := []byte("Hello Datastore!")
+
+	err := d.Put(t.Context(), k, val)
+	require.NoError(t, err, "error putting to datastore")
+
+	have, err := d.Has(t.Context(), k)
+	require.NoError(t, err, "error calling has on key we just put")
+
+	if !have {
+		t.Fatal("should have key foo, has returned false")
+	}
+
+	out, err := d.Get(t.Context(), k)
+	require.NoError(t, err)
+
+	if !bytes.Equal(out, val) {
+		t.Fatal("value received on get wasn't what we expected:", out)
+	}
+
+	have, err = d.Has(t.Context(), k)
+	require.NoError(t, err)
+
+	if !have {
+		t.Fatal("should have key foo, has returned false")
+	}
+
+	err = d.Delete(t.Context(), k)
+	require.NoError(t, err)
+
+	have, err = d.Has(t.Context(), k)
+	require.NoError(t, err)
+
+	if have {
+		t.Fatal("should not have key foo, has returned true")
+	}
+}
+
+func TestNotFounds(t *testing.T) {
+	t.Parallel()
+
+	d, done := newDS(t, nil)
+	defer done()
+
+	badk := ds.NewKey("notreal")
+
+	val, err := d.Get(t.Context(), badk)
+	require.ErrorIs(t, err, ds.ErrNotFound)
+
+	if val != nil {
+		t.Fatal("get should always return nil for not found values")
+	}
+
+	have, err := d.Has(t.Context(), badk)
+	require.NoError(t, err)
+	if have {
+		t.Fatal("has returned true for key we don't have")
+	}
+}
+
+func TestManyKeysAndQuery(t *testing.T) {
+	t.Parallel()
+
+	d, done := newDS(t, nil)
+	defer done()
+
+	count := 100
+	keys := make([]ds.Key, 0, count)
+	keystrs := make([]string, 0, count)
+	values := make([][]byte, 0, count)
+	for i := range count {
+		s := fmt.Sprintf("%dkey%d", i, i)
+		dsk := ds.NewKey(s)
+		keystrs = append(keystrs, dsk.String())
+		keys = append(keys, dsk)
+		buf := make([]byte, 64)
+		_, err := rand.Read(buf)
+		require.NoError(t, err)
+		values = append(values, buf)
+	}
+
+	t.Logf("putting %d values", count)
+	for i, k := range keys {
+		err := d.Put(t.Context(), k, values[i])
+		require.NoError(t, err)
+	}
+
+	t.Log("getting values back")
+	for i, k := range keys {
+		val, err := d.Get(t.Context(), k)
+		require.NoError(t, err)
+
+		if !bytes.Equal(val, values[i]) {
+			t.Fatal("input value didn't match the one returned from Get")
+		}
+	}
+
+	t.Log("querying values")
+	q := dsq.Query{KeysOnly: true}
+	resp, err := d.Query(t.Context(), q)
+	require.NoError(t, err)
+
+	t.Log("aggregating query results")
+	var outkeys []string
+	for {
+		res, ok := resp.NextSync()
+		require.NoError(t, res.Error)
+		if !ok {
+			break
+		}
+
+		outkeys = append(outkeys, res.Key)
+	}
+
+	t.Log("verifying query output")
+	sort.Strings(keystrs)
+	sort.Strings(outkeys)
+
+	if len(keystrs) != len(outkeys) {
+		t.Fatalf("got wrong number of keys back, %d != %d", len(keystrs), len(outkeys))
+	}
+
+	for i, s := range keystrs {
+		if outkeys[i] != s {
+			t.Fatalf("in key output, got %s but expected %s", outkeys[i], s)
+		}
+	}
+
+	t.Log("deleting all keys")
+	for _, k := range keys {
+		require.NoError(t, d.Delete(t.Context(), k))
+	}
+}
+
+func TestGC(t *testing.T) {
+	t.Parallel()
+
+	d, done := newDS(t, nil)
+	defer done()
+
+	count := 10000
+
+	b, err := d.Batch(t.Context())
+	require.NoError(t, err)
+
+	t.Logf("putting %d values", count)
+	for i := range count {
+		buf := make([]byte, 6400)
+		_, err := rand.Read(buf)
+		require.NoError(t, err)
+		err = b.Put(t.Context(), ds.NewKey(fmt.Sprintf("/key%d", i)), buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	err = b.Commit(t.Context())
+	require.NoError(t, err)
+
+	b, err = d.Batch(t.Context())
+	require.NoError(t, err)
+
+	t.Logf("deleting %d values", count)
+	for i := range count {
+		err := b.Delete(t.Context(), ds.NewKey(fmt.Sprintf("/key%d", i)))
+		require.NoError(t, err)
+	}
+
+	err = b.Commit(t.Context())
+	require.NoError(t, err)
+
+	if err := d.CollectGarbage(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestDisksage verifies we fetch some badger size correctly.
+// Because the Size metric is only updated every minute in badger and
+// this interval is not configurable, we re-open the database
+// (the size is always calculated on Open) to make things quick.
+func TestDiskUsage(t *testing.T) {
+	t.Parallel()
+
+	path := t.TempDir()
+	defer os.RemoveAll(path)
+
+	opts := badger.DefaultOptions(path)
+	opts.ValueLogFileSize = 104857600 // 100 MiB as we have problems running tests on 32bit
+	opts.MemTableSize = 41943040      // 40 MiB
+	opts.NumMemtables = 1
+
+	db, err := badger.Open(opts)
+	require.NoError(t, err)
+
+	d, err := NewDatastore(db, nil)
+	require.NoError(t, err)
+
+	addTestCases(t, d, testcases)
+	d.Close()
+
+	db, err = badger.Open(opts)
+	require.NoError(t, err)
+
+	d, err = NewDatastore(db, nil)
+	require.NoError(t, err)
+
+	s, _ := d.DiskUsage(t.Context())
+	if s == 0 {
+		t.Error("expected some size")
+	}
+	d.Close()
+}
+
+func TestTxnDiscard(t *testing.T) {
+	t.Parallel()
+
+	path := t.TempDir()
+	defer os.RemoveAll(path)
+
+	opts := badger.DefaultOptions(path)
+	opts.ValueLogFileSize = 104857600 // 100 MiB as we have problems running tests on 32bit
+	opts.MemTableSize = 41943040      // 40 MiB
+	opts.NumMemtables = 1
+
+	db, err := badger.Open(opts)
+	require.NoError(t, err)
+
+	d, err := NewDatastore(db, nil)
+	defer os.RemoveAll(path)
+	require.NoError(t, err)
+
+	txn, err := d.NewTransaction(t.Context(), false)
+	require.NoError(t, err)
+	key := ds.NewKey("/test/thing")
+	if err := txn.Put(t.Context(), key, []byte{1, 2, 3}); err != nil {
+		t.Fatal(err)
+	}
+	txn.Discard(t.Context())
+	has, err := d.Has(t.Context(), key)
+	require.NoError(t, err)
+	if has {
+		t.Fatal("key written in aborted transaction still exists")
+	}
+
+	d.Close()
+}
+
+func TestTxnCommit(t *testing.T) {
+	t.Parallel()
+
+	path := t.TempDir()
+	defer os.RemoveAll(path)
+
+	opts := badger.DefaultOptions(path)
+	opts.ValueLogFileSize = 104857600 // 100 MiB as we have problems running tests on 32bit
+	opts.MemTableSize = 41943040      // 40 MiB
+	opts.NumMemtables = 1
+
+	db, err := badger.Open(opts)
+	require.NoError(t, err)
+
+	d, err := NewDatastore(db, nil)
+	require.NoError(t, err)
+
+	txn, err := d.NewTransaction(t.Context(), false)
+	require.NoError(t, err)
+
+	key := ds.NewKey("/test/thing")
+	require.NoError(t, txn.Put(t.Context(), key, []byte{1, 2, 3}))
+
+	err = txn.Commit(t.Context())
+	require.NoError(t, err)
+
+	has, err := d.Has(t.Context(), key)
+	require.NoError(t, err)
+	if !has {
+		t.Fatal("key written in committed transaction does not exist")
+	}
+
+	d.Close()
+}
+
+func TestTxnBatch(t *testing.T) {
+	t.Parallel()
+
+	path := t.TempDir()
+	defer os.RemoveAll(path)
+
+	opts := badger.DefaultOptions(path)
+	opts.ValueLogFileSize = 104857600 // 100 MiB as we have problems running tests on 32bit
+	opts.MemTableSize = 41943040      // 40 MiB
+	opts.NumMemtables = 1
+
+	db, err := badger.Open(opts)
+	require.NoError(t, err)
+
+	d, err := NewDatastore(db, nil)
+	require.NoError(t, err)
+
+	txn, err := d.NewTransaction(t.Context(), false)
+	require.NoError(t, err)
+	data := make(map[ds.Key][]byte)
+	for i := range 10 {
+		key := ds.NewKey(fmt.Sprintf("/test/%d", i))
+		bytes := make([]byte, 16)
+		_, err := rand.Read(bytes)
+		require.NoError(t, err)
+		data[key] = bytes
+
+		err = txn.Put(t.Context(), key, bytes)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	err = txn.Commit(t.Context())
+	require.NoError(t, err)
+
+	for key, bytes := range data {
+		retrieved, err := d.Get(t.Context(), key)
+		require.NoError(t, err)
+		if len(retrieved) != len(bytes) {
+			t.Fatal("bytes stored different length from bytes generated")
+		}
+		for i, b := range retrieved {
+			if bytes[i] != b {
+				t.Fatal("bytes stored different content from bytes generated")
+			}
+		}
+	}
+
+	d.Close()
+}
+
+func TestTTL(t *testing.T) {
+	t.Parallel()
+
+	if detectrace.WithRace() {
+		t.Skip("disabling timing dependent test while race detector is enabled")
+	}
+
+	path := t.TempDir()
+	defer os.RemoveAll(path)
+
+	opts := badger.DefaultOptions(path)
+	opts.ValueLogFileSize = 104857600 // 100 MiB as we have problems running tests on 32bit
+	opts.MemTableSize = 41943040      // 40 MiB
+	opts.NumMemtables = 1
+
+	db, err := badger.Open(opts)
+	require.NoError(t, err)
+
+	d, err := NewDatastore(db, nil)
+	require.NoError(t, err)
+
+	txn, err := d.NewTransaction(t.Context(), false)
+	require.NoError(t, err)
+
+	data := make(map[ds.Key][]byte)
+	for i := range 10 {
+		key := ds.NewKey(fmt.Sprintf("/test/%d", i))
+		bytes := make([]byte, 16)
+		_, err := rand.Read(bytes)
+		require.NoError(t, err)
+		data[key] = bytes
+	}
+
+	// write data
+	for key, bytes := range data {
+		dsTTL, ok := txn.(ds.TTL)
+		require.True(t, ok)
+		require.NoError(t, dsTTL.PutWithTTL(t.Context(), key, bytes, time.Second))
+	}
+	err = txn.Commit(t.Context())
+	require.NoError(t, err)
+
+	// set ttl
+	txn, err = d.NewTransaction(t.Context(), false)
+	require.NoError(t, err)
+	for key := range data {
+		dsTTL, ok := txn.(ds.TTL)
+		require.True(t, ok)
+		require.NoError(t, dsTTL.SetTTL(t.Context(), key, time.Second))
+	}
+	err = txn.Commit(t.Context())
+	require.NoError(t, err)
+
+	txn, err = d.NewTransaction(t.Context(), true)
+	require.NoError(t, err)
+	for key := range data {
+		_, err := txn.Get(t.Context(), key)
+		require.NoError(t, err)
+	}
+	txn.Discard(t.Context())
+
+	time.Sleep(time.Second)
+
+	for key := range data {
+		has, err := d.Has(t.Context(), key)
+		require.NoError(t, err)
+		if has {
+			t.Fatal("record with ttl did not expire")
+		}
+	}
+
+	d.Close()
+}
+
+func TestExpirations(t *testing.T) {
+	t.Parallel()
+
+	var err error
+
+	d, done := newDS(t, nil)
+	defer done()
+
+	txn, err := d.NewTransaction(t.Context(), false)
+	require.NoError(t, err)
+	ttltxn, ok := txn.(ds.TTL)
+	require.True(t, ok)
+	defer txn.Discard(t.Context())
+
+	key := ds.NewKey("/abc/def")
+	val := make([]byte, 32)
+	n, err := rand.Read(val)
+	require.NoError(t, err)
+	require.Equal(t, 32, n)
+
+	ttl := time.Hour
+	now := time.Now()
+	tgt := now.Add(ttl)
+
+	require.NoError(t, ttltxn.PutWithTTL(t.Context(), key, val, ttl))
+	require.NoError(t, txn.Commit(t.Context()))
+
+	// Second transaction to retrieve expirations.
+	txn, err = d.NewTransaction(t.Context(), true)
+	require.NoError(t, err)
+	ttltxn, ok = txn.(ds.TTL)
+	require.True(t, ok)
+	defer txn.Discard(t.Context())
+
+	// GetExpiration returns expected value.
+	var dsExp time.Time
+	if dsExp, err = ttltxn.GetExpiration(t.Context(), key); err != nil {
+		t.Fatalf("getting expiration failed: %v", err)
+	} else if tgt.Sub(dsExp) >= 5*time.Second {
+		t.Fatal("expiration returned by datastore not within the expected range (tolerance: 5 seconds)")
+	} else if tgt.Sub(dsExp) < 0 {
+		t.Fatal("expiration returned by datastore was earlier than expected")
+	}
+
+	// Iterator returns expected value.
+	q := dsq.Query{
+		ReturnExpirations: true,
+		KeysOnly:          true,
+	}
+	var ress dsq.Results
+	if ress, err = txn.Query(t.Context(), q); err != nil {
+		t.Fatalf("querying datastore failed: %v", err)
+	}
+
+	defer ress.Close()
+	if res, ok := ress.NextSync(); !ok {
+		t.Fatal("expected 1 result in iterator")
+	} else if res.Expiration != dsExp {
+		t.Fatalf("expiration returned from iterator differs from GetExpiration, expected: %v, actual: %v", dsExp, res.Expiration)
+	}
+
+	if _, ok := ress.NextSync(); ok {
+		t.Fatal("expected no more results in iterator")
+	}
+
+	// Datastore->GetExpiration()
+	if exp, err := d.GetExpiration(t.Context(), key); err != nil {
+		t.Fatalf("querying datastore failed: %v", err)
+	} else if exp != dsExp {
+		t.Fatalf("expiration returned from DB differs from that returned by txn, expected: %v, actual: %v", dsExp, exp)
+	}
+
+	_, err = d.GetExpiration(t.Context(), ds.NewKey("/foo/bar"))
+	require.ErrorIs(t, err, ds.ErrNotFound)
+}
+
+func TestOptions(t *testing.T) {
+	t.Parallel()
+
+	path := t.TempDir()
+	opts := DefaultOptions
+	opts.TTL = time.Minute
+
+	bOpts := badger.DefaultOptions(path)
+	bOpts.ValueLogFileSize = 104857600 // 100 MiB as we have problems running tests on 32bit
+	bOpts.MemTableSize = 41943040      // 40 MiB
+	bOpts.NumMemtables = 1
+
+	db, err := badger.Open(bOpts)
+	require.NoError(t, err)
+
+	d, err := NewDatastore(db, &opts)
+	require.NoError(t, err)
+
+	if d.ttl != time.Minute {
+		t.Fatal("datastore ttl not set")
+	}
+
+	ratio := 0.5
+	ttl := 4 * time.Second
+	o := DefaultOptions.
+		WithTTL(ttl).
+		WithGcDiscardRatio(ratio)
+
+	assert.Equal(t, ttl, o.TTL)
+	assert.InEpsilon(t, ratio, o.GcDiscardRatio, 0.01)
+
+	// Make sure DefaultOptions aren't changed
+	assert.Equal(t, time.Duration(0), DefaultOptions.TTL)
+}
+
+func TestClosedError(t *testing.T) {
+	t.Parallel()
+
+	path := t.TempDir()
+	opts := DefaultOptions
+
+	bOpts := badger.DefaultOptions(path)
+	bOpts.ValueLogFileSize = 104857600 // 100 MiB as we have problems running tests on 32bit
+	bOpts.MemTableSize = 41943040      // 40 MiB
+	bOpts.NumMemtables = 1
+
+	db, err := badger.Open(bOpts)
+	require.NoError(t, err)
+
+	d, err := NewDatastore(db, &opts)
+	require.NoError(t, err)
+
+	dstx, err := d.NewTransaction(t.Context(), false)
+	require.NoError(t, err)
+
+	tx, ok := dstx.(*txn)
+	require.True(t, ok)
+
+	err = d.Close()
+	require.NoError(t, err)
+	os.RemoveAll(path)
+
+	key := ds.NewKey("/a/b/c")
+
+	_, err = d.NewTransaction(t.Context(), false)
+	require.ErrorIs(t, err, ErrClosed)
+
+	require.ErrorIs(t, d.Put(t.Context(), key, nil), ErrClosed)
+	require.ErrorIs(t, d.Sync(t.Context(), key), ErrClosed)
+	require.ErrorIs(t, d.PutWithTTL(t.Context(), key, nil, time.Second), ErrClosed)
+	require.ErrorIs(t, d.Close(), ErrClosed)
+	require.ErrorIs(t, d.CollectGarbage(t.Context()), ErrClosed)
+	require.ErrorIs(t, d.gcOnce(), ErrClosed)
+	require.ErrorIs(t, tx.Put(t.Context(), key, nil), ErrClosed)
+	require.ErrorIs(t, tx.Sync(t.Context(), key), ErrClosed)
+	require.ErrorIs(t, tx.PutWithTTL(t.Context(), key, nil, time.Second), ErrClosed)
+	require.ErrorIs(t, tx.SetTTL(t.Context(), key, time.Second), ErrClosed)
+	require.ErrorIs(t, tx.Commit(t.Context()), ErrClosed)
+	require.ErrorIs(t, tx.Close(), ErrClosed)
+	require.ErrorIs(t, tx.Delete(t.Context(), key), ErrClosed)
+
+	err = d.SetTTL(t.Context(), key, time.Second)
+	require.ErrorIs(t, err, ErrClosed)
+
+	_, err = d.GetExpiration(t.Context(), ds.Key{})
+	require.ErrorIs(t, err, ErrClosed)
+
+	_, err = d.Get(t.Context(), key)
+	require.ErrorIs(t, err, ErrClosed)
+
+	_, err = d.Has(t.Context(), key)
+	require.ErrorIs(t, err, ErrClosed)
+
+	_, err = d.GetSize(t.Context(), key)
+	require.ErrorIs(t, err, ErrClosed)
+
+	_, err = d.Query(t.Context(), dsq.Query{})
+	require.ErrorIs(t, err, ErrClosed)
+
+	_, err = d.DiskUsage(t.Context())
+	require.ErrorIs(t, err, ErrClosed)
+
+	_, err = tx.GetExpiration(t.Context(), key)
+	require.ErrorIs(t, err, ErrClosed)
+
+	_, err = tx.Get(t.Context(), key)
+	require.ErrorIs(t, err, ErrClosed)
+
+	_, err = tx.Has(t.Context(), key)
+	require.ErrorIs(t, err, ErrClosed)
+
+	_, err = tx.GetSize(t.Context(), key)
+	require.ErrorIs(t, err, ErrClosed)
+
+	_, err = tx.Query(t.Context(), dsq.Query{})
+	require.ErrorIs(t, err, ErrClosed)
+}
+
+func TestDefaultTTL(t *testing.T) {
+	t.Parallel()
+
+	opts := DefaultOptions.WithTTL(time.Second)
+	d, done := newDS(t, &opts)
+	defer done()
+
+	data1 := make(map[ds.Key][]byte)
+	data2 := make(map[ds.Key][]byte)
+	for i := range 10 {
+		key1 := ds.NewKey(fmt.Sprintf("/test1/%d", i))
+		key2 := ds.NewKey(fmt.Sprintf("/test2/%d", i))
+		bytes := make([]byte, 16)
+		_, err := rand.Read(bytes)
+		require.NoError(t, err)
+		data1[key1] = bytes
+		data2[key2] = bytes
+	}
+
+	// put directly into datastore
+	for key, bytes := range data1 {
+		err := d.Put(t.Context(), key, bytes)
+		require.NoError(t, err)
+
+		// check data was persisted
+		has, err := d.Has(t.Context(), key)
+		require.NoError(t, err)
+		assert.True(t, has, "record not in db")
+	}
+
+	// put via transactions
+	for key, bytes := range data2 {
+		tx, err := d.NewTransaction(t.Context(), false)
+		require.NoError(t, err)
+
+		err = tx.Put(t.Context(), key, bytes)
+		require.NoError(t, err)
+
+		err = tx.Commit(t.Context())
+		require.NoError(t, err)
+
+		// check data was persisted
+		has, err := d.Has(t.Context(), key)
+		require.NoError(t, err)
+		assert.True(t, has, "record not in db")
+	}
+
+	time.Sleep(time.Second)
+
+	// check datastore data has expired
+	for key := range data1 {
+		has, err := d.Has(t.Context(), key)
+		require.NoError(t, err)
+		assert.False(t, has, "record with ttl did not expire")
+	}
+
+	// check txn data has expired
+	for key := range data2 {
+		has, err := d.Has(t.Context(), key)
+		require.NoError(t, err)
+		assert.False(t, has, "record with ttl did not expire")
+	}
+}
+
+func TestSuite(t *testing.T) {
+	t.Parallel()
+
+	d, done := newDS(t, nil)
+	defer done()
+
+	dstest.SubtestAll(t, d)
+}

--- a/nil/internal/db/tables.go
+++ b/nil/internal/db/tables.go
@@ -33,6 +33,8 @@ const (
 	errorByTransactionHashTable = TableName("ErrorByTransactionHash")
 	schemeVersionTable          = TableName("SchemeVersion")
 	LastBlockTable              = TableName("LastBlock")
+
+	DHTTable = TableName("DHT")
 )
 
 func ShardTableName(tableName ShardedTableName, shardId types.ShardId) TableName {

--- a/nil/internal/network/manager_test.go
+++ b/nil/internal/network/manager_test.go
@@ -57,14 +57,14 @@ func (s *ManagerSuite) TestNewManager() {
 		emptyConfig := &Config{}
 		s.Require().False(emptyConfig.Enabled())
 
-		_, err := NewManager(s.context, emptyConfig)
+		_, err := NewManager(s.context, emptyConfig, nil)
 		s.Require().ErrorIs(err, ErrNetworkDisabled)
 	})
 
 	s.Run("NoPrivateKey", func() {
 		_, err := NewManager(s.context, &Config{
 			TcpPort: 1234,
-		})
+		}, nil)
 		s.Require().ErrorIs(err, ErrPrivateKeyMissing)
 	})
 }

--- a/nil/internal/network/testaide.go
+++ b/nil/internal/network/testaide.go
@@ -39,7 +39,7 @@ func NewTestManagerWithBaseConfig(t *testing.T, ctx context.Context, conf *Confi
 		conf.PrivateKey = privateKey
 	}
 
-	m, err := NewManager(ctx, conf)
+	m, err := NewManager(ctx, conf, nil)
 	require.NoError(t, err)
 	return m
 }

--- a/nil/services/nilservice/service.go
+++ b/nil/services/nilservice/service.go
@@ -388,7 +388,7 @@ func CreateNode(ctx context.Context, name string, cfg *Config, database db.DB, i
 	if cfg.Network != nil && cfg.RunMode != NormalRunMode {
 		cfg.Network.DHTMode = dht.ModeClient
 	}
-	networkManager, err := createNetworkManager(ctx, cfg)
+	networkManager, err := createNetworkManager(ctx, cfg, database)
 	if err != nil {
 		logger.Error().Err(err).Msg("Failed to create network manager")
 		return nil, err
@@ -535,16 +535,16 @@ func Run(ctx context.Context, cfg *Config, database db.DB, interop chan<- Servic
 	return 0
 }
 
-func createNetworkManager(ctx context.Context, cfg *Config) (*network.Manager, error) {
+func createNetworkManager(ctx context.Context, cfg *Config, database db.DB) (*network.Manager, error) {
 	if cfg.RunMode == RpcRunMode {
-		return network.NewClientManager(ctx, cfg.Network)
+		return network.NewClientManager(ctx, cfg.Network, database)
 	}
 
 	if cfg.Network == nil || !cfg.Network.Enabled() {
 		return nil, nil
 	}
 
-	return network.NewManager(ctx, cfg.Network)
+	return network.NewManager(ctx, cfg.Network, database)
 }
 
 func initDefaultValidator(cfg *Config) error {

--- a/nil/tests/detectrace/detectrace.go
+++ b/nil/tests/detectrace/detectrace.go
@@ -1,0 +1,7 @@
+//go:build test
+
+package detectrace
+
+func WithRace() bool {
+	return withRace
+}

--- a/nil/tests/detectrace/no_race.go
+++ b/nil/tests/detectrace/no_race.go
@@ -1,0 +1,7 @@
+//go:build !race
+
+package detectrace
+
+const (
+	withRace = false
+)

--- a/nil/tests/detectrace/race.go
+++ b/nil/tests/detectrace/race.go
@@ -1,0 +1,7 @@
+//go:build race
+
+package detectrace
+
+const (
+	withRace = true
+)

--- a/nix/nil.nix
+++ b/nix/nil.nix
@@ -49,7 +49,7 @@ buildGo124Module rec {
   ];
 
   # to obtain run `nix build` with vendorHash = "";
-  vendorHash = "sha256-FHORBSOas4WET3TGJcEw8Ey3gQk2K8FG3elC9tXxo00=";
+  vendorHash = "sha256-5xUsl/IT8MhejLiQfwtaotgv7Jh/WfTR8AbRlzbRWgs=";
   hardeningDisable = [ "all" ];
 
   postInstall = ''


### PR DESCRIPTION
This patch adds a DHT datastore, which aims to make the network more stable and allow nodes to survive restarts more reliably.

Originally, all the code was taken from github.com/ipfs/go-ds-badger4. However, since we use Badger as the primary storage, there is no reason to open a separate database. To prevent mixing blockchain data with DHT data, table functionality was introduced. Everything continues to work as expected since we use an external test suite.