### PR TITLE
[rpc] add metrics to rpc request handler

### DIFF
--- a/nil/internal/telemetry/telattr/attributes.go
+++ b/nil/internal/telemetry/telattr/attributes.go
@@ -31,3 +31,7 @@ func Topic(topic string) attribute.KeyValue {
 func Type(t string) attribute.KeyValue {
 	return attribute.String(logging.FieldType, t)
 }
+
+func RpcMethod(method string) attribute.KeyValue {
+	return attribute.String(logging.FieldRpcMethod, method)
+}


### PR DESCRIPTION
This patch adds duration/count metrics to JSON RPC request handler.