### PR TITLE
[GH-#] Expose BasicHost in `network.Manager`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,6 +61,7 @@ require (
 	github.com/shopspring/decimal v1.4.0
 	github.com/spf13/viper v1.20.0
 	go.dedis.ch/kyber/v3 v3.1.0
+	go.uber.org/fx v1.23.0
 	golang.org/x/term v0.30.0
 	golang.org/x/text v0.23.0
 )
@@ -231,7 +232,6 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/otel/trace v1.35.0 // indirect
 	go.uber.org/dig v1.18.1 // indirect
-	go.uber.org/fx v1.23.0 // indirect
 	go.uber.org/mock v0.5.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect

--- a/nil/internal/network/manager.go
+++ b/nil/internal/network/manager.go
@@ -13,13 +13,14 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/peerstore"
 	"github.com/libp2p/go-libp2p/core/protocol"
+	basichost "github.com/libp2p/go-libp2p/p2p/host/basic"
 )
 
 type Manager struct {
 	ctx    context.Context
 	prefix string
 
-	host   Host
+	host   *basichost.BasicHost
 	pubSub *PubSub
 	dht    *DHT
 
@@ -32,7 +33,7 @@ func ConnectToPeers(ctx context.Context, peers AddrInfoSlice, m Manager, logger 
 	connectToPeers(ctx, peers, m.host, logger)
 }
 
-func connectToPeers(ctx context.Context, peers AddrInfoSlice, h Host, logger logging.Logger) {
+func connectToPeers(ctx context.Context, peers AddrInfoSlice, h host.Host, logger logging.Logger) {
 	for _, peerInfo := range peers {
 		if h.ID() == peerInfo.ID {
 			// Skip connecting to self.
@@ -47,14 +48,14 @@ func connectToPeers(ctx context.Context, peers AddrInfoSlice, h Host, logger log
 	}
 }
 
-func connectToDhtBootstrapPeers(ctx context.Context, conf *Config, h Host, logger logging.Logger) {
+func connectToDhtBootstrapPeers(ctx context.Context, conf *Config, h host.Host, logger logging.Logger) {
 	connectToPeers(ctx, conf.DHTBootstrapPeers, h, logger)
 }
 
 func newManagerFromHost(
 	ctx context.Context,
 	conf *Config,
-	h host.Host,
+	h *basichost.BasicHost,
 	database db.DB,
 	logger logging.Logger,
 ) (*Manager, error) {

--- a/nil/internal/network/pubsub.go
+++ b/nil/internal/network/pubsub.go
@@ -10,6 +10,7 @@ import (
 	"github.com/NilFoundation/nil/nil/internal/telemetry"
 	"github.com/NilFoundation/nil/nil/internal/telemetry/telattr"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/core/host"
 )
 
 const subscriptionChannelSize = 100
@@ -49,7 +50,7 @@ type Subscription struct {
 }
 
 // newPubSub creates a new PubSub instance. It must be closed after use.
-func newPubSub(ctx context.Context, h Host, conf *Config, logger logging.Logger) (*PubSub, error) {
+func newPubSub(ctx context.Context, h host.Host, conf *Config, logger logging.Logger) (*PubSub, error) {
 	impl, err := pubsub.NewGossipSub(ctx, h)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
A small preparatory edit. I didn't find another way to access `BasicHost`, and internally libp2p uses [the same one](https://github.com/libp2p/go-libp2p/blob/a743f9f88ab0f7249d83789f34234d86b6be5b3b/config/config.go#L567-L568).
The `newtork.Host` alias wasn't used outside the module, so I removed it and left the use of external types as an implementation detail.
We need access to BasicHost, for example, to access [identify.IDService](https://github.com/libp2p/go-libp2p/blob/a743f9f88ab0f7249d83789f34234d86b6be5b3b/p2p/host/basic/basic_host.go#L529).