### PR TITLE
Reduce npm modules size

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -142,6 +142,11 @@
                   ./scripts/binary_patch_version.sh
                 } ./usr/bin/cometa ${versionFull}
                 ${pkgs.fpm}/bin/fpm -s dir -t deb --name ${pkg.pname} -v ${version} --deb-use-file-permissions usr
+
+                # Add postrm script
+                mkdir -p ./DEBIAN
+                cp ${./scripts/postrm.sh} ./DEBIAN/postrm
+                chmod 755 ./DEBIAN/postrm
               '';
               installPhase = ''
                 mkdir -p $out

--- a/scripts/postrm.sh
+++ b/scripts/postrm.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+case "$1" in
+    remove|purge)
+        echo "Cleaning up rollup-bridge-contracts..."
+        rm -rf /usr/share/rollup-bridge-contracts
+        ;;
+esac
+
+exit 0
+


### PR DESCRIPTION
On my server after several runs
usr/share/rollup-bridge-contracts folder is super big.
This PR should fix this issue