### PR TITLE
feat(synccommittee): rework task pipeline, block proofs -> batch proof

### DIFF
--- a/nil/cmd/sync_committee_cli/internal/commands/task_fields.go
+++ b/nil/cmd/sync_committee_cli/internal/commands/task_fields.go
@@ -22,9 +22,6 @@ var TaskViewFields = map[TaskField]struct {
 }{
 	"Id":          {func(task *public.TaskView) string { return task.Id.String() }, true},
 	"BatchId":     {func(task *public.TaskView) string { return task.BatchId.String() }, false},
-	"ShardId":     {func(task *public.TaskView) string { return task.ShardId.String() }, true},
-	"BlockNumber": {func(task *public.TaskView) string { return task.BlockNumber.String() }, true},
-	"BlockHash":   {func(task *public.TaskView) string { return task.BlockHash.String() }, false},
 	"Type":        {func(task *public.TaskView) string { return task.Type.String() }, true},
 	"CircuitType": {func(task *public.TaskView) string { return task.CircuitType.String() }, true},
 	"CreatedAt":   {func(task *public.TaskView) string { return task.CreatedAt.Format(timeFormat) }, true},

--- a/nil/services/synccommittee/core/aggregator.go
+++ b/nil/services/synccommittee/core/aggregator.go
@@ -348,21 +348,21 @@ func (agg *aggregator) handleBlockBatch(ctx context.Context, batch *types.BlockB
 	return nil
 }
 
-// createProofTask generates proof tasks for block batch
+// createProofTask generates proof task for block batch
 func (agg *aggregator) createProofTasks(ctx context.Context, batch *types.BlockBatch) error {
 	currentTime := agg.clock.Now()
-	proofTasks, err := batch.CreateProofTasks(currentTime)
+	proofTask, err := batch.CreateProofTask(currentTime)
 	if err != nil {
 		return fmt.Errorf("error creating proof tasks, mainHash=%s: %w", batch.MainShardBlock.Hash, err)
 	}
 
-	if err := agg.taskStorage.AddTaskEntries(ctx, proofTasks...); err != nil {
+	if err := agg.taskStorage.AddTaskEntries(ctx, proofTask); err != nil {
 		return fmt.Errorf("error adding task entries, mainHash=%s: %w", batch.MainShardBlock.Hash, err)
 	}
 
 	agg.logger.Debug().
 		Stringer(logging.FieldBatchId, batch.Id).
-		Msgf("created %d proof tasks, mainHash=%s", len(proofTasks), batch.MainShardBlock.Hash)
+		Msgf("created proof task, mainHash=%s", batch.MainShardBlock.Hash)
 
 	return nil
 }

--- a/nil/services/synccommittee/core/block_batch_test.go
+++ b/nil/services/synccommittee/core/block_batch_test.go
@@ -117,38 +117,23 @@ func (s *BlockBatchTestSuite) TestNewBlockBatch() {
 	}
 }
 
-/* TODO update with respect new task policy
-func (s *BlockBatchTestSuite) TestCreateProofTasks() {
+func (s *BlockBatchTestSuite) TestCreateProofTask() {
 	const childBLockCount = 4
 	batch := testaide.NewBlockBatch(childBLockCount)
 
-	taskEntries, err := batch.CreateProofTasks(testaide.Now)
+	taskEntry, err := batch.CreateProofTask(testaide.Now)
 	s.Require().NoError(err)
 
-	s.Require().Len(taskEntries, childBLockCount+1)
+	task := taskEntry.Task
+	s.Require().Equal(types.ProofBatch, task.TaskType)
+	s.Require().Equal(batch.Id, task.BatchId)
+	s.Require().Equal(batch.MainShardBlock.Hash, task.BlockIds[0].Hash)
+	s.Require().Nil(task.ParentTaskId)
 
-	shardTasks := make(map[coreTypes.ShardId]types.Task)
-	for _, entry := range taskEntries {
-		shardTasks[entry.Task.ShardId] = entry.Task
+	for i, childBlock := range batch.ChildBlocks {
+		// `testaide.NewBlockBatch(n)` creates one main shard block and `n` child blocks, each for different shard
+		taskChildBlock := task.BlockIds[i+1]
+
+		s.Require().Equal(childBlock.Hash, taskChildBlock.Hash)
 	}
-
-	mainShardTask, ok := shardTasks[coreTypes.MainShardId]
-	s.Require().True(ok)
-
-	s.Require().Equal(types.AggregateProofs, mainShardTask.TaskType)
-	s.Require().Equal(batch.Id, mainShardTask.BatchId)
-	s.Require().Equal(batch.MainShardBlock.Hash, mainShardTask.BlockHash)
-	s.Require().Equal(batch.MainShardBlock.Number, mainShardTask.BlockNum)
-	s.Require().Nil(mainShardTask.ParentTaskId)
-
-	for _, childBlock := range batch.ChildBlocks {
-		childTask, ok := shardTasks[childBlock.ShardId]
-		s.Require().True(ok)
-
-		s.Require().Equal(types.ProofBlock, childTask.TaskType)
-		s.Require().Equal(batch.Id, childTask.BatchId)
-		s.Require().Equal(childBlock.Hash, childTask.BlockHash)
-		s.Require().Equal(childBlock.Number, childTask.BlockNum)
-		s.Require().Equal(mainShardTask.Id, *childTask.ParentTaskId)
-	}
-}*/
+}

--- a/nil/services/synccommittee/internal/log/events.go
+++ b/nil/services/synccommittee/internal/log/events.go
@@ -14,10 +14,7 @@ func NewTaskEvent(
 	//nolint:zerologlint // 'must be dispatched by Msg or Send method' error is ignored
 	return logger.WithLevel(level).
 		Stringer(logging.FieldTaskId, task.Id).
-		Stringer(logging.FieldShardId, task.ShardId).
 		Stringer(logging.FieldBatchId, task.BatchId).
-		Stringer(logging.FieldBlockHash, task.BlockHash).
-		Stringer(logging.FieldBlockNumber, task.BlockNum).
 		Stringer(logging.FieldTaskType, task.TaskType).
 		Interface(logging.FieldTaskParentId, task.ParentTaskId)
 }

--- a/nil/services/synccommittee/internal/rpc/task_debug_rpc_test.go
+++ b/nil/services/synccommittee/internal/rpc/task_debug_rpc_test.go
@@ -42,7 +42,7 @@ var (
 	someExecutor   = testaide.RandomExecutorId()
 	running        = types.Running
 	failed         = types.Failed
-	proofBlockType = types.ProofBlock
+	proofBatchType = types.ProofBatch
 	sortExecTime   = public.OrderByExecutionTime
 	sortCreatedAt  = public.OrderByCreatedAt
 	outputLimit    = 4
@@ -53,9 +53,9 @@ func newTaskEntries(now time.Time) []*types.TaskEntry {
 		testaide.NewTaskEntry(now.Add(-6*time.Minute), running, testaide.RandomExecutorId()),
 		testaide.NewTaskEntry(now.Add(-4*time.Minute), running, someExecutor),
 		testaide.NewTaskEntry(now.Add(-8*time.Minute), running, someExecutor),
-		testaide.NewTaskEntryOfType(proofBlockType, now.Add(-2*time.Minute), failed, someExecutor),
+		testaide.NewTaskEntryOfType(proofBatchType, now.Add(-2*time.Minute), failed, someExecutor),
 		testaide.NewTaskEntryOfType(
-			proofBlockType, now.Add(-10*time.Minute), types.WaitingForInput, testaide.RandomExecutorId()),
+			proofBatchType, now.Add(-10*time.Minute), types.WaitingForInput, testaide.RandomExecutorId()),
 		testaide.NewTaskEntry(now, types.WaitingForExecutor, testaide.RandomExecutorId()),
 	}
 }
@@ -154,7 +154,7 @@ func (s *TaskSchedulerDebugRpcTestSuite) Test_Get_Tasks() {
 		},
 		{
 			name:            "FilterByTaskType",
-			request:         public.NewTaskDebugRequest(nil, &proofBlockType, nil, nil, false, nil),
+			request:         public.NewTaskDebugRequest(nil, &proofBatchType, nil, nil, false, nil),
 			expectedResults: []*types.TaskEntry{entries[3], entries[4]},
 			ignoreOrder:     true,
 		},
@@ -408,9 +408,6 @@ func (s *TaskSchedulerDebugRpcTestSuite) requireTaskViewEqual(expected *types.Ta
 
 	assertions = append(assertions, []bool{
 		s.Equal(expected.Task.BatchId, actual.BatchId),
-		s.Equal(expected.Task.ShardId, actual.ShardId),
-		s.Equal(expected.Task.BlockNum, actual.BlockNumber),
-		s.Equal(expected.Task.BlockHash, actual.BlockHash),
 
 		s.Equal(expected.Created, actual.CreatedAt),
 		s.Equal(expected.Started, actual.StartedAt),

--- a/nil/services/synccommittee/internal/rpc/task_request_handler_rpc_suite_test.go
+++ b/nil/services/synccommittee/internal/rpc/task_request_handler_rpc_suite_test.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/NilFoundation/nil/nil/common"
 	"github.com/NilFoundation/nil/nil/common/logging"
-	coreTypes "github.com/NilFoundation/nil/nil/internal/types"
 	"github.com/NilFoundation/nil/nil/services/rpc"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/api"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/scheduler"
@@ -97,16 +95,12 @@ var tasksForExecutors = map[types.TaskExecutorId]*types.Task{
 	firstExecutorId: {
 		Id:          types.NewTaskId(),
 		BatchId:     types.NewBatchId(),
-		ShardId:     coreTypes.MainShardId,
-		BlockNum:    1,
-		BlockHash:   common.EmptyHash,
 		TaskType:    types.PartialProve,
 		CircuitType: types.CircuitBytecode,
 	},
 	secondExecutorId: {
 		Id:          types.NewTaskId(),
 		BatchId:     types.NewBatchId(),
-		BlockNum:    10,
 		TaskType:    types.AggregatedFRI,
 		CircuitType: types.CircuitReadWrite,
 		DependencyResults: map[types.TaskId]types.TaskResultDetails{

--- a/nil/services/synccommittee/internal/storage/task_storage_test.go
+++ b/nil/services/synccommittee/internal/storage/task_storage_test.go
@@ -59,10 +59,8 @@ func (s *TaskStorageSuite) Test_Request_And_Process_Result() {
 
 	// Initialize two tasks waiting for input
 	lowerPriorityEntry := testaide.NewTaskEntry(now, types.WaitingForInput, types.UnknownExecutorId)
-	lowerPriorityEntry.Task.BlockNum = 222
 
 	higherPriorityEntry := testaide.NewTaskEntry(now, types.WaitingForInput, types.UnknownExecutorId)
-	higherPriorityEntry.Task.BlockNum = 14
 
 	// Initialize two corresponding dependencies for them which are running
 	dependency1 := testaide.NewTaskEntry(now, types.Running, testaide.RandomExecutorId())

--- a/nil/services/synccommittee/internal/testaide/prover_tasks.go
+++ b/nil/services/synccommittee/internal/testaide/prover_tasks.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/NilFoundation/nil/nil/common/check"
-	coreTypes "github.com/NilFoundation/nil/nil/internal/types"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
 )
 
@@ -56,12 +55,9 @@ func NewTask() *types.Task {
 
 func NewTaskOfType(taskType types.TaskType) *types.Task {
 	return &types.Task{
-		Id:        types.NewTaskId(),
-		BatchId:   types.NewBatchId(),
-		ShardId:   coreTypes.MainShardId,
-		BlockNum:  1,
-		BlockHash: RandomHash(),
-		TaskType:  taskType,
+		Id:       types.NewTaskId(),
+		BatchId:  types.NewBatchId(),
+		TaskType: taskType,
 	}
 }
 

--- a/nil/services/synccommittee/internal/types/block_batch.go
+++ b/nil/services/synccommittee/internal/types/block_batch.go
@@ -124,18 +124,8 @@ func (b *BlockBatch) AllBlocks() []*jsonrpc.RPCBlock {
 	return blocks
 }
 
-// TODO: update signature CreateProofTask(currentTime time.Time) (*TaskEntry, error)
-func (b *BlockBatch) CreateProofTasks(currentTime time.Time) ([]*TaskEntry, error) {
-	taskEntries := make([]*TaskEntry, 0, 1)
-
-	batchProofTask, err := NewBatchProofTaskEntry(b.Id, b.AllBlocks(), currentTime)
-	if err != nil {
-		return nil, err
-	}
-
-	taskEntries = append(taskEntries, batchProofTask)
-
-	return taskEntries, nil
+func (b *BlockBatch) CreateProofTask(currentTime time.Time) (*TaskEntry, error) {
+	return NewBatchProofTaskEntry(b.Id, b.AllBlocks(), currentTime)
 }
 
 type PrunedBatch struct {

--- a/nil/services/synccommittee/internal/types/task_type.go
+++ b/nil/services/synccommittee/internal/types/task_type.go
@@ -11,8 +11,6 @@ type TaskType uint8
 
 const (
 	TaskTypeNone TaskType = iota
-	AggregateProofs
-	ProofBlock
 	ProofBatch
 	PartialProve
 	AggregatedChallenge
@@ -23,8 +21,6 @@ const (
 )
 
 var TaskTypes = map[string]TaskType{
-	"AggregateProofs":      AggregateProofs,
-	"ProofBlock":           ProofBlock,
 	"ProofBatch":           ProofBatch,
 	"PartialProve":         PartialProve,
 	"AggregatedChallenge":  AggregatedChallenge,

--- a/nil/services/synccommittee/proofprovider/task_handler_test.go
+++ b/nil/services/synccommittee/proofprovider/task_handler_test.go
@@ -63,9 +63,12 @@ func (s *TaskHandlerTestSuite) TestReturnErrorOnUnexpectedTaskType() {
 		taskType types.TaskType
 	}{
 		{name: "PartialProve", taskType: types.PartialProve},
+		{name: "AggregatedChallenge", taskType: types.AggregatedChallenge},
+		{name: "CombinedQ", taskType: types.CombinedQ},
+		{name: "AggregatedFRI", taskType: types.AggregatedFRI},
 		{name: "FRIConsistencyChecks", taskType: types.FRIConsistencyChecks},
 		{name: "MergeProof", taskType: types.MergeProof},
-		{name: "AggregatedFRI", taskType: types.AggregatedFRI},
+		{name: "TaskTypeNone", taskType: types.TaskTypeNone},
 	}
 
 	executorId := testaide.RandomExecutorId()

--- a/nil/services/synccommittee/prover/commands/aggregate_challenges.go
+++ b/nil/services/synccommittee/prover/commands/aggregate_challenges.go
@@ -60,9 +60,7 @@ func (cmd *aggregateChallengesCmd) BeforeCommandExecuted(
 	if err != nil {
 		return err
 	}
-	aggregateFileName := filepath.Join(
-		cmd.outDir,
-		fmt.Sprintf("aggregated_thetas.%v.%v", task.ShardId, task.BlockHash.String()))
+	aggregateFileName := filepath.Join(cmd.outDir, fmt.Sprintf("aggregated_thetas.%v", task.BatchId))
 	results[types.AggregatedThetaPowers] = aggregateFileName
 	return os.WriteFile(aggregateFileName, bytes, 0o644) //nolint:gosec
 }
@@ -76,7 +74,7 @@ func (cmd *aggregateChallengesCmd) MakeCommandDefinition(task *types.Task) (*Com
 	}
 	inputs := append([]string{"--input-challenge-files"}, inputFiles...)
 	outFile := filepath.Join(cmd.outDir,
-		fmt.Sprintf("aggregated_challenges.%v.%v", task.ShardId, task.BlockHash.String()))
+		fmt.Sprintf("aggregated_challenges.%v", task.BatchId))
 	outArg := []string{"--aggregated-challenge-file", outFile}
 	allArgs := slices.Concat(stage, inputs, outArg)
 	execCmd := exec.Command(binary, allArgs...)

--- a/nil/services/synccommittee/prover/commands/aggregate_fri.go
+++ b/nil/services/synccommittee/prover/commands/aggregate_fri.go
@@ -41,7 +41,7 @@ func (cmd *aggregateFRICmd) MakeCommandDefinition(task *types.Task) (*CommandDef
 	combinedQ := append([]string{"--input-combined-Q-polynomial-files"}, combinedQFiles...)
 
 	resFiles := make(types.TaskOutputArtifacts)
-	filePostfix := fmt.Sprintf(".%v.%v", task.ShardId, task.BlockHash.String())
+	filePostfix := fmt.Sprintf(".%v", task.BatchId)
 	resFiles[types.AggregatedFRIProof] = filepath.Join(cmd.outDir, "aggregated_FRI_proof"+filePostfix)
 	resFiles[types.ProofOfWork] = filepath.Join(cmd.outDir, "POW"+filePostfix)
 	resFiles[types.ConsistencyCheckChallenges] = filepath.Join(cmd.outDir, "challenges"+filePostfix)

--- a/nil/services/synccommittee/prover/commands/aggregate_proof.go
+++ b/nil/services/synccommittee/prover/commands/aggregate_proof.go
@@ -36,7 +36,7 @@ func (cmd *aggregateProofCmd) MakeCommandDefinition(task *types.Task) (*CommandD
 	blockProofs := append([]string{"--block-proof"}, blockProofFiles...)
 
 	outFile := filepath.Join(cmd.outDir,
-		fmt.Sprintf("aggregated-proof.%v.%v", task.ShardId, task.BlockHash.String()))
+		fmt.Sprintf("aggregated-proof.%v", task.BatchId))
 	outArg := []string{"--proof", outFile}
 
 	allArgs := slices.Concat(stage, blockProofs, outArg)

--- a/nil/services/synccommittee/prover/commands/combined_q.go
+++ b/nil/services/synccommittee/prover/commands/combined_q.go
@@ -60,7 +60,7 @@ func (cmd *combinedQCmd) MakeCommandDefinition(task *types.Task) (*CommandDefini
 	}
 	startingPowerArg := []string{"--combined-Q-starting-power", strconv.Itoa(startingPower)}
 	outFile := filepath.Join(cmd.outDir,
-		fmt.Sprintf("combined_Q.%v.%v.%v", circuitIdx(task.CircuitType), task.ShardId, task.BlockHash.String()))
+		fmt.Sprintf("combined_Q.%v.%v", circuitIdx(task.CircuitType), task.BatchId))
 	outArg := []string{"--combined-Q-polynomial-file", outFile}
 
 	allArgs := slices.Concat(stage, commitmentState, aggregateChallenges, startingPowerArg, outArg)

--- a/nil/services/synccommittee/prover/commands/command_factory.go
+++ b/nil/services/synccommittee/prover/commands/command_factory.go
@@ -31,9 +31,7 @@ func (factory *CommandFactory) MakeHandlerCommandForTaskType(taskType types.Task
 		return NewConsistencyCheckCmd(factory.config), nil
 	case types.MergeProof:
 		return NewMergeProofCmd(factory.config), nil
-	case types.AggregateProofs:
-		return NewAggregateProofCmd(factory.config), nil
-	case types.ProofBlock, types.ProofBatch:
+	case types.ProofBatch:
 		return nil, types.NewTaskErrNotSupportedType(taskType)
 	case types.TaskTypeNone:
 		return nil, types.NewTaskExecErrorf(types.TaskErrInvalidTask, "TaskType cannot be None")

--- a/nil/services/synccommittee/prover/commands/consistency_check.go
+++ b/nil/services/synccommittee/prover/commands/consistency_check.go
@@ -39,9 +39,7 @@ func (cmd *consistencyCheckCmd) MakeCommandDefinition(task *types.Task) (*Comman
 	consistencyChallenges := []string{"--consistency-checks-challenges-file", consistencyChallengeFile}
 
 	outFile := filepath.Join(cmd.outDir,
-		fmt.Sprintf(
-			"LPC_consistency_check_proof.%v.%v.%v",
-			circuitIdx(task.CircuitType), task.ShardId, task.BlockHash.String()))
+		fmt.Sprintf("LPC_consistency_check_proof.%v.%v", circuitIdx(task.CircuitType), task.BatchId))
 	outArg := []string{"--proof", outFile}
 
 	allArgs := slices.Concat(stage, commitmentState, combinedQ, consistencyChallenges, outArg)

--- a/nil/services/synccommittee/prover/commands/merge_proof.go
+++ b/nil/services/synccommittee/prover/commands/merge_proof.go
@@ -44,7 +44,7 @@ func (cmd *mergeProofCmd) MakeCommandDefinition(task *types.Task) (*CommandDefin
 	aggFRI := []string{"--aggregated-FRI-proof", aggFRIFile}
 
 	outFile := filepath.Join(cmd.outDir,
-		fmt.Sprintf("final-proof.%v.%v", task.ShardId, task.BlockHash.String()))
+		fmt.Sprintf("final-proof.%v", task.BatchId))
 	outArg := []string{"--proof", outFile}
 
 	allArgs := slices.Concat(stage, partialProofs, LPCChecks, aggFRI, outArg)

--- a/nil/services/synccommittee/prover/commands/partial_proof.go
+++ b/nil/services/synccommittee/prover/commands/partial_proof.go
@@ -37,7 +37,7 @@ func (cmd *partialProofCmd) MakeCommandDefinition(task *types.Task) (*CommandDef
 	resultFiles := make(types.TaskOutputArtifacts)
 	proofProducerBinary := cmd.binary
 	stage := []string{"--stage", "fast-generate-partial-proof"}
-	filePostfix := fmt.Sprintf(".%v.%v.%v", circuitIdx(task.CircuitType), task.ShardId, task.BlockHash.String())
+	filePostfix := fmt.Sprintf(".%v.%v", circuitIdx(task.CircuitType), task.BatchId)
 	circuitName := []string{"--circuit-name", circuitTypeToArg(task.CircuitType)}
 
 	assignmentDescFile := filepath.Join(cmd.outDir, "assignment_table_description"+filePostfix)
@@ -105,7 +105,7 @@ func (cmd *partialProofCmd) BeforeCommandExecuted(
 		shardIdsStr += blockId.ShardId.String() + " "
 		blockRef := transport.HashBlockReference(blockId.Hash)
 		blockIds[i].Id = blockRef
-		blockIdsStr += blockId.Hash.String() + " "
+		blockIdsStr += blockId.Hash.String()
 	}
 	cmd.logger.Info().Msgf(
 		"Tracer arguments: trace --nil-endpoint %v %v %v %v",

--- a/nil/services/synccommittee/public/task_view.go
+++ b/nil/services/synccommittee/public/task_view.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/NilFoundation/nil/nil/common"
 	coreTypes "github.com/NilFoundation/nil/nil/internal/types"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
 )
@@ -51,10 +50,8 @@ func makeTaskViewCommon(taskEntry *types.TaskEntry, currentTime time.Time) TaskV
 type TaskView struct {
 	TaskViewCommon
 
-	BatchId     BatchId     `json:"batchId"`
-	ShardId     ShardId     `json:"shardId"`
-	BlockNumber BlockNumber `json:"blockNumber"`
-	BlockHash   common.Hash `json:"blockHash"`
+	BatchId  BatchId         `json:"batchId"`
+	BlockIds []types.BlockId `json:"blockIds"`
 
 	CreatedAt time.Time  `json:"createdAt"`
 	StartedAt *time.Time `json:"startedAt,omitempty"`
@@ -64,10 +61,8 @@ func NewTaskView(taskEntry *types.TaskEntry, currentTime time.Time) *TaskView {
 	return &TaskView{
 		TaskViewCommon: makeTaskViewCommon(taskEntry, currentTime),
 
-		BatchId:     taskEntry.Task.BatchId,
-		ShardId:     taskEntry.Task.ShardId,
-		BlockNumber: taskEntry.Task.BlockNum,
-		BlockHash:   taskEntry.Task.BlockHash,
+		BatchId:  taskEntry.Task.BatchId,
+		BlockIds: taskEntry.Task.BlockIds,
 
 		CreatedAt: taskEntry.Created,
 		StartedAt: taskEntry.Started,


### PR DESCRIPTION
The updated pipeline for generating proofs now omits the aggregation step, block proofs are replaced with a single batch proof.

Updated Task Pipeline:
1. SyncCommittee: Initiates a task to prove the batch.
2. Proof-provider processes the following DFRI tasks:
   - Partial proofs.
   - Generation of aggregated challenges.
   - Computation of combined Q.
   - Aggregation of FRI.
   - Execution of consistency checks.
   - Merging of proofs.
3. The resulting merged proof, along with the public input, is returned to the SyncCommittee as a binary task result, serving as the proof of the batch.