### PR TITLE
[playground] fixed second tutorial

### DIFF
--- a/explorer_frontend/src/features/tutorial-check/checks/tutorialTwoCheck.ts
+++ b/explorer_frontend/src/features/tutorial-check/checks/tutorialTwoCheck.ts
@@ -93,6 +93,8 @@ async function runTutorialCheckTwo() {
     return;
   }
 
+  const gasPrice = await client.getGasPrice(1);
+
   tutorialContractStepPassedEvent("CustomToken has minted tokens successfully!");
 
   const hashSending = await smartAccount.sendTransaction({
@@ -100,6 +102,7 @@ async function runTutorialCheckTwo() {
     abi: operatorContract.abi,
     functionName: "checkSendToken",
     args: [resultCustomToken.address, CUSTOM_TOKEN_AMOUNT],
+    feeCredit: gasPrice * 5_000_000n,
   });
 
   const resSending = await waitTillCompleted(client, hashSending);

--- a/explorer_frontend/src/features/tutorial/assets/tutorialTwo/tutorialTwoContracts.sol
+++ b/explorer_frontend/src/features/tutorial/assets/tutorialTwo/tutorialTwoContracts.sol
@@ -11,6 +11,11 @@ import "@nilfoundation/smart-contracts/contracts/NilTokenBase.sol";
  */
 contract Operator is NilBase {
     /**
+     * The default function for receiving calls with empty call data.
+     */
+    receive() external payable {}
+
+    /**
      * The function calling mintTokenCustom() on CustomToken.
      * @param dst The address of CustomToken.
      * @param amount The amount of the custom token to mint.


### PR DESCRIPTION
This diff fixes the check for the second tutorial by capping `feeCredit` and adding a proper `receive()` function.