### PR TITLE
[telemetry] report OTEL_SERVICE_NAME as a service name if it's provided

### DIFF
--- a/nil/internal/telemetry/telemetry.go
+++ b/nil/internal/telemetry/telemetry.go
@@ -16,8 +16,13 @@ type (
 )
 
 func NewDefaultConfig() *Config {
+	// https://opentelemetry.io/docs/languages/sdk-configuration/general/#otel_service_name
+	serviceName := os.Getenv("OTEL_SERVICE_NAME")
+	if serviceName == "" {
+		serviceName = os.Args[0]
+	}
 	return &Config{
-		ServiceName: os.Args[0],
+		ServiceName: serviceName,
 	}
 }
 


### PR DESCRIPTION
Right now all our instances has `/usr/bin/nild` as a service name. After this patch it should be `nil-0`, ..., `nil-N`, `nil-rpc-0`,...