### PR TITLE
Introduce Stresser service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GO_DBG_BUILD = GOPRIVATE="$(GOPRIVATE)" $(GO) build -tags $(BUILD_TAGS),debug,as
 GOTEST = GOPRIVATE="$(GOPRIVATE)" GODEBUG=cgocheck=0 $(GO) test -tags $(BUILD_TAGS),debug,assert,test $(GO_FLAGS) ./... -p 2
 
 SC_COMMANDS = sync_committee sync_committee_cli proof_provider prover nil_block_generator relayer
-COMMANDS += nild nil nil_load_generator exporter cometa faucet journald_forwarder relay $(SC_COMMANDS)
+COMMANDS += nild nil nil_load_generator exporter cometa faucet journald_forwarder relay stresser $(SC_COMMANDS)
 
 all: $(COMMANDS)
 

--- a/nil/client/client.go
+++ b/nil/client/client.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/NilFoundation/nil/nil/common"
 	"github.com/NilFoundation/nil/nil/common/hexutil"
@@ -297,4 +298,20 @@ func SendTransactionViaSmartAccount(
 		return common.EmptyHash, err
 	}
 	return c.SendExternalTransaction(ctx, calldataExt, smartAccountAddress, pk, fee)
+}
+
+func WaitForReceipt(
+	ctx context.Context,
+	client Client,
+	hash common.Hash,
+	timeout time.Duration,
+) (*jsonrpc.RPCReceipt, error) {
+	var receipt *jsonrpc.RPCReceipt
+	var err error
+	err = common.WaitFor(ctx, timeout, 500*time.Millisecond, func(ctx context.Context) bool {
+		receipt, err = client.GetInTransactionReceipt(ctx, hash)
+		return err == nil && receipt.IsComplete()
+	})
+
+	return receipt, err
 }

--- a/nil/client/client.go
+++ b/nil/client/client.go
@@ -104,7 +104,7 @@ type Client interface {
 	) (common.Hash, error)
 	SendExternalTransaction(
 		ctx context.Context,
-		bytecode types.Code,
+		calldata types.Code,
 		contractAddress types.Address,
 		pk *ecdsa.PrivateKey,
 		fee types.FeePack,
@@ -196,10 +196,10 @@ func CreateExternalTransaction(
 }
 
 func SendExternalTransaction(
-	ctx context.Context, c Client, bytecode types.Code, contractAddress types.Address,
+	ctx context.Context, c Client, calldata types.Code, contractAddress types.Address,
 	pk *ecdsa.PrivateKey, fee types.FeePack, isDeploy bool, withRetry bool,
 ) (common.Hash, error) {
-	extTxn, err := CreateExternalTransaction(ctx, c, bytecode, contractAddress, fee, isDeploy, 0)
+	extTxn, err := CreateExternalTransaction(ctx, c, calldata, contractAddress, fee, isDeploy, 0)
 	if err != nil {
 		return common.EmptyHash, err
 	}

--- a/nil/cmd/stresser/main.go
+++ b/nil/cmd/stresser/main.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/NilFoundation/nil/nil/services/stresser"
+	"github.com/spf13/cobra"
+)
+
+func main() {
+	rootCmd := &cobra.Command{
+		Use:   "stresser --config <config-file>",
+		Short: "Run stresser",
+	}
+
+	var configFile string
+	rootCmd.Flags().StringVar(&configFile, "config", "", "config file")
+
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	st, err := stresser.NewStresserFromFile(configFile)
+	if err != nil {
+		fmt.Println("Failed to create stresser:", err)
+		os.Exit(1)
+	}
+	if err = st.Run(context.Background()); err != nil {
+		fmt.Println("Failed to run stresser:", err)
+		os.Exit(1)
+	}
+}

--- a/nil/common/concurrent/utils.go
+++ b/nil/common/concurrent/utils.go
@@ -41,36 +41,6 @@ func RunWithTimeout(ctx context.Context, timeout time.Duration, fs ...Func) erro
 	return nil
 }
 
-// WaitFor repeatedly calls the given function until it returns true or an error.
-// In case function return some data not equal to nil, it returns true.
-func WaitFor[T any](
-	ctx context.Context,
-	timeout,
-	tick time.Duration,
-	f func(ctx context.Context) (*T, error),
-) (*T, error) {
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
-	ticker := time.NewTicker(tick)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-ticker.C:
-			res, err := f(ctx)
-			if err != nil {
-				return res, err
-			}
-			if res != nil {
-				return res, nil
-			}
-		}
-	}
-}
-
 // Run calls RunWithTimeout without a timeout.
 func Run(ctx context.Context, fs ...Func) error {
 	return RunWithTimeout(ctx, 0, fs...)

--- a/nil/common/logging/typed_logger.go
+++ b/nil/common/logging/typed_logger.go
@@ -509,6 +509,10 @@ func (l Logger) With() Context {
 	return Context{ctx: l.logger.With()}
 }
 
+func (l *Logger) GetLevel() zerolog.Level {
+	return l.logger.GetLevel()
+}
+
 // Trace
 func (l *Logger) Trace() *Event {
 	return &Event{event: l.logger.Trace()} //nolint:zerologlint

--- a/nil/common/util.go
+++ b/nil/common/util.go
@@ -1,0 +1,56 @@
+package common
+
+import (
+	"context"
+	"time"
+)
+
+// WaitFor repeatedly calls the given function until it returns true or an error.
+func WaitFor(ctx context.Context, timeout, tick time.Duration, f func(ctx context.Context) bool) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(tick)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			if f(ctx) {
+				return nil
+			}
+		}
+	}
+}
+
+// WaitForValue repeatedly calls the given function until it returns true or an error.
+// In case function return some data not equal to nil, it returns true.
+func WaitForValue[T any](
+	ctx context.Context,
+	timeout,
+	tick time.Duration,
+	f func(ctx context.Context) (*T, error),
+) (*T, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(tick)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ticker.C:
+			res, err := f(ctx)
+			if err != nil {
+				return res, err
+			}
+			if res != nil {
+				return res, nil
+			}
+		}
+	}
+}

--- a/nil/contracts/solidity/tests/Stresser.sol
+++ b/nil/contracts/solidity/tests/Stresser.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import "../lib/NilTokenBase.sol";
+
+contract Stresser {
+
+    uint256 public value;
+
+    constructor() payable {}
+
+    function add(uint256 v) public returns(uint256) {
+        value += v;
+        return value;
+    }
+
+    function gasConsumer(uint256 v) public returns(uint256) {
+        for (uint256 i = 1; i < v; i++) {
+            value *= 2;
+        }
+        return value;
+    }
+
+    function sendTransactions(address[] memory addresses, uint256 v) public {
+        for (uint256 i = 0; i < addresses.length; i++) {
+            Nil.asyncCall(
+                addresses[i],
+                address(0),
+                0,
+                abi.encodeWithSignature("geometricSeq(uint256)", v)
+            );
+        }
+    }
+
+    function sendRequests(address[] memory addresses, uint256 v) public {
+        bytes memory context = abi.encodeWithSelector(this.sendRequestsResponse.selector);
+        bytes memory callData = abi.encodeWithSignature("gasConsumer(uint256)", v);
+        for (uint256 i = 0; i < addresses.length; i++) {
+            Nil.sendRequest(
+                addresses[i],
+                0,
+                Nil.ASYNC_REQUEST_MIN_GAS,
+                context,
+                callData
+            );
+        }
+    }
+
+    function sendRequestsResponse(
+        bool success,
+        bytes memory,
+        bytes memory
+    ) public pure {
+        require(success, "Request failed");
+    }
+
+    function factorialAwait(uint32 n, address peer) public returns (uint256) {
+        return factorialRec(uint256(n), peer);
+    }
+
+    function factorialRec(uint256 n, address peer) public returns (uint256) {
+        if (n == 0) {
+            return 1;
+        }
+        bytes memory callData = abi.encodeWithSelector(this.factorialRec.selector, n - 1, address(this));
+        (bytes memory returnData, bool success) = Nil.awaitCall(peer, Nil.ASYNC_REQUEST_MIN_GAS, callData);
+        require(success, "awaitCall failed");
+        uint256 prev = abi.decode(returnData, (uint256));
+        return n * prev;
+    }
+
+    function verifyExternal(
+        uint256,
+        bytes calldata
+    ) external pure returns (bool) {
+        return true;
+    }
+}

--- a/nil/internal/collate/proposer.go
+++ b/nil/internal/collate/proposer.go
@@ -95,6 +95,7 @@ func (p *proposer) GenerateProposal(ctx context.Context, txFabric db.DB) (*execu
 		Block:          block,
 		ConfigAccessor: configAccessor,
 		FeeCalculator:  p.params.FeeCalculator,
+		Mode:           execution.ModeProposal,
 	})
 	if err != nil {
 		return nil, err
@@ -295,6 +296,10 @@ func (p *proposer) handleTransactionsFromPool() error {
 		return err
 	}
 
+	if len(poolTxns) != 0 {
+		p.logger.Debug().Int("txNum", len(poolTxns)).Msg("Start handling transactions from the pool")
+	}
+
 	var unverified []common.Hash
 	handle := func(mt *types.TxnWithHash) (bool, error) {
 		txnHash := mt.Hash()
@@ -342,6 +347,10 @@ func (p *proposer) handleTransactionsFromPool() error {
 			p.logger.Error().Err(err).
 				Msgf("Failed to remove %d unverifiable transactions from the pool", len(unverified))
 		}
+	}
+
+	if len(poolTxns) != 0 {
+		p.logger.Debug().Int("txAdded", len(p.proposal.ExternalTxns)).Msg("Finish transactions handling")
 	}
 
 	return nil

--- a/nil/internal/collate/replay_scheduler.go
+++ b/nil/internal/collate/replay_scheduler.go
@@ -32,6 +32,7 @@ type ReplayScheduler struct {
 }
 
 func NewReplayScheduler(txFabric db.DB, params ReplayParams) *ReplayScheduler {
+	params.ExecutionMode = execution.ModeReplay
 	return &ReplayScheduler{
 		txFabric: txFabric,
 		params:   params,

--- a/nil/internal/collate/validator.go
+++ b/nil/internal/collate/validator.go
@@ -154,6 +154,7 @@ func (s *Validator) VerifyProposal(ctx context.Context, proposal *execution.Prop
 		return nil, fmt.Errorf("%w: expected %x, got %x", errHashMismatch, prevBlockHash, proposal.PrevBlockHash)
 	}
 
+	s.params.ExecutionMode = execution.ModeVerify
 	gen, err := execution.NewBlockGenerator(ctx, s.params.BlockGeneratorParams, s.txFabric, prevBlock)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create block generator: %w", err)
@@ -196,6 +197,7 @@ func (s *Validator) insertProposalUnlocked(
 		return err
 	}
 
+	s.params.ExecutionMode = execution.ModeProposal
 	gen, err := execution.NewBlockGenerator(ctx, s.params.BlockGeneratorParams, s.txFabric, prevBlock)
 	if err != nil {
 		return fmt.Errorf("failed to create block generator: %w", err)
@@ -374,6 +376,7 @@ func (s *Validator) replayBlockUnlocked(ctx context.Context, block *types.BlockW
 		return err
 	}
 
+	s.params.ExecutionMode = execution.ModeReplay
 	gen, err := execution.NewBlockGenerator(ctx, s.params.BlockGeneratorParams, s.txFabric, prevBlock)
 	if err != nil {
 		return err

--- a/nil/internal/contracts/testaide.go
+++ b/nil/internal/contracts/testaide.go
@@ -22,6 +22,7 @@ const (
 	NameRequestResponseTest        = "tests/RequestResponseTest"
 	NamePrecompilesTest            = "tests/PrecompilesTest"
 	NameConfigTest                 = "tests/ConfigTest"
+	NameStresser                   = "tests/Stresser"
 )
 
 func GetDeployPayload(t *testing.T, name string) types.DeployPayload {

--- a/nil/internal/execution/block_generator.go
+++ b/nil/internal/execution/block_generator.go
@@ -21,6 +21,7 @@ type BlockGeneratorParams struct {
 	MainKeysPath     string
 	DisableConsensus bool
 	FeeCalculator    FeeCalculator
+	ExecutionMode    string
 }
 
 func NewBlockGeneratorParams(shardId types.ShardId, nShards uint32) BlockGeneratorParams {
@@ -73,6 +74,7 @@ func NewBlockGenerator(
 		Block:          block,
 		ConfigAccessor: configAccessor,
 		FeeCalculator:  params.FeeCalculator,
+		Mode:           params.ExecutionMode,
 	})
 	if err != nil {
 		return nil, err

--- a/nil/internal/execution/fee.go
+++ b/nil/internal/execution/fee.go
@@ -88,13 +88,6 @@ func (m *MainFeeCalculator) CalculateBaseFee(prevBlock *types.Block) types.Value
 		resultBaseFee = types.NewValueFromBigMust(newFee.BigInt())
 	}
 
-	if resultBaseFee.Cmp(prevBlock.BaseFee) != 0 {
-		logger.Debug().
-			Stringer("Old", prevBlock.BaseFee).
-			Stringer("New", resultBaseFee).
-			Msg("Gas price updated")
-	}
-
 	return resultBaseFee
 }
 

--- a/nil/internal/execution/transactions.go
+++ b/nil/internal/execution/transactions.go
@@ -196,7 +196,7 @@ func ValidateExternalTransaction(es *ExecutionState, transaction *types.Transact
 	}
 
 	if transaction.MaxFeePerGas.IsZero() {
-		logger.Error().Msg("MaxFeePerGas is zero")
+		es.logger.Error().Msg("MaxFeePerGas is zero")
 		return NewExecutionResult().SetError(types.NewError(types.ErrorMaxFeePerGasIsZero))
 	}
 

--- a/nil/internal/execution/zerostate.go
+++ b/nil/internal/execution/zerostate.go
@@ -224,7 +224,7 @@ func (es *ExecutionState) GenerateZeroState(stateConfig *ZeroStateConfig) error 
 			return err
 		}
 
-		logger.Debug().Str("name", contract.Name).Stringer("address", addr).Msg("Created zero state contract")
+		es.logger.Debug().Str("name", contract.Name).Stringer("address", addr).Msg("Created zero state contract")
 	}
 	return nil
 }

--- a/nil/internal/telemetry/telemetry.go
+++ b/nil/internal/telemetry/telemetry.go
@@ -3,6 +3,7 @@ package telemetry
 import (
 	"context"
 
+	"github.com/NilFoundation/nil/nil/common/check"
 	"github.com/NilFoundation/nil/nil/internal/telemetry/internal"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric"
@@ -35,4 +36,22 @@ func Shutdown(ctx context.Context) {
 
 func NewMeter(name string) Meter {
 	return otel.Meter(name)
+}
+
+func Int64Gauge(meter metric.Meter, name string) metric.Int64Gauge {
+	res, err := meter.Int64Gauge(name)
+	check.PanicIfErr(err)
+	return res
+}
+
+func Int64Counter(meter metric.Meter, name string) metric.Int64Counter {
+	res, err := meter.Int64Counter(name)
+	check.PanicIfErr(err)
+	return res
+}
+
+func Int64UpDownCounter(meter metric.Meter, name string) metric.Int64UpDownCounter {
+	res, err := meter.Int64UpDownCounter(name)
+	check.PanicIfErr(err)
+	return res
 }

--- a/nil/internal/types/address.go
+++ b/nil/internal/types/address.go
@@ -231,6 +231,15 @@ func GenerateRandomAddress(shardId ShardId) Address {
 	return BytesToAddress(raw)
 }
 
+func GenerateRandomHash() common.Hash {
+	randomBytes := make([]byte, 32)
+	_, err := rand.Read(randomBytes)
+	if err != nil {
+		panic(err)
+	}
+	return common.BytesToHash(randomBytes)
+}
+
 func ToShardedHash(h common.Hash, shardId ShardId) common.Hash {
 	raw := h
 	setShardId(raw[:], shardId)

--- a/nil/internal/types/bitflags.go
+++ b/nil/internal/types/bitflags.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"fmt"
 	"unsafe"
 
 	"golang.org/x/exp/constraints"
@@ -25,6 +26,18 @@ func (b BitFlags[T]) Set(i int, v bool) BitFlags[T] {
 		b.ClearBit(i)
 	}
 	return b
+}
+
+func (b *BitFlags[T]) SetRange(start, count uint) error {
+	if count == 0 {
+		return nil
+	}
+	end := start + count
+	if start >= end || end >= uint(unsafe.Sizeof(b.Bits)*8) {
+		return fmt.Errorf("invalid range: %d-%d", start, end)
+	}
+	b.Bits |= ((T(1) << (end - start)) - 1) << start
+	return nil
 }
 
 func (b *BitFlags[T]) SetBit(i int) {
@@ -54,4 +67,12 @@ func (b *BitFlags[T]) Clear() {
 
 func (b *BitFlags[T]) BitsNum() int {
 	return int(unsafe.Sizeof(b.Bits) * 8)
+}
+
+func (b *BitFlags[T]) Uint64() uint64 {
+	return uint64(b.Bits)
+}
+
+func (b *BitFlags[T]) None() bool {
+	return b.Bits == 0
 }

--- a/nil/internal/types/bitflags_test.go
+++ b/nil/internal/types/bitflags_test.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -48,6 +49,29 @@ func test[T constraints.Integer](t *testing.T) {
 			require.False(t, b2.GetBit(i))
 		}
 	}
+
+	b.Clear()
+
+	require.True(t, b.None())
+
+	err := b.SetRange(0, 5)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0x1f), b.Uint64())
+
+	b.Clear()
+	err = b.SetRange(4, 3)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0x70), b.Uint64())
+
+	b.Clear()
+	err = b.SetRange(0, 0)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), b.Uint64())
+
+	err = b.SetRange(math.MaxUint64, 5)
+	require.Error(t, err)
+	err = b.SetRange(1, uint(bitSize))
+	require.Error(t, err)
 }
 
 func TestBitFlags(t *testing.T) {

--- a/nil/services/cliservice/faucet.go
+++ b/nil/services/cliservice/faucet.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/NilFoundation/nil/nil/common"
 	"github.com/NilFoundation/nil/nil/common/check"
-	"github.com/NilFoundation/nil/nil/common/concurrent"
 	"github.com/NilFoundation/nil/nil/common/logging"
 	"github.com/NilFoundation/nil/nil/internal/contracts"
 	"github.com/NilFoundation/nil/nil/internal/types"
@@ -95,7 +94,7 @@ func (s *Service) waitForReceiptCommon(
 	txnHash common.Hash,
 	check func(receipt *jsonrpc.RPCReceipt) bool,
 ) (*jsonrpc.RPCReceipt, error) {
-	receipt, err := concurrent.WaitFor(
+	receipt, err := common.WaitForValue(
 		s.ctx,
 		ReceiptWaitFor,
 		ReceiptWaitTick,

--- a/nil/services/nilservice/service.go
+++ b/nil/services/nilservice/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"os/signal"
 	"slices"
 	"sync"
@@ -568,6 +569,7 @@ func Run(
 
 	node, err := CreateNode(ctx, "nil", cfg, database, interop, workers...)
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create node: %s", err.Error())
 		return 1
 	}
 	defer node.Close(ctx)

--- a/nil/services/rpc/rawapi/local_call.go
+++ b/nil/services/rpc/rawapi/local_call.go
@@ -191,6 +191,7 @@ func (api *LocalShardApi) Call(
 	es, err := execution.NewExecutionState(tx, shardId, execution.StateParams{
 		Block:          block,
 		ConfigAccessor: configAccessor,
+		Mode:           execution.ModeReadOnly,
 	})
 	if err != nil {
 		return nil, err
@@ -246,6 +247,7 @@ func (api *LocalShardApi) Call(
 	esOld, err := execution.NewExecutionState(tx, shardId, execution.StateParams{
 		Block:          block,
 		ConfigAccessor: config.GetStubAccessor(),
+		Mode:           execution.ModeReadOnly,
 	})
 	if err != nil {
 		return nil, err

--- a/nil/services/stresser/core/contract.go
+++ b/nil/services/stresser/core/contract.go
@@ -1,0 +1,24 @@
+package core
+
+import (
+	"github.com/NilFoundation/nil/nil/internal/abi"
+	"github.com/NilFoundation/nil/nil/internal/contracts"
+	"github.com/NilFoundation/nil/nil/internal/types"
+)
+
+type Contract struct {
+	Address types.Address
+	Abi     *abi.ABI
+}
+
+func NewContract(name string, address types.Address) (*Contract, error) {
+	abi, err := contracts.GetAbi(name)
+	if err != nil {
+		return nil, err
+	}
+	return &Contract{Abi: abi, Address: address}, nil
+}
+
+func (c *Contract) PackCallData(method string, args ...any) ([]byte, error) {
+	return c.Abi.Pack(method, args...)
+}

--- a/nil/services/stresser/core/helper.go
+++ b/nil/services/stresser/core/helper.go
@@ -1,0 +1,151 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/NilFoundation/nil/nil/client"
+	"github.com/NilFoundation/nil/nil/client/rpc"
+	"github.com/NilFoundation/nil/nil/common"
+	"github.com/NilFoundation/nil/nil/common/logging"
+	"github.com/NilFoundation/nil/nil/internal/contracts"
+	"github.com/NilFoundation/nil/nil/internal/types"
+	"github.com/NilFoundation/nil/nil/services/faucet"
+	"github.com/NilFoundation/nil/nil/services/rpc/jsonrpc"
+	"github.com/rs/zerolog"
+)
+
+type Helper struct {
+	ctx    context.Context
+	Client client.Client
+	faucet *faucet.Client
+	logger logging.Logger
+}
+
+func NewHelper(ctx context.Context, endpoint string) (*Helper, error) {
+	c := &Helper{ctx: ctx}
+	rpcLogger := logging.NewLogger("rpc").Level(zerolog.DebugLevel)
+	c.Client = rpc.NewClient(endpoint, rpcLogger)
+	if c.Client == nil {
+		return nil, errors.New("failed to create rpc client")
+	}
+	c.faucet = faucet.NewClient(endpoint)
+	if c.faucet == nil {
+		return nil, errors.New("failed to create faucet client")
+	}
+
+	c.logger = logging.NewLogger("client")
+
+	return c, nil
+}
+
+func (h *Helper) WaitClusterReady(numShards int) error {
+	readyFlags := types.NewBitFlags[int64]()
+	if numShards > readyFlags.BitsNum() {
+		return fmt.Errorf("too many shards: %d", numShards)
+	}
+	if err := readyFlags.SetRange(0, uint(numShards)); err != nil {
+		return fmt.Errorf("failed to set range: %w", err)
+	}
+	err := common.WaitFor(h.ctx, time.Second*30, time.Second*2,
+		func(ctx context.Context) bool {
+			for shard := range numShards {
+				if readyFlags.GetBit(shard) {
+					if _, err := h.Client.GetBlock(ctx, types.ShardId(shard), "latest", false); err == nil {
+						readyFlags.ClearBit(shard)
+					}
+				}
+			}
+			return readyFlags.None()
+		})
+	return err
+}
+
+func (h *Helper) DeployContract(name string, shardId types.ShardId) (*Contract, error) {
+	h.logger.Debug().Msgf("Start deploying contract: %s on shard %d", name, shardId)
+
+	code, err := contracts.GetCode(name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get code for %s: %w", name, err)
+	}
+
+	payload := types.BuildDeployPayload(code, types.GenerateRandomHash())
+
+	addr := types.CreateAddress(shardId, payload)
+
+	topUpValue := types.GasToValue(10_000_000_000)
+	topUpValue = topUpValue.Mul(topUpValue)
+	if err := h.TopUp(addr, topUpValue); err != nil {
+		return nil, fmt.Errorf("failed to top up: %w", err)
+	}
+
+	tx, addr, err := h.Client.DeployExternal(h.ctx, shardId, payload, types.NewFeePackFromGas(100_000_000))
+	if err != nil {
+		return nil, fmt.Errorf("failed to deploy contract: %w", err)
+	}
+	receipt, err := common.WaitForValue[jsonrpc.RPCReceipt](h.ctx, time.Second*9, time.Millisecond*500,
+		func(ctx context.Context) (*jsonrpc.RPCReceipt, error) {
+			return h.Client.GetInTransactionReceipt(ctx, tx)
+		})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get receipt: %w", err)
+	}
+	if !receipt.Success {
+		return nil, fmt.Errorf("failed to deploy contract: %s", receipt.Status)
+	}
+
+	balance, err := h.Client.GetBalance(h.ctx, addr, "latest")
+	if err != nil {
+		h.logger.Error().Err(err).Str("addr", addr.Hex()).Msgf("Failed to get balance")
+	}
+
+	h.logger.Info().Msgf("Contract deployed at %x, balance: %s", addr.Hex(), balance)
+
+	return NewContract(name, addr)
+}
+
+type TxParams struct {
+	FeePack types.FeePack
+	Value   *types.Value
+}
+
+func (h *Helper) Call(contract *Contract, method string, params *TxParams, args ...any) (*Transaction, error) {
+	calldata, err := contract.PackCallData(method, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to pack call data: %w", err)
+	}
+	feePack := params.FeePack
+	if feePack.FeeCredit.IsZero() {
+		feePack = types.NewFeePackFromGas(1_000_000)
+	}
+	tx, err := h.Client.SendExternalTransaction(h.ctx, calldata, contract.Address, nil, feePack)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send external transaction: %w", err)
+	}
+
+	txn := NewTransaction(tx)
+
+	return txn, nil
+}
+
+func (h *Helper) TopUp(addr types.Address, value types.Value) error {
+	if tx, err := h.faucet.TopUpViaFaucet(types.FaucetAddress, addr, value); err != nil {
+		return fmt.Errorf("failed to top up via faucet: %w", err)
+	} else {
+		if receipt, err := h.WaitTx(tx); err != nil {
+			return fmt.Errorf("failed to get receipt during top up: %w", err)
+		} else if !receipt.Success {
+			return fmt.Errorf("failed to top up via faucet: %s", receipt.Status)
+		}
+	}
+	return nil
+}
+
+func (h *Helper) WaitTx(tx common.Hash) (*jsonrpc.RPCReceipt, error) {
+	return common.WaitForValue[jsonrpc.RPCReceipt](h.ctx, time.Second*3, time.Millisecond*500,
+		func(ctx context.Context) (*jsonrpc.RPCReceipt, error) {
+			return h.Client.GetInTransactionReceipt(ctx, tx)
+		})
+}

--- a/nil/services/stresser/core/tx.go
+++ b/nil/services/stresser/core/tx.go
@@ -1,0 +1,64 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/NilFoundation/nil/nil/common"
+	"github.com/NilFoundation/nil/nil/common/check"
+	"github.com/NilFoundation/nil/nil/services/rpc/jsonrpc"
+)
+
+var ErrTxFailed = errors.New("transaction is failed")
+
+const defaultTimeout = 15 * time.Second
+
+type Transaction struct {
+	Hash         common.Hash
+	Receipt      *jsonrpc.RPCReceipt
+	Error        error
+	StartTm      time.Time
+	ExpectedFail bool
+	Timeout      time.Duration
+}
+
+func NewTransaction(hash common.Hash) *Transaction {
+	return &Transaction{Hash: hash, StartTm: time.Now(), Timeout: defaultTimeout}
+}
+
+func (t *Transaction) CheckFinished(ctx context.Context, c *Helper) bool {
+	t.Receipt, t.Error = c.Client.GetInTransactionReceipt(ctx, t.Hash)
+	if complete := t.Error == nil && t.Receipt.IsComplete(); !complete {
+		if time.Since(t.StartTm) > t.Timeout {
+			t.Error = fmt.Errorf("transaction timed out(timeout=%fs)", t.Timeout.Seconds())
+			return true
+		}
+		return false
+	}
+	if !t.Receipt.AllSuccess() {
+		t.Error = ErrTxFailed
+	} else if t.ExpectedFail {
+		t.Error = errors.New("transaction is expected to fail")
+	}
+	return true
+}
+
+func (t *Transaction) Dump(full bool) string {
+	res := fmt.Sprintf("Tx %s\n", t.Hash.Hex())
+	txRes := "success"
+	if t.Error != nil {
+		txRes = t.Error.Error()
+	}
+	res += "  Result: " + txRes + "\n"
+	if full {
+		if t.Receipt != nil {
+			d, err := json.MarshalIndent(t.Receipt, "", "  ")
+			check.PanicIfErr(err)
+			res += string(d)
+		}
+	}
+	return res
+}

--- a/nil/services/stresser/examples/config.devnet.yaml
+++ b/nil/services/stresser/examples/config.devnet.yaml
@@ -1,0 +1,7 @@
+mode: devnet
+endpoint: http://127.0.0.1:8529
+devnetFile: ./devnet.yaml
+workingDir: ./
+nildPath: ./build/bin/nild
+numShards: 5
+workloadFile: ./workload.yaml

--- a/nil/services/stresser/examples/config.external.yaml
+++ b/nil/services/stresser/examples/config.external.yaml
@@ -1,0 +1,4 @@
+mode: external-rpc
+endpoint: http://127.0.0.1:8529
+numShards: 5
+workloadFile: ./workload.yaml

--- a/nil/services/stresser/examples/config.single_instance.yaml
+++ b/nil/services/stresser/examples/config.single_instance.yaml
@@ -1,0 +1,7 @@
+mode: single-instance
+endpoint: http://127.0.0.1:8529
+rpcPort: 8529
+workingDir: ./
+nildPath: ./build/bin/nild
+numShards: 5
+workloadFile: ./workload.yaml

--- a/nil/services/stresser/examples/devnet.yaml
+++ b/nil/services/stresser/examples/devnet.yaml
@@ -1,0 +1,26 @@
+nil_server_name: stresser
+nild_config_dir: "Path to cluster working dir"
+nild_credentials_dir: "Path to cluster working dir"
+nild_p2p_base_tcp_port: 30303
+nil_wipe_on_update: true
+nShards: 5
+nil_rpc_host: 127.0.0.1
+nil_rpc_port: 8529
+nil_rpc_enable_on_validators: false
+clickhouse_host: 127.0.0.1
+clickhouse_port: 9000
+clickhouse_login: nil
+clickhouse_database: nil_database
+cometa_rpc_host: 127.0.0.1
+cometa_port: 8528
+faucet_rpc_host: 127.0.0.1
+faucet_port: 8527
+instance_env: "dev"
+nil_config:
+- { id: 0, shards: [0, 1], splitShards: true, dhtBootstrapPeersIdx: [1, 2, 3] }
+- { id: 1, shards: [0, 2], splitShards: true, dhtBootstrapPeersIdx: [0, 2, 3] }
+- { id: 2, shards: [0, 3], splitShards: true, dhtBootstrapPeersIdx: [0, 1, 3] }
+- { id: 3, shards: [0, 4], splitShards: true, dhtBootstrapPeersIdx: [0, 1, 2] }
+nil_rpc_config:
+- { id: 0, dhtBootstrapPeersIdx: [0, 1, 2, 3] }
+nil_load_generators_enable: false

--- a/nil/services/stresser/examples/workload.yaml
+++ b/nil/services/stresser/examples/workload.yaml
@@ -1,0 +1,26 @@
+# This is an example of workload configuration file.
+# To see a full list of options for concrete workload, please refer to the corresponding workload source file.
+
+- name: external_tx
+  interval: 1s
+  waitTxsTimeout: 15s
+  minTxsPerIteration: 100
+  gasRange:
+    from: 10000
+    to: 5000000
+- name: send_requests
+  interval: 1s
+  waitTxsTimeout: 15s
+  gasRange:
+    from: 10000
+    to: 500000
+- name: await_call
+  interval: 2s
+  range: 100
+  ContractsNumToSend: 4
+- name: block_range
+  interval: 1s
+  range: 100
+  batchSize: 20
+- name: blockchain_metrics
+  interval: 10s

--- a/nil/services/stresser/instance.go
+++ b/nil/services/stresser/instance.go
@@ -1,0 +1,113 @@
+package stresser
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"syscall"
+
+	"github.com/NilFoundation/nil/nil/common/logging"
+)
+
+type NildInstance struct {
+	Name       string
+	IsRpc      bool
+	workingDir string
+	cmd        *exec.Cmd
+	logger     logging.Logger
+}
+
+func (n *NildInstance) Init(nildPath string, workingDir string) error {
+	n.logger = logging.NewLogger(n.Name)
+
+	n.workingDir = workingDir
+	if err := os.MkdirAll(n.workingDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create working directory: %w", err)
+	}
+
+	cfgFile := filepath.Join(n.workingDir, "nild.yaml")
+
+	cmd := "run"
+	if n.IsRpc {
+		cmd = "rpc"
+	}
+	n.cmd = exec.Command(nildPath, cmd, "--config", cfgFile, "-l", "debug", "--log-filter", "-consensus")
+	n.cmd.Dir = n.workingDir
+
+	return nil
+}
+
+func (n *NildInstance) InitSingle(nildPath string, rootDir string, rpcPort int, numShards int) error {
+	n.Name = "nil-single"
+	n.logger = logging.NewLogger("nil")
+	if rootDir == "" {
+		var err error
+		rootDir, err = os.Getwd()
+		if err != nil {
+			return fmt.Errorf("failed to get working directory: %w", err)
+		}
+	}
+
+	n.workingDir = rootDir
+	if err := os.MkdirAll(n.workingDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create working directory: %w", err)
+	}
+
+	n.cmd = exec.Command(nildPath, "run", "--nshards", strconv.Itoa(numShards), "--http-port", //nolint:gosec
+		strconv.Itoa(rpcPort), "-l", "debug", "--log-filter", "-consensus")
+	n.cmd.Dir = n.workingDir
+
+	return nil
+}
+
+func (n *NildInstance) Run(ctx context.Context, wg *sync.WaitGroup) error {
+	if n.cmd == nil {
+		return nil
+	}
+
+	// Set process group to allow killing the entire group
+	n.cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	wg.Add(1)
+
+	logFile, err := os.Create(filepath.Join(n.workingDir, "output.log"))
+	if err != nil {
+		return fmt.Errorf("error opening log file: %w", err)
+	}
+	n.cmd.Stdout = logFile
+	n.cmd.Stderr = logFile
+
+	if err = n.cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start process: %w", err)
+	}
+
+	exitEvent := make(chan struct{})
+
+	go func() {
+		err := n.cmd.Wait()
+		if err != nil {
+			n.logger.Error().Err(err).Int("pid", n.cmd.Process.Pid).Msg("Process exited with error")
+		} else {
+			n.logger.Info().Msg("Process exited successfully")
+		}
+		close(exitEvent)
+	}()
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			n.logger.Error().Msg("Stopping node")
+		case <-exitEvent:
+			n.logger.Info().Msg("Process has stopped")
+		}
+		wg.Done()
+	}()
+
+	n.logger.Info().Str("command", n.cmd.String()).Int("pid", n.cmd.Process.Pid).Msg("Started process")
+
+	return nil
+}

--- a/nil/services/stresser/jsonrpc.go
+++ b/nil/services/stresser/jsonrpc.go
@@ -1,0 +1,12 @@
+package stresser
+
+type StresserAPI interface {
+	New(name, config string) error
+	Remove(name string) error
+	ListStressers() ([]string, error)
+	GetStatus(name string) (string, error)
+	Stop(name string) error
+	Resume(name string) error
+}
+
+// TODO: implement

--- a/nil/services/stresser/metrics/metrics.go
+++ b/nil/services/stresser/metrics/metrics.go
@@ -1,0 +1,13 @@
+package metrics
+
+import (
+	"github.com/NilFoundation/nil/nil/internal/telemetry"
+)
+
+var (
+	Meter        = telemetry.NewMeter("stresser")
+	PendingTxNum = telemetry.Int64UpDownCounter(Meter, "pending_tx_num")
+	TotalTxNum   = telemetry.Int64Gauge(Meter, "total_tx_num")
+	FailedTxNum  = telemetry.Int64Counter(Meter, "failed_tx_num")
+	SuccessTxNum = telemetry.Int64Counter(Meter, "success_tx_num")
+)

--- a/nil/services/stresser/stresser.go
+++ b/nil/services/stresser/stresser.go
@@ -1,0 +1,459 @@
+package stresser
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/NilFoundation/nil/nil/common"
+	"github.com/NilFoundation/nil/nil/common/check"
+	"github.com/NilFoundation/nil/nil/common/concurrent"
+	"github.com/NilFoundation/nil/nil/common/logging"
+	"github.com/NilFoundation/nil/nil/internal/telemetry"
+	"github.com/NilFoundation/nil/nil/internal/types"
+	"github.com/NilFoundation/nil/nil/services/stresser/core"
+	"github.com/NilFoundation/nil/nil/services/stresser/metrics"
+	"github.com/NilFoundation/nil/nil/services/stresser/workload"
+	"golang.org/x/sync/errgroup"
+	"gopkg.in/yaml.v3"
+)
+
+var logger = logging.NewLogger("stresser")
+
+const (
+	// TODO: should be configurable
+	contractsNum     = 16
+	workloadInterval = 200 * time.Millisecond
+	pollTxInterval   = 4 * time.Second
+	maxPendingTxs    = 10000
+
+	modeSingleInstance = "single-instance"
+	modeDevnet         = "devnet"
+	modeExternal       = "external"
+)
+
+type Config struct {
+	Mode       string `yaml:"mode"`
+	NildPath   string `yaml:"nildPath"`
+	WorkingDir string `yaml:"workingDir"`
+
+	// Single instance mode params
+	RpcPort   int `yaml:"rpcPort"`
+	NumShards int `yaml:"numShards"`
+
+	// External RPC mode params
+	RpcEndpoint string `yaml:"endpoint"`
+
+	// Devnet mode params
+	DevnetFile string `yaml:"devnetFile"`
+
+	// Number of Stresser contracts to deploy at the beginning
+	ContractsNum int `yaml:"contractsNum"`
+	// Maximum transactions that can be pending (we are waiting their receipts) at the same time
+	MaxPendingTxs int `yaml:"maxPendingTxs"`
+
+	// File with workload configuration
+	WorkloadFile string `yaml:"workloadFile"`
+	// Embedded workload configuration. It has higher priority than workloadFile.
+	Workload []any `yaml:"workload"`
+}
+
+type Stresser struct {
+	cfg           *Config
+	nodes         []*NildInstance
+	client        *core.Helper
+	failedTxsFile *os.File
+	workload      []*workload.Runner
+	// This channel is used by workloads to send new transactions
+	newTxs chan []*core.Transaction
+
+	// This map contains transactions that are waiting for their receipts
+	pendingTxs      map[common.Hash]*core.Transaction
+	suspendWorkload atomic.Bool
+}
+
+func NewStresserFromFile(configFile string) (*Stresser, error) {
+	data, err := os.ReadFile(configFile)
+	if err != nil {
+		return nil, fmt.Errorf("can't read config file: %w", err)
+	}
+	return NewStresser(string(data), filepath.Dir(configFile))
+}
+
+func NewStresser(configYaml string, configPath string) (*Stresser, error) {
+	var cfg Config
+	if err := yaml.Unmarshal([]byte(configYaml), &cfg); err != nil {
+		return nil, fmt.Errorf("can't parse config: %w", err)
+	}
+
+	if cfg.NumShards <= 1 {
+		return nil, errors.New("numShards must be greater than 1")
+	}
+
+	s := &Stresser{
+		cfg:        &cfg,
+		newTxs:     make(chan []*core.Transaction),
+		pendingTxs: make(map[common.Hash]*core.Transaction),
+	}
+
+	if cfg.WorkingDir != "" {
+		if err := os.MkdirAll(cfg.WorkingDir, 0o755); err != nil {
+			return nil, fmt.Errorf("failed to make dir %s: %w", cfg.WorkingDir, err)
+		}
+	} else {
+		var err error
+		cfg.WorkingDir, err = os.Getwd()
+		if err != nil {
+			return nil, fmt.Errorf("failed to os.Getwd(): %w", err)
+		}
+	}
+
+	var rpc_endpoint string
+	switch cfg.Mode {
+	case modeSingleInstance:
+		node := &NildInstance{}
+		if err := node.InitSingle(cfg.NildPath, cfg.WorkingDir, cfg.RpcPort, cfg.NumShards); err != nil {
+			return nil, fmt.Errorf("failed to init node: %w", err)
+		}
+		s.nodes = append(s.nodes, node)
+		rpc_endpoint = fmt.Sprintf("http://127.0.0.1:%d", cfg.RpcPort)
+	case modeDevnet:
+		devnetFile := resolveFile(cfg.DevnetFile, configPath)
+		cmd := exec.Command(cfg.NildPath, "gen-configs", devnetFile, "--basedir", cfg.WorkingDir) //nolint:gosec
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return nil, fmt.Errorf("failed to generate devnet config: %w\n %s", err, out)
+		}
+
+		if err := s.loadDevnetConfig(devnetFile); err != nil {
+			return nil, fmt.Errorf("failed to load devnet config: %w", err)
+		}
+
+		for _, node := range s.nodes {
+			nodeDir := filepath.Join(cfg.WorkingDir, node.Name)
+			if err := node.Init(cfg.NildPath, nodeDir); err != nil {
+				return nil, fmt.Errorf("failed to init node: %w", err)
+			}
+		}
+		rpc_endpoint = fmt.Sprintf("http://127.0.0.1:%d", cfg.RpcPort)
+	case modeExternal:
+		var err error
+		s.client, err = core.NewHelper(context.Background(), cfg.RpcEndpoint)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create client: %w", err)
+		}
+		rpc_endpoint = cfg.RpcEndpoint
+	default:
+		return nil, fmt.Errorf("unknown mode: %s", cfg.Mode)
+	}
+
+	var err error
+	s.client, err = core.NewHelper(context.Background(), rpc_endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client: %w", err)
+	}
+
+	// Create a file for failed transactions dumps
+	s.failedTxsFile, err = os.OpenFile(path.Join(cfg.WorkingDir, "failed_txs.txt"),
+		os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create failed_txs.txt file: %w", err)
+	}
+	logger.Info().Msgf("Failed transactions will be saved to %s", s.failedTxsFile.Name())
+
+	// Init workload
+	switch {
+	case len(s.cfg.Workload) != 0:
+		if err = s.readWorkloadYaml(s.cfg.Workload); err != nil {
+			return nil, fmt.Errorf("failed to read workload yaml: %w", err)
+		}
+	case s.cfg.WorkloadFile != "":
+		data, err := os.ReadFile(resolveFile(s.cfg.WorkloadFile, configPath))
+		if err != nil {
+			return nil, fmt.Errorf("failed to read workload file: %w", err)
+		}
+		var workload []any
+		err = yaml.Unmarshal(data, &workload)
+		if err != nil {
+			return nil, fmt.Errorf("can't unmarshal workload file: %w", err)
+		}
+		if err = s.readWorkloadYaml(workload); err != nil {
+			return nil, fmt.Errorf("failed to read workload yaml: %w", err)
+		}
+	default:
+		logger.Warn().Msg("Running without workload")
+	}
+
+	// Init telemetry
+	telemetryCfg := telemetry.NewDefaultConfig()
+	telemetryCfg.ExportMetrics = true
+	if err := telemetry.Init(context.Background(), telemetryCfg); err != nil {
+		return nil, fmt.Errorf("failed to init telemetry: %w", err)
+	}
+
+	return s, nil
+}
+
+func (s *Stresser) Run(ctx context.Context) error {
+	ctx, cancelFn := context.WithCancel(ctx)
+	defer cancelFn()
+
+	logger.Info().Msg("Starting stresser")
+
+	wg := &sync.WaitGroup{}
+
+	ctx, cancel := signal.NotifyContext(ctx, syscall.SIGTERM, syscall.SIGINT, syscall.SIGSEGV)
+	defer func() {
+		cancel()
+	}()
+
+	for _, node := range s.nodes {
+		if err := node.Run(ctx, wg); err != nil {
+			return fmt.Errorf("failed to run node %s", node.Name)
+		}
+	}
+
+	logger.Info().Msgf("%d nodes started", len(s.nodes))
+
+	exitChan := make(chan struct{})
+	go func() {
+		if err := s.runWorkload(ctx); err != nil {
+			logger.Error().Err(err).Msg("workload returns error")
+		}
+		close(exitChan)
+	}()
+
+	if len(s.nodes) != 0 {
+		go func() {
+			wg.Wait()
+			logger.Info().Msg("All nodes are stopped")
+		}()
+	}
+
+	select {
+	case <-ctx.Done():
+	case <-exitChan:
+	}
+
+	s.killAll()
+
+	return nil
+}
+
+func (s *Stresser) runWorkload(ctx context.Context) error {
+	defer func() {
+		if recResult := recover(); recResult != nil {
+			s.killAll()
+			panic(recResult)
+		}
+	}()
+
+	logger.Info().Int("workloads_num", len(s.workload)).Msg("Starting workload")
+
+	logger.Info().Int("num_shards", s.cfg.NumShards).Msg("Waiting for cluster ready...")
+	if err := s.client.WaitClusterReady(s.cfg.NumShards); err != nil {
+		return fmt.Errorf("failed to wait for rpc node: %w", err)
+	}
+
+	contracts, err := s.deployContracts()
+	if err != nil {
+		return fmt.Errorf("failed to deploy contracts: %w", err)
+	}
+
+	workloadArgs := &workload.WorkloadParams{Contracts: contracts, NumShards: s.cfg.NumShards}
+
+	for _, w := range s.workload {
+		if err := w.Workload.Init(ctx, s.client, workloadArgs); err != nil {
+			return fmt.Errorf("failed to init workload: %w", err)
+		}
+		if err := w.StartMainLoop(ctx); err != nil {
+			return fmt.Errorf("failed to run workload runner: %w", err)
+		}
+	}
+
+	go s.updateState(ctx)
+
+	tm := time.Now()
+	iteration := 0
+	concurrent.RunTickerLoop(ctx, workloadInterval, func(ctx context.Context) {
+		if s.suspendWorkload.Load() {
+			return
+		}
+		if time.Since(tm) >= 1*time.Second {
+			tm = time.Now()
+		}
+		iteration += 1
+
+		for _, w := range s.workload {
+			if err := w.RunWorkload(workload.RunParams{}); err != nil {
+				logger.Error().Err(err).Msg("failed run workload")
+			}
+		}
+	})
+	return nil
+}
+
+func (s *Stresser) updateState(ctx context.Context) {
+	ticker := time.NewTicker(pollTxInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.checkTransactions(ctx)
+		case txs := <-s.newTxs:
+			for _, tx := range txs {
+				s.pendingTxs[tx.Hash] = tx
+			}
+			if len(s.pendingTxs) > maxPendingTxs {
+				s.suspendWorkload.Store(true)
+			}
+		}
+	}
+}
+
+func (s *Stresser) checkTransactions(ctx context.Context) {
+	totalTxsNum := 0
+	for _, w := range s.workload {
+		totalTxsNum += w.Workload.TotalTxsNum()
+	}
+
+	if len(s.pendingTxs) == 0 {
+		return
+	}
+
+	successTxsNum := 0
+	failedTxsNum := 0
+
+	prevPendingTxs := len(s.pendingTxs)
+
+	for _, tx := range s.pendingTxs {
+		if tx.CheckFinished(ctx, s.client) {
+			if tx.Error == nil {
+				successTxsNum++
+			} else {
+				failedTxsNum++
+				_, err := s.failedTxsFile.WriteString(tx.Dump(true))
+				check.PanicIfErr(err)
+			}
+			delete(s.pendingTxs, tx.Hash)
+		}
+	}
+	logger.Info().Msgf("Transactions: total=%d, pending=%d, success=%d, failed=%d", totalTxsNum,
+		len(s.pendingTxs), successTxsNum, failedTxsNum)
+
+	metrics.PendingTxNum.Add(ctx, int64(len(s.pendingTxs)-prevPendingTxs))
+	metrics.TotalTxNum.Record(ctx, int64(totalTxsNum))
+	metrics.SuccessTxNum.Add(ctx, int64(successTxsNum))
+	metrics.FailedTxNum.Add(ctx, int64(failedTxsNum))
+}
+
+func (s *Stresser) readWorkloadYaml(workloadList []any) error {
+	for _, wAny := range workloadList {
+		wMap, ok := wAny.(map[string]any)
+		if !ok {
+			return errors.New("can't parse node")
+		}
+		data, err := yaml.Marshal(wAny)
+		if err != nil {
+			return fmt.Errorf("can't marshal workload: %w", err)
+		}
+		name, ok := wMap["name"].(string)
+		if !ok {
+			return errors.New("can't parse name")
+		}
+		wd, err := workload.GetWorkload(name)
+		if err != nil {
+			return fmt.Errorf("can't get workload: %w", err)
+		}
+		if err = yaml.Unmarshal(data, wd); err != nil {
+			return fmt.Errorf("can't unmarshal %s: %w", name, err)
+		}
+		s.workload = append(s.workload, workload.NewRunner(wd, s.newTxs))
+	}
+	return nil
+}
+
+func (s *Stresser) loadDevnetConfig(file string) error {
+	data, err := os.ReadFile(file)
+	if err != nil {
+		return fmt.Errorf("can't read devnet file: %w", err)
+	}
+	cfg := make(map[string]any)
+
+	err = yaml.Unmarshal(data, cfg)
+	if err != nil {
+		return fmt.Errorf("devnet unmashal error: %w", err)
+	}
+	m, ok := cfg["nil_config"].([]any)
+	if !ok {
+		return errors.New("can't parse nil_config")
+	}
+	s.nodes = make([]*NildInstance, 0, len(m)+1)
+	for i := range m {
+		node := &NildInstance{Name: fmt.Sprintf("nil-%d", i)}
+		s.nodes = append(s.nodes, node)
+	}
+	node := &NildInstance{Name: "nil-rpc-0", IsRpc: true}
+	s.nodes = append(s.nodes, node)
+
+	s.cfg.RpcPort, ok = cfg["nil_rpc_port"].(int)
+	if !ok {
+		return errors.New("can't parse nil_rpc_port")
+	}
+	return nil
+}
+
+func (s *Stresser) killAll() {
+	for _, node := range s.nodes {
+		if node.cmd.ProcessState != nil && node.cmd.ProcessState.Exited() {
+			continue
+		}
+		if err := node.cmd.Process.Kill(); err != nil {
+			logger.Error().Err(err).Msg("failed to kill node")
+		}
+	}
+}
+
+func (s *Stresser) deployContracts() ([]*core.Contract, error) {
+	contracts := make([]*core.Contract, contractsNum)
+
+	var g errgroup.Group
+
+	for i := range contractsNum {
+		shardId := i%(s.cfg.NumShards-1) + 1
+		g.Go(func() error {
+			contract, err := s.client.DeployContract("tests/Stresser", types.ShardId(shardId))
+			if err != nil {
+				logger.Error().Err(err).Msg("failed to deploy contract")
+				return err
+			}
+			contracts[i] = contract
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, fmt.Errorf("failed to deploy contracts: %w", err)
+	}
+
+	return contracts, nil
+}
+
+func resolveFile(name string, basePath string) string {
+	var fileResolved string
+	if filepath.IsAbs(name) {
+		fileResolved = name
+	} else {
+		fileResolved = path.Join(basePath, name)
+	}
+	return fileResolved
+}

--- a/nil/services/stresser/workload/await_call.go
+++ b/nil/services/stresser/workload/await_call.go
@@ -1,0 +1,53 @@
+package workload
+
+import (
+	"context"
+	"math/rand"
+
+	"github.com/NilFoundation/nil/nil/common/logging"
+	"github.com/NilFoundation/nil/nil/internal/types"
+	"github.com/NilFoundation/nil/nil/services/stresser/core"
+)
+
+// AwaitCall is a workload that calculates factorial by recursively calling factorial function via awaitCall.
+// It is quite expensive since it produces a lot of transactions. The intensity of the workload can be controlled
+// by setting N and ContractsNumToSend to a smaller value.
+type AwaitCall struct {
+	WorkloadBase       `yaml:",inline"`
+	N                  uint32 `yaml:"n"`                  // Depth of the factorial
+	ContractsNumToSend int    `yaml:"contractsNumToSend"` // Number of contracts to send transactions to
+}
+
+func (w *AwaitCall) Init(ctx context.Context, client *core.Helper, args *WorkloadParams) error {
+	w.WorkloadBase.Init(ctx, client, args)
+	if w.ContractsNumToSend > len(args.Contracts) {
+		w.ContractsNumToSend = len(args.Contracts)
+	}
+	w.logger = logging.NewLogger("await_call")
+	return nil
+}
+
+func (w *AwaitCall) Run(ctx context.Context, args *RunParams) ([]*core.Transaction, error) {
+	options := &core.TxParams{FeePack: types.NewFeePackFromGas(100_000_000)}
+	contractsNumToSend := w.ContractsNumToSend
+	start := 0
+	if contractsNumToSend < len(w.params.Contracts) {
+		start = rand.Intn(len(w.params.Contracts) - contractsNumToSend) //nolint:gosec
+	}
+
+	for i, contract := range w.params.Contracts[start : start+contractsNumToSend] {
+		var peer types.Address
+		if i == 0 {
+			peer = w.params.Contracts[len(w.params.Contracts)-1].Address
+		} else {
+			peer = w.params.Contracts[i-1].Address
+		}
+
+		if tx, err := w.client.Call(contract, "factorialAwait", options, w.N, peer); err != nil {
+			w.logger.Error().Err(err).Msg("failed to call factorialAwait")
+		} else {
+			w.AddTx(tx)
+		}
+	}
+	return w.txs, nil
+}

--- a/nil/services/stresser/workload/block_range.go
+++ b/nil/services/stresser/workload/block_range.go
@@ -1,0 +1,56 @@
+package workload
+
+import (
+	"context"
+
+	"github.com/NilFoundation/nil/nil/common/logging"
+	"github.com/NilFoundation/nil/nil/internal/types"
+	"github.com/NilFoundation/nil/nil/services/stresser/core"
+)
+
+const (
+	defaultBlockRange = 100
+	defaultBatchSize  = 20
+)
+
+type BlockRange struct {
+	WorkloadBase `yaml:",inline"`
+	Range        int `yaml:"range"`
+	BatchSize    int `yaml:"batchSize"`
+}
+
+func (w *BlockRange) Init(ctx context.Context, client *core.Helper, args *WorkloadParams) error {
+	w.WorkloadBase.Init(ctx, client, args)
+	if w.Range == 0 {
+		w.Range = defaultBlockRange
+	}
+	if w.BatchSize == 0 {
+		w.BatchSize = defaultBatchSize
+	}
+	w.logger = logging.NewLogger("block_range")
+	return nil
+}
+
+func (w *BlockRange) Run(ctx context.Context, args *RunParams) (
+	[]*core.Transaction, error,
+) {
+	for shard := range w.params.NumShards {
+		block, err := w.client.Client.GetBlock(ctx, types.ShardId(shard), "latest", true)
+		if err != nil {
+			w.logger.Error().Err(err).Msg("failed to get last block")
+			continue
+		}
+		startBlock := types.BlockNumber(0)
+		endBlockNumber := block.Number + 1
+		if endBlockNumber-startBlock > types.BlockNumber(w.Range) {
+			startBlock = endBlockNumber - types.BlockNumber(w.Range)
+		}
+		_, err = w.client.Client.GetBlocksRange(ctx, types.ShardId(shard), startBlock, block.Number, true, w.BatchSize)
+		if err != nil {
+			w.logger.Error().Err(err).Msg("failed to get block range")
+			continue
+		}
+	}
+
+	return w.txs, nil
+}

--- a/nil/services/stresser/workload/blockchain_metrics.go
+++ b/nil/services/stresser/workload/blockchain_metrics.go
@@ -1,0 +1,101 @@
+package workload
+
+import (
+	"context"
+
+	"github.com/NilFoundation/nil/nil/internal/telemetry"
+	"github.com/NilFoundation/nil/nil/internal/telemetry/telattr"
+	"github.com/NilFoundation/nil/nil/internal/types"
+	"github.com/NilFoundation/nil/nil/services/stresser/core"
+	"go.opentelemetry.io/otel/metric"
+)
+
+const (
+	batchSize = 20
+)
+
+var (
+	meter               = telemetry.NewMeter("stresser")
+	blockTxsNum         = telemetry.Int64Gauge(meter, "block_txs_num")
+	blockExternalTxsNum = telemetry.Int64Gauge(meter, "block_external_txs_num")
+	blockInternalTxsNum = telemetry.Int64Gauge(meter, "block_internal_txs_num")
+	blockResponseTxsNum = telemetry.Int64Gauge(meter, "block_response_txs_num")
+	blockRefundTxsNum   = telemetry.Int64Gauge(meter, "block_refund_txs_num")
+	blockBaseFee        = telemetry.Int64Gauge(meter, "block_base_fee")
+)
+
+// BlockchainMetrics is a workload that collects metrics about the blockchain.
+// It uses GetBlock and GetBlocksRange to get the latest block and a range of blocks.
+type BlockchainMetrics struct {
+	WorkloadBase `yaml:",inline"`
+	lastBlocks   []types.BlockNumber
+	options      []metric.MeasurementOption
+}
+
+type BlockInfo struct {
+	Block *types.Block
+	Tps   float64
+}
+
+func (w *BlockchainMetrics) Init(ctx context.Context, client *core.Helper, args *WorkloadParams) error {
+	w.WorkloadBase.Init(ctx, client, args)
+	for shardId := range args.NumShards {
+		w.options = append(w.options, telattr.With(telattr.ShardId(types.ShardId(shardId))))
+	}
+	w.lastBlocks = make([]types.BlockNumber, args.NumShards)
+	return nil
+}
+
+func (w *BlockchainMetrics) Run(ctx context.Context, args *RunParams) ([]*core.Transaction, error) {
+	for shard := range w.params.NumShards {
+		block, err := w.client.Client.GetBlock(ctx, types.ShardId(shard), "latest", true)
+		if err != nil {
+			w.logger.Error().Err(err).Msg("failed to get last block")
+			continue
+		}
+		if w.lastBlocks[shard] == 0 {
+			w.lastBlocks[shard] = block.Number
+			continue
+		}
+		if block != nil && w.lastBlocks[shard] == block.Number {
+			continue
+		}
+		blocks, err := w.client.Client.GetBlocksRange(ctx, types.ShardId(shard), w.lastBlocks[shard], block.Number-1,
+			true, batchSize)
+		if err != nil {
+			w.logger.Error().Err(err).Msg("failed to get block range")
+			continue
+		}
+		blocks = append(blocks, block)
+		w.lastBlocks[shard] = block.Number
+
+		for _, b := range blocks {
+			externalTxsNum := int64(0)
+			internalTxsNum := int64(0)
+			responseTxsNum := int64(0)
+			refundTxsNum := int64(0)
+
+			for _, tx := range b.Transactions {
+				if tx.Flags.IsInternal() {
+					internalTxsNum++
+				} else {
+					externalTxsNum++
+				}
+				if tx.Flags.IsResponse() {
+					responseTxsNum++
+				}
+				if tx.Flags.IsRefund() {
+					refundTxsNum++
+				}
+			}
+			blockTxsNum.Record(ctx, int64(len(b.Transactions)), w.options[b.ShardId])
+			blockExternalTxsNum.Record(ctx, externalTxsNum, w.options[b.ShardId])
+			blockInternalTxsNum.Record(ctx, internalTxsNum, w.options[b.ShardId])
+			blockResponseTxsNum.Record(ctx, responseTxsNum, w.options[b.ShardId])
+			blockRefundTxsNum.Record(ctx, refundTxsNum, w.options[b.ShardId])
+			blockBaseFee.Record(ctx, int64(b.BaseFee.Uint64()), w.options[b.ShardId])
+		}
+	}
+
+	return nil, nil
+}

--- a/nil/services/stresser/workload/external_tx.go
+++ b/nil/services/stresser/workload/external_tx.go
@@ -1,0 +1,52 @@
+package workload
+
+import (
+	"context"
+	"errors"
+	"math/big"
+
+	"github.com/NilFoundation/nil/nil/common/logging"
+	"github.com/NilFoundation/nil/nil/internal/types"
+	"github.com/NilFoundation/nil/nil/services/stresser/core"
+)
+
+// ExternalTxs workload sends single external transactions to the network.
+// Range specifies how many gas transactions will consume. It will be randomly selected between From and To.
+// MinTxsPerIteration specifies the minimum number of transactions to be sent in one iteration.
+type ExternalTxs struct {
+	WorkloadBase       `yaml:",inline"`
+	GasRange           Range `yaml:"gasRange"`
+	MinTxsPerIteration int   `yaml:"minTxsPerIteration"`
+}
+
+// getNumForGasConsumer calculates the number of iterations (n parameter of `gasConsumer` contract method) for the
+// given gas. 529 was calculated experimentally.
+func getNumForGasConsumer(gas uint64) uint64 {
+	return gas / 529
+}
+
+func (w *ExternalTxs) Init(ctx context.Context, client *core.Helper, params *WorkloadParams) error {
+	w.WorkloadBase.Init(ctx, client, params)
+	if w.GasRange.To < w.GasRange.From {
+		return errors.New("GasRange.From should be less than GasRange.To")
+	}
+	w.logger = logging.NewLogger("external_tx")
+	return nil
+}
+
+func (w *ExternalTxs) Run(ctx context.Context, args *RunParams) ([]*core.Transaction, error) {
+	options := &core.TxParams{FeePack: types.NewFeePackFromGas(100_000_000)}
+	sentTxNum := 0
+	for sentTxNum < w.MinTxsPerIteration {
+		for _, contract := range w.params.Contracts {
+			n := getNumForGasConsumer(w.GasRange.RandomValue())
+			if tx, err := w.client.Call(contract, "gasConsumer", options, big.NewInt(int64(n))); err != nil {
+				w.logger.Error().Err(err).Msg("failed to call contract")
+			} else {
+				w.AddTx(tx)
+			}
+			sentTxNum++
+		}
+	}
+	return w.txs, nil
+}

--- a/nil/services/stresser/workload/runner.go
+++ b/nil/services/stresser/workload/runner.go
@@ -1,0 +1,56 @@
+package workload
+
+import (
+	"context"
+
+	"github.com/NilFoundation/nil/nil/common/logging"
+	"github.com/NilFoundation/nil/nil/services/stresser/core"
+)
+
+type Runner struct {
+	Workload Workload
+	tasks    chan RunParams
+	newTxs   chan<- []*core.Transaction
+	logger   logging.Logger
+}
+
+func NewRunner(workload Workload, newTxs chan<- []*core.Transaction) *Runner {
+	r := &Runner{
+		Workload: workload,
+		newTxs:   newTxs,
+		tasks:    make(chan RunParams),
+		logger:   logging.NewLogger("runner"),
+	}
+	return r
+}
+
+func (r *Runner) StartMainLoop(ctx context.Context) error {
+	go r.MainLoop(ctx)
+	return nil
+}
+
+func (r *Runner) RunWorkload(params RunParams) error {
+	if r.Workload.CheckIsReady() {
+		r.tasks <- params
+	}
+	return nil
+}
+
+func (r *Runner) MainLoop(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case p := <-r.tasks:
+			r.Workload.PreRun(ctx, &p)
+			txs, err := r.Workload.Run(ctx, &p)
+			if err != nil {
+				r.logger.Error().Err(err).Msg("Error running workload")
+				return
+			}
+			if len(txs) > 0 {
+				r.newTxs <- txs
+			}
+		}
+	}
+}

--- a/nil/services/stresser/workload/send_requests.go
+++ b/nil/services/stresser/workload/send_requests.go
@@ -1,0 +1,41 @@
+package workload
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/NilFoundation/nil/nil/common/logging"
+	"github.com/NilFoundation/nil/nil/internal/types"
+	"github.com/NilFoundation/nil/nil/services/stresser/core"
+)
+
+type SendRequests struct {
+	WorkloadBase `yaml:",inline"`
+	GasRange     Range `yaml:"gasRange"`
+	RequestsNum  int   `yaml:"requestsNum"`
+	addresses    []types.Address
+}
+
+func (w *SendRequests) Init(ctx context.Context, client *core.Helper, args *WorkloadParams) error {
+	w.WorkloadBase.Init(ctx, client, args)
+	w.addresses = make([]types.Address, 0, w.RequestsNum)
+	for _, cntr := range args.Contracts {
+		w.addresses = append(w.addresses, cntr.Address)
+	}
+	w.logger = logging.NewLogger("send_requests")
+	return nil
+}
+
+func (w *SendRequests) Run(ctx context.Context, args *RunParams) ([]*core.Transaction, error) {
+	params := &core.TxParams{FeePack: types.NewFeePackFromGas(100_000_000)}
+	for _, contract := range w.params.Contracts {
+		n := getNumForGasConsumer(w.GasRange.RandomValue())
+		tx, err := w.client.Call(contract, "sendRequests", params, w.addresses, big.NewInt(int64(n)))
+		if err != nil {
+			w.logger.Error().Err(err).Msg("failed to call sendRequests")
+		} else {
+			w.AddTx(tx)
+		}
+	}
+	return w.txs, nil
+}

--- a/nil/services/stresser/workload/workload.go
+++ b/nil/services/stresser/workload/workload.go
@@ -1,0 +1,117 @@
+package workload
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sync/atomic"
+	"time"
+
+	"github.com/NilFoundation/nil/nil/common/check"
+	"github.com/NilFoundation/nil/nil/common/logging"
+	"github.com/NilFoundation/nil/nil/services/stresser/core"
+)
+
+type Workload interface {
+	Init(ctx context.Context, client *core.Helper, args *WorkloadParams) error
+	PreRun(ctx context.Context, args *RunParams)
+	Run(ctx context.Context, args *RunParams) ([]*core.Transaction, error)
+	TotalTxsNum() int
+	CheckIsReady() bool
+}
+
+type WorkloadBase struct {
+	Interval       time.Duration `yaml:"interval"`
+	WaitTxsTimeout time.Duration `yaml:"waitTxsTimeout"`
+
+	params WorkloadParams
+	// Time of the workload last start, used to calculate the interval.
+	lastStartTm time.Time
+	// List of created transactions on each run. We can use local array and return it on each run, but we also need
+	// to take into account that we don't need to add transactions if WaitTxsTimeout!=0. Now it is checked in one place
+	// instead of checking it in each workload.
+	txs []*core.Transaction
+	// Total number of transactions sent by the workload
+	totalTxsNum atomic.Int64
+
+	client *core.Helper
+	logger logging.Logger
+}
+
+type RunParams struct{}
+
+type WorkloadParams struct {
+	Contracts []*core.Contract
+	NumShards int
+}
+
+func (w *WorkloadBase) Init(ctx context.Context, client *core.Helper, args *WorkloadParams) {
+	w.client = client
+	w.params = *args
+	w.lastStartTm = time.Now()
+}
+
+func (w *WorkloadBase) PreRun(ctx context.Context, args *RunParams) {
+	w.txs = nil
+}
+
+func (w *WorkloadBase) CheckIsReady() bool {
+	res := time.Since(w.lastStartTm) >= w.Interval
+	if res {
+		w.lastStartTm = time.Now()
+	}
+	return res
+}
+
+func (w *WorkloadBase) AddTx(tx *core.Transaction) {
+	if w.shouldWaitTx() {
+		tx.Timeout = w.WaitTxsTimeout
+		w.txs = append(w.txs, tx)
+	}
+	w.totalTxsNum.Add(1)
+}
+
+func (w *WorkloadBase) TotalTxsNum() int {
+	return int(w.totalTxsNum.Load())
+}
+
+func (w *WorkloadBase) shouldWaitTx() bool {
+	return w.WaitTxsTimeout > 0
+}
+
+func GetWorkload(name string) (Workload, error) {
+	var wd Workload
+	switch name {
+	case "external_tx":
+		wd = &ExternalTxs{}
+	case "await_call":
+		wd = &AwaitCall{}
+	case "block_range":
+		wd = &BlockRange{}
+	case "send_requests":
+		wd = &SendRequests{}
+	case "blockchain_metrics":
+		wd = &BlockchainMetrics{}
+	default:
+		return nil, fmt.Errorf("unknown workload name: %s", name)
+	}
+	return wd, nil
+}
+
+type Range struct {
+	From, To uint64
+}
+
+func NewGasRange(from, to uint64) Range {
+	check.PanicIfNotf(to > from, "GasRange.From should be less than GasRange.To")
+	return Range{From: from, To: to}
+}
+
+func (r Range) RandomValue() uint64 {
+	gas := r.From
+	if r.To != r.From {
+		v := rand.Intn(int(r.To - r.From)) //nolint:gosec
+		gas = uint64(v) + r.From
+	}
+	return gas
+}

--- a/nil/services/synccommittee/internal/rollupcontract/wrapper.go
+++ b/nil/services/synccommittee/internal/rollupcontract/wrapper.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/NilFoundation/nil/nil/common"
-	"github.com/NilFoundation/nil/nil/common/concurrent"
 	"github.com/NilFoundation/nil/nil/common/logging"
 	ethereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -131,7 +130,7 @@ func (r *Wrapper) WaitForReceipt(ctx context.Context, txnHash ethcommon.Hash) (*
 		ReceiptWaitFor  = 30 * time.Second
 		ReceiptWaitTick = 500 * time.Millisecond
 	)
-	return concurrent.WaitFor(
+	return common.WaitForValue(
 		ctx,
 		ReceiptWaitFor,
 		ReceiptWaitTick,

--- a/nil/services/synccommittee/prover/tracer/internal/mpttracer/account.go
+++ b/nil/services/synccommittee/prover/tracer/internal/mpttracer/account.go
@@ -2,6 +2,7 @@ package mpttracer
 
 import (
 	"github.com/NilFoundation/nil/nil/common"
+	"github.com/NilFoundation/nil/nil/common/logging"
 	"github.com/NilFoundation/nil/nil/internal/execution"
 	"github.com/NilFoundation/nil/nil/internal/mpt"
 	"github.com/NilFoundation/nil/nil/internal/types"
@@ -18,7 +19,7 @@ func NewTracerAccount(
 	addr types.Address,
 	account *types.SmartContract,
 ) (*TracerAccount, error) {
-	as, err := execution.NewAccountState(es, addr, account)
+	as, err := execution.NewAccountState(es, addr, account, logging.NewLogger("mpttracer"))
 	if err != nil {
 		return nil, err
 	}

--- a/nil/services/txnpool/txnpool.go
+++ b/nil/services/txnpool/txnpool.go
@@ -166,6 +166,7 @@ func (p *TxnPool) add(txns ...*metaTxn) ([]DiscardReason, error) {
 			Uint64(logging.FieldShardId, uint64(txn.To.ShardId())).
 			Stringer(logging.FieldTransactionHash, txn.Hash()).
 			Stringer(logging.FieldTransactionTo, txn.To).
+			Int("total", p.all.tree.Len()).
 			Msg("Added new transaction.")
 	}
 


### PR DESCRIPTION
Stresser service is a service which spams transactions to a target cluster. Type of transactions and their intensity can be customized in configuration.
At the moment, the following workloads are supported:
- External transactions with adjustable gas consumption.
- Request/response transactions (sendRequest)
- `awaitCall` transactions
- `getBlockRange` RPC requests
- blockchain metric collector - auxiliary workload that fetches blocks from the blockchain and emits metrics about it

Stresser can run in three modes:
- `single-instance` it runs one `nild` binary with all validators and rpc node inside
- `devnet` run separate nodes for validators and rpc node (similar to devnet server).
- `external` runs nothing and uses a specified endpoint as a target rpc node