### PR TITLE
[collate] fix deadlock on block subscription

### DIFF
--- a/nil/internal/collate/validator.go
+++ b/nil/internal/collate/validator.go
@@ -424,7 +424,10 @@ func (s *Validator) notify(blockId types.BlockNumber) {
 	defer s.subsMutex.Unlock()
 
 	for _, ch := range s.subs {
-		ch <- blockId
+		select {
+		case ch <- blockId:
+		default:
+		}
 	}
 }
 


### PR DESCRIPTION
Seems it's possible case when we write two notify messages into a channel before wait code call unsubscribe. Let's skip channels that don't accept messages.