### PR TITLE
[rawapi] fix GetContract token and asyncContext return values

### DIFF
--- a/nil/services/rpc/rawapi/local_account.go
+++ b/nil/services/rpc/rawapi/local_account.go
@@ -168,7 +168,7 @@ func (api *LocalShardApi) GetContract(
 	}
 
 	asyncContextReader := execution.NewDbAsyncContextTrieReader(tx, address.ShardId())
-	asyncContextReader.SetRootHash(contract.TokenRoot)
+	asyncContextReader.SetRootHash(contract.AsyncContextRoot)
 	asyncContextEntries, err := asyncContextReader.Entries()
 	if err != nil {
 		return nil, err

--- a/nil/services/rpc/rawapi/proto/account.proto
+++ b/nil/services/rpc/rawapi/proto/account.proto
@@ -35,11 +35,19 @@ message TokensResponse {
   }
 }
 
+message AsyncContext {
+  bool isAwait = 1;
+  bytes data = 2;
+  uint64 responseProcessingGas = 3;
+}
+
 message RawContract {
   bytes contractSSZ = 1;
   bytes code = 2;
   bytes proofEncoded = 3;
   map<string, Uint256> storage = 4;
+  map<string, Uint256> tokens = 5;
+  map<uint64, AsyncContext> asyncContext = 6;
 }
 
 message RawContractResponse {

--- a/nil/tests/faucet/faucet_test.go
+++ b/nil/tests/faucet/faucet_test.go
@@ -207,8 +207,17 @@ func (s *SuiteFaucet) TestTopUpTokenViaFaucet() {
 	tokens, err := s.DefaultClient.GetTokens(s.Context, address, transport.LatestBlockNumber)
 	s.Require().NoError(err)
 	s.Require().Len(tokens, 4)
+
+	debugContract, err := s.DefaultClient.GetDebugContract(s.Context, address, "latest")
+	s.Require().NoError(err)
+	s.Require().Len(debugContract.Tokens, 4)
+
 	for _, faucet := range faucetsAddr {
 		curValue, ok := tokens[types.TokenId(faucet)]
+		s.Require().True(ok)
+		s.Require().Equal(value.Uint64(), curValue.Uint64())
+
+		curValue, ok = debugContract.Tokens[types.TokenId(faucet)]
 		s.Require().True(ok)
 		s.Require().Equal(value.Uint64(), curValue.Uint64())
 	}


### PR DESCRIPTION
First, these two fields were missing in protobuf converters and were always empty. Second, we used an incorrect root (token instead of async context to reading data).