### PR TITLE
improved clickhouse columns

### DIFF
--- a/nil/internal/types/block.go
+++ b/nil/internal/types/block.go
@@ -41,7 +41,7 @@ type BlockData struct {
 	// It can be considered as an array, where each segment is referred by corresponding receipt.
 	OutTransactionsRoot common.Hash `json:"outTransactionsRoot" ch:"out_transactions_root"`
 	// We cache the size of out transactions, otherwise we should iterate all the tree to get its size
-	OutTransactionsNum  TransactionIndex `json:"outTransactionsNum" ch:"out_transaction_num"`
+	OutTransactionsNum  TransactionIndex `json:"outTransactionsNum" ch:"out_txn_num"`
 	ReceiptsRoot        common.Hash      `json:"receiptsRoot" ch:"receipts_root"`
 	ChildBlocksRootHash common.Hash      `json:"childBlocksRootHash" ch:"child_blocks_root_hash"`
 	MainShardHash       common.Hash      `json:"mainShardHash" ch:"main_chain_hash"`

--- a/nil/internal/types/transaction.go
+++ b/nil/internal/types/transaction.go
@@ -161,8 +161,8 @@ type TransactionDigest struct {
 type Transaction struct {
 	TransactionDigest
 	From     Address        `json:"from,omitempty" ch:"from"`
-	RefundTo Address        `json:"refundTo,omitempty" ch:"refundTo"`
-	BounceTo Address        `json:"bounceTo,omitempty" ch:"bounceTo"`
+	RefundTo Address        `json:"refundTo,omitempty" ch:"refund_to"`
+	BounceTo Address        `json:"bounceTo,omitempty" ch:"bounce_to"`
 	Value    Value          `json:"value,omitempty" ch:"value" ssz-size:"32"`
 	Token    []TokenBalance `json:"token,omitempty" ch:"token" ssz-max:"256"`
 
@@ -198,8 +198,8 @@ type InternalTransactionPayload struct {
 	FeeCredit      Value           `json:"feeCredit,omitempty" ch:"fee_credit" ssz-size:"32"`
 	ForwardKind    ForwardKind     `json:"forwardKind,omitempty" ch:"forward_kind"`
 	To             Address         `json:"to,omitempty" ch:"to"`
-	RefundTo       Address         `json:"refundTo,omitempty" ch:"refundTo"`
-	BounceTo       Address         `json:"bounceTo,omitempty" ch:"bounceTo"`
+	RefundTo       Address         `json:"refundTo,omitempty" ch:"refund_to"`
+	BounceTo       Address         `json:"bounceTo,omitempty" ch:"bounce_to"`
 	Token          []TokenBalance  `json:"token,omitempty" ch:"token" ssz-max:"256"`
 	Value          Value           `json:"value,omitempty" ch:"value" ssz-size:"32"`
 	Data           Code            `json:"data,omitempty" ch:"data" ssz-max:"24576"`


### PR DESCRIPTION
Closes #469 

Changes:
- Changed clickhouse column name to `out_txn_num` in `BlockData.OutTransactionsNum` in file `internal/types/block.go` to match with `BlockWithBinary.OutTxnNum` in `clickhouse.go`
- converted from camelcase ch names to snake case in `internal/types/transaction.go`