### PR TITLE
Adjust faucet timings and fix exporter

### DIFF
--- a/nil/cmd/exporter/internal/clickhouse/clickhouse.go
+++ b/nil/cmd/exporter/internal/clickhouse/clickhouse.go
@@ -306,6 +306,9 @@ func exportTransactionsAndLogs(ctx context.Context, conn driver.Conn, blocks []b
 			if !ok {
 				return errors.New("receipt not found")
 			}
+			if receipt.decoded.OutTxnIndex+receipt.decoded.OutTxnNum >= uint32(len(parentIndex)) {
+				return fmt.Errorf("output txs range is out of bound: [index=%d, num=%d], block out txs count: %d, block id: %d", receipt.decoded.OutTxnIndex, receipt.decoded.OutTxnNum, len(parentIndex), block.decoded.Id)
+			}
 			for i := receipt.decoded.OutTxnIndex; i < receipt.decoded.OutTxnIndex+receipt.decoded.OutTxnNum; i++ {
 				parentIndex[i] = hash
 			}

--- a/nil/services/cliservice/faucet.go
+++ b/nil/services/cliservice/faucet.go
@@ -19,8 +19,8 @@ import (
 )
 
 const (
-	ReceiptWaitFor  = 15 * time.Second
-	ReceiptWaitTick = 200 * time.Millisecond
+	ReceiptWaitFor  = 20 * time.Second
+	ReceiptWaitTick = 500 * time.Millisecond
 )
 
 var ErrSmartAccountExists = errors.New("smart account already exists")


### PR DESCRIPTION
These changes are the result of devnet debugging:
- Exporter can't start due to panic with wrong receipt's output transactions.
- Increasing faucet timings will probably help to cope with a significant load on the rpc-node.
