### PR TITLE
Sync committee: Fix initialization last proved state root

### DIFF
--- a/nil/services/synccommittee/core/proposer_test.go
+++ b/nil/services/synccommittee/core/proposer_test.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/NilFoundation/nil/nil/client"
 	"github.com/NilFoundation/nil/nil/common/logging"
 	"github.com/NilFoundation/nil/nil/internal/db"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/metrics"
@@ -32,6 +33,7 @@ type ProposerTestSuite struct {
 	clock            clockwork.Clock
 	storage          *storage.BlockStorage
 	ethClient        *rollupcontract.EthClientMock
+	rpcClientMock    *client.ClientMock
 	proposer         *proposer
 	testData         *types.ProposalData
 	callContractMock *callContractMock
@@ -137,7 +139,8 @@ func (s *ProposerTestSuite) SetupSuite() {
 			return &ethtypes.Receipt{Status: ethtypes.ReceiptStatusSuccessful}, nil
 		},
 	}
-	s.proposer, err = NewProposer(s.ctx, s.params, s.storage, s.ethClient, metricsHandler, logger)
+	s.rpcClientMock = &client.ClientMock{}
+	s.proposer, err = NewProposer(s.ctx, s.params, s.storage, s.ethClient, s.rpcClientMock, metricsHandler, logger)
 	s.Require().NoError(err)
 }
 

--- a/nil/services/synccommittee/core/service.go
+++ b/nil/services/synccommittee/core/service.go
@@ -62,6 +62,7 @@ func New(cfg *Config, database db.DB, ethClient rollupcontract.EthClient) (*Sync
 		cfg.ProposerParams,
 		blockStorage,
 		ethClient,
+		client,
 		metricsHandler,
 		logger,
 	)

--- a/nil/services/synccommittee/core/task_state_change_handler.go
+++ b/nil/services/synccommittee/core/task_state_change_handler.go
@@ -57,7 +57,7 @@ func (h *taskStateChangeHandler) OnTaskTerminated(ctx context.Context, task *typ
 }
 
 func (h *taskStateChangeHandler) onTaskSuccess(ctx context.Context, task *types.Task, result *types.TaskResult) error {
-	if task.TaskType != types.AggregateProofs {
+	if task.TaskType != types.ProofBatch {
 		log.NewTaskEvent(h.logger, zerolog.DebugLevel, task).
 			Msgf("task has type %s, just update pending dependency", task.TaskType)
 		return nil

--- a/nil/services/synccommittee/internal/storage/block_storage.go
+++ b/nil/services/synccommittee/internal/storage/block_storage.go
@@ -1066,6 +1066,19 @@ func (bs *BlockStorage) addStoredCountTx(tx db.RwTx, delta int32) error {
 	return bs.putBatchesCountTx(tx, newBatchesCount)
 }
 
+func (bs *BlockStorage) GetFreeSpaceBatchCount(ctx context.Context) (uint32, error) {
+	tx, err := bs.database.CreateRoTx(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback()
+	batchCount, err := bs.getBatchesCountTx(tx)
+	if err != nil {
+		return 0, err
+	}
+	return bs.config.StoredBatchesLimit - batchCount, nil
+}
+
 func (bs *BlockStorage) getBatchesCountTx(tx db.RoTx) (uint32, error) {
 	bytes, err := tx.Get(storedBatchesCountTable, mainShardKey)
 	switch {

--- a/nil/services/synccommittee/prover/tracer/state_db.go
+++ b/nil/services/synccommittee/prover/tracer/state_db.go
@@ -736,7 +736,9 @@ func (tsdb *TracerStateDB) AddSlotToAccessList(addr types.Address, slot common.H
 }
 
 func (tsdb *TracerStateDB) RevertToSnapshot(int) {
-	panic("prover execution should not revert")
+	// TODO implement revert
+	tsdb.logger.Warn().
+		Msg("skip RevertToSnapshot, which is not inmplemented yet")
 }
 
 // Snapshot returns an identifier for the current revision of the state.


### PR DESCRIPTION
### Changes

- Return initialization of latest proved state root back to `proposer`
- If `Nil RollUp` contract not accessible - set hash of genesis block from main shard
  - Add RPC client to `proposer`
- Fix processing result of `ProofBatch` tasks