### PR TITLE
relayer: transaction sender impl

### DIFF
--- a/nil/Makefile.inc
+++ b/nil/Makefile.inc
@@ -13,7 +13,8 @@ generate_mocks: \
 	$(root_db)/rwtx_generated_mock.go \
 	$(root_db)/db_generated_mock.go \
 	$(root_rollup)/l1_fetcher_generated_mock.go \
-	$(root_relayer)/gen_l1_mocks
+	$(root_relayer)/gen_l1_mocks \
+	$(root_relayer)/gen_l2_mocks
 
 $(root_client)/client_generated_mock.go: $(root_client)/client.go ssz_types
 	cd $(root_client) && go generate
@@ -32,3 +33,6 @@ $(root_rollup)/l1_fetcher_generated_mock.go: $(root_rollup)/l1_fetcher.go
 
 $(root_relayer)/gen_l1_mocks: $(root_relayer)/internal/l1/generate.go
 	cd $(root_relayer)/internal/l1 && go generate generate.go
+
+$(root_relayer)/gen_l2_mocks: $(root_relayer)/internal/l2/generate.go
+	cd $(root_relayer)/internal/l2 && go generate generate.go

--- a/nil/cmd/relayer/main.go
+++ b/nil/cmd/relayer/main.go
@@ -67,23 +67,19 @@ func execute() error {
 
 func addRunCommandFlags(runCmd *cobra.Command, cfg *Config) {
 	runCmd.Flags().StringVar(&cfg.DbPath, "db-path", "relayer.db", "path to database")
-	runCmd.Flags().StringVar(&cfg.L1ClientConfig.Endpoint, "l1-endpoint", "", "URL for ETH L1 client")
-	runCmd.Flags().DurationVar(&cfg.L1ClientConfig.Timeout,
-		"l1-timeout", time.Second, "Max timeout for ETH client to timeout")
 
+	runCmd.Flags().StringVar(&cfg.L1ClientConfig.Endpoint,
+		"l1-endpoint", "", "URL for ETH L1 client",
+	)
 	runCmd.Flags().StringVar(
 		&cfg.RelayerConfig.EventListenerConfig.BridgeMessengerContractAddress,
 		"l1-contract-addr",
 		"",
 		"Address of L1BridgeMessenger contract to fetch events from",
 	)
-	runCmd.Flags().StringVar(
-		&cfg.RelayerConfig.EventListenerConfig.BridgeMessengerContractAddress,
-		"l2-contract-addr",
-		"",
-		"Address of L2BridgeMessenger contract to forward events to",
+	runCmd.Flags().DurationVar(&cfg.L1ClientConfig.Timeout,
+		"l1-timeout", time.Second, "Max timeout for ETH client to timeout",
 	)
-
 	runCmd.Flags().IntVar(
 		&cfg.RelayerConfig.EventListenerConfig.BatchSize,
 		"l1-fetcher-batch-size",
@@ -96,6 +92,34 @@ func addRunCommandFlags(runCmd *cobra.Command, cfg *Config) {
 		"l1-fetcher-poll-interval",
 		cfg.RelayerConfig.EventListenerConfig.PollInterval,
 		"Pause which l1 fetcher takes between fetching historical data batches",
+	)
+
+	runCmd.Flags().StringVar(
+		&cfg.L2ContractConfig.Endpoint, "l2-endpoint", "", "URL for nil L2 client",
+	)
+	runCmd.Flags().StringVar(
+		&cfg.L2ContractConfig.ContractAddress,
+		"l2-contract-addr",
+		cfg.L2ContractConfig.ContractAddress,
+		"Address of L2BridgeMessenger contract to forward events to",
+	)
+	runCmd.Flags().StringVar(
+		&cfg.L2ContractConfig.SmartAccountAddress,
+		"l2-smart-account-addr",
+		cfg.L2ContractConfig.SmartAccountAddress,
+		"Smart account address for relayer to operate on L2",
+	)
+	runCmd.Flags().StringVar(
+		&cfg.L2ContractConfig.ContractABIPath,
+		"l2-contract-abi-path",
+		cfg.L2ContractConfig.ContractABIPath,
+		"ABI of nil L2BridgeMessenger contract",
+	)
+	runCmd.Flags().DurationVar(
+		&cfg.TransactionSenderConfig.DbPollInterval,
+		"l2-transaction-sender-db-poll-interval",
+		cfg.TransactionSenderConfig.DbPollInterval,
+		"Poll interval for L2 transaction sender",
 	)
 }
 

--- a/nil/services/relayer/internal/l1/finality_ensurer.go
+++ b/nil/services/relayer/internal/l1/finality_ensurer.go
@@ -68,7 +68,7 @@ type FinalityEnsurer struct {
 	finalizedBlockLock sync.RWMutex
 
 	// cache for fetched finalized block number
-	// it must contain only blocks with number >= finalizedBlock.BlockNumber
+	// it must contain only blocks with number <= finalizedBlock.BlockNumber
 	finBlockCache *lru.Cache[uint64, *ProcessedBlock]
 
 	config        *FinalityEnsurerConfig

--- a/nil/services/relayer/internal/l2/contract_wrapper.go
+++ b/nil/services/relayer/internal/l2/contract_wrapper.go
@@ -1,0 +1,131 @@
+package l2
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/NilFoundation/nil/nil/client"
+	"github.com/NilFoundation/nil/nil/common"
+	"github.com/NilFoundation/nil/nil/internal/abi"
+	"github.com/NilFoundation/nil/nil/internal/types"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+type ContractConfig struct {
+	Endpoint            string
+	SmartAccountAddress string
+	ContractAddress     string
+	PrivateKeyPath      string
+	ContractABIPath     string
+}
+
+func DefaultContractConfig() *ContractConfig {
+	return &ContractConfig{
+		PrivateKeyPath:  "relayer_key.ecdsa",
+		ContractABIPath: "l2_bridge_messenger_abi.json",
+	}
+}
+
+func (cfg *ContractConfig) Validate() error {
+	if len(cfg.Endpoint) == 0 {
+		return errors.New("empty L2 endpoint")
+	}
+	if len(cfg.SmartAccountAddress) == 0 {
+		return errors.New("empty relayer smart account address")
+	}
+	if len(cfg.PrivateKeyPath) == 0 {
+		return errors.New("empty relayer private key file path")
+	}
+	if len(cfg.ContractAddress) == 0 {
+		return errors.New("empty L2BridgeMessenger contract address")
+	}
+	if len(cfg.ContractABIPath) == 0 {
+		return errors.New("empty L2BridgeMessenger contract ABI path")
+	}
+	return nil
+}
+
+type L2Contract interface {
+	RelayMessage(ctx context.Context, event *Event) (common.Hash, error)
+}
+
+type l2ContractWrapper struct {
+	nilClient        client.Client
+	privateKey       *ecdsa.PrivateKey
+	smartAccountAddr types.Address
+	contractAddr     types.Address
+	abi              abi.ABI
+}
+
+var _ L2Contract = (*l2ContractWrapper)(nil)
+
+func NewL2ContractWrapper(
+	ctx context.Context,
+	config *ContractConfig,
+	nilClient client.Client,
+) (*l2ContractWrapper, error) {
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+
+	smartAccountAddr := types.HexToAddress(config.SmartAccountAddress)
+	contractAddr := types.HexToAddress(config.ContractAddress)
+
+	abiFile, err := os.Open(config.ContractABIPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open '%s' L2 ABI file: %w", config.ContractABIPath, err)
+	}
+	defer abiFile.Close()
+
+	contractABI, err := abi.JSON(abiFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode L2 ABI: %w", err)
+	}
+
+	pk, err := crypto.LoadECDSA(config.PrivateKeyPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load private key: %w", err)
+	}
+
+	return &l2ContractWrapper{
+		nilClient:        nilClient,
+		privateKey:       pk,
+		smartAccountAddr: smartAccountAddr,
+		contractAddr:     contractAddr,
+		abi:              contractABI,
+	}, nil
+}
+
+func (w *l2ContractWrapper) RelayMessage(
+	ctx context.Context,
+	evt *Event,
+) (common.Hash, error) {
+	const methodName = "relayMessage"
+	calldata, err := w.abi.Pack(methodName,
+		evt.Sender,
+		evt.Target,
+		evt.Type,
+		evt.Value,
+		evt.Nonce,
+		evt.Message,
+	)
+	if err != nil {
+		return common.EmptyHash, err
+	}
+
+	return client.SendTransactionViaSmartAccount(
+		ctx,
+		w.nilClient,
+		w.smartAccountAddr,
+		calldata,
+		evt.FeePack, // TODO(oclaw) check me
+		evt.L2Limit, // TODO(oclaw) check me
+		nil,         // TODO(oclaw) what is this?
+		w.contractAddr,
+		w.privateKey,
+		false,
+	)
+}

--- a/nil/services/relayer/internal/l2/generate.go
+++ b/nil/services/relayer/internal/l2/generate.go
@@ -1,0 +1,3 @@
+package l2
+
+//go:generate go run github.com/matryer/moq -out l2_contract_generated_mock.go -rm -stub -with-resets . L2Contract

--- a/nil/services/relayer/internal/l2/l2_bridge_messenger_abi.json
+++ b/nil/services/relayer/internal/l2/l2_bridge_messenger_abi.json
@@ -27,70 +27,6 @@
     },
     {
       "inputs": [],
-      "name": "BridgeAlreadyAuthorized",
-      "type": "error"
-    },
-    {
-      "inputs": [],
-      "name": "BridgeNotAuthorized",
-      "type": "error"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "bytes32",
-          "name": "messageHash",
-          "type": "bytes32"
-        }
-      ],
-      "name": "DepositMessageAlreadyCancelled",
-      "type": "error"
-    },
-    {
-      "inputs": [],
-      "name": "DepositMessageAlreadyClaimed",
-      "type": "error"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "bytes32",
-          "name": "messageHash",
-          "type": "bytes32"
-        }
-      ],
-      "name": "DepositMessageAlreadyExist",
-      "type": "error"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "bytes32",
-          "name": "messageHash",
-          "type": "bytes32"
-        }
-      ],
-      "name": "DepositMessageDoesNotExist",
-      "type": "error"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "bytes32",
-          "name": "messageHash",
-          "type": "bytes32"
-        }
-      ],
-      "name": "DepositMessageNotExpired",
-      "type": "error"
-    },
-    {
-      "inputs": [],
-      "name": "DepositMessageStillInQueue",
-      "type": "error"
-    },
-    {
-      "inputs": [],
       "name": "EnforcedPause",
       "type": "error"
     },
@@ -152,11 +88,6 @@
     },
     {
       "inputs": [],
-      "name": "ErrorInvalidClaimProof",
-      "type": "error"
-    },
-    {
-      "inputs": [],
       "name": "ErrorInvalidCounterpartBridgeMessenger",
       "type": "error"
     },
@@ -182,7 +113,17 @@
     },
     {
       "inputs": [],
+      "name": "ErrorInvalidMessageType",
+      "type": "error"
+    },
+    {
+      "inputs": [],
       "name": "ErrorInvalidOwner",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ErrorInvalidRelayer",
       "type": "error"
     },
     {
@@ -202,48 +143,7 @@
     },
     {
       "inputs": [],
-      "name": "InvalidBridgeInterface",
-      "type": "error"
-    },
-    {
-      "inputs": [],
       "name": "InvalidInitialization",
-      "type": "error"
-    },
-    {
-      "inputs": [],
-      "name": "InvalidMaxMessageProcessingTime",
-      "type": "error"
-    },
-    {
-      "inputs": [],
-      "name": "InvalidMessageCancelDeltaTime",
-      "type": "error"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "bytes32",
-          "name": "messageHash",
-          "type": "bytes32"
-        }
-      ],
-      "name": "MessageHashNotInQueue",
-      "type": "error"
-    },
-    {
-      "inputs": [],
-      "name": "NotAuthorizedToPopMessages",
-      "type": "error"
-    },
-    {
-      "inputs": [],
-      "name": "NotEnoughMessagesInQueue",
-      "type": "error"
-    },
-    {
-      "inputs": [],
-      "name": "NotEnoughMessagesInQueue",
       "type": "error"
     },
     {
@@ -274,16 +174,6 @@
       "type": "error"
     },
     {
-      "inputs": [],
-      "name": "QueueIsEmpty",
-      "type": "error"
-    },
-    {
-      "inputs": [],
-      "name": "ReentrancyGuardReentrantCall",
-      "type": "error"
-    },
-    {
       "anonymous": false,
       "inputs": [
         {
@@ -307,19 +197,6 @@
       "inputs": [
         {
           "indexed": false,
-          "internalType": "bytes32",
-          "name": "messageHash",
-          "type": "bytes32"
-        }
-      ],
-      "name": "DepositMessageCancelled",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
           "internalType": "uint64",
           "name": "version",
           "type": "uint64"
@@ -334,93 +211,43 @@
         {
           "indexed": true,
           "internalType": "address",
-          "name": "messageSender",
+          "name": "bridgeRouter",
           "type": "address"
         },
         {
           "indexed": true,
           "internalType": "address",
-          "name": "messageTarget",
+          "name": "newBridgeRouter",
           "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "messageValue",
-          "type": "uint256"
-        },
+        }
+      ],
+      "name": "L2BridgeRouterSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
         {
           "indexed": true,
-          "internalType": "uint256",
-          "name": "messageNonce",
-          "type": "uint256"
-        },
-        {
-          "indexed": false,
-          "internalType": "bytes",
-          "name": "message",
-          "type": "bytes"
-        },
-        {
-          "indexed": false,
           "internalType": "bytes32",
           "name": "messageHash",
           "type": "bytes32"
-        },
-        {
-          "indexed": false,
-          "internalType": "enum NilConstants.MessageType",
-          "name": "messageType",
-          "type": "uint8"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "messageCreatedAt",
-          "type": "uint256"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "messageExpiryTime",
-          "type": "uint256"
-        },
-        {
-          "indexed": false,
-          "internalType": "address",
-          "name": "l2FeeRefundAddress",
-          "type": "address"
-        },
-        {
-          "components": [
-            {
-              "internalType": "uint256",
-              "name": "nilGasLimit",
-              "type": "uint256"
-            },
-            {
-              "internalType": "uint256",
-              "name": "maxFeePerGas",
-              "type": "uint256"
-            },
-            {
-              "internalType": "uint256",
-              "name": "maxPriorityFeePerGas",
-              "type": "uint256"
-            },
-            {
-              "internalType": "uint256",
-              "name": "feeCredit",
-              "type": "uint256"
-            }
-          ],
-          "indexed": false,
-          "internalType": "struct INilGasPriceOracle.FeeCreditData",
-          "name": "feeCreditData",
-          "type": "tuple"
         }
       ],
-      "name": "MessageSent",
+      "name": "MessageRelayFailed",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "messageHash",
+          "type": "bytes32"
+        }
+      ],
+      "name": "MessageRelaySuccessful",
       "type": "event"
     },
     {
@@ -453,6 +280,25 @@
         }
       ],
       "name": "Paused",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "relayer",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "relayerAddress",
+          "type": "address"
+        }
+      ],
+      "name": "RelayerSet",
       "type": "event"
     },
     {
@@ -577,7 +423,7 @@
           "type": "address"
         }
       ],
-      "name": "authorizeBridge",
+      "name": "authoriseBridge",
       "outputs": [],
       "stateMutability": "nonpayable",
       "type": "function"
@@ -590,38 +436,7 @@
           "type": "address[]"
         }
       ],
-      "name": "authorizeBridges",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "bytes32",
-          "name": "messageHash",
-          "type": "bytes32"
-        }
-      ],
-      "name": "cancelDeposit",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "bytes32",
-          "name": "messageHash",
-          "type": "bytes32"
-        },
-        {
-          "internalType": "bytes32[]",
-          "name": "claimProof",
-          "type": "bytes32[]"
-        }
-      ],
-      "name": "claimFailedDeposit",
+      "name": "authoriseBridges",
       "outputs": [],
       "stateMutability": "nonpayable",
       "type": "function"
@@ -630,27 +445,27 @@
       "inputs": [
         {
           "internalType": "address",
-          "name": "messageSender",
+          "name": "_messageSender",
           "type": "address"
         },
         {
           "internalType": "address",
-          "name": "messageTarget",
+          "name": "_messageTarget",
           "type": "address"
         },
         {
           "internalType": "uint256",
-          "name": "value",
+          "name": "_value",
           "type": "uint256"
         },
         {
           "internalType": "uint256",
-          "name": "messageNonce",
+          "name": "_messageNonce",
           "type": "uint256"
         },
         {
           "internalType": "bytes",
-          "name": "message",
+          "name": "_message",
           "type": "bytes"
         }
       ],
@@ -697,110 +512,6 @@
       "type": "function"
     },
     {
-      "inputs": [
-        {
-          "internalType": "bytes32",
-          "name": "",
-          "type": "bytes32"
-        }
-      ],
-      "name": "depositMessages",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "sender",
-          "type": "address"
-        },
-        {
-          "internalType": "address",
-          "name": "target",
-          "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "value",
-          "type": "uint256"
-        },
-        {
-          "internalType": "uint256",
-          "name": "nonce",
-          "type": "uint256"
-        },
-        {
-          "internalType": "uint256",
-          "name": "expiryTime",
-          "type": "uint256"
-        },
-        {
-          "internalType": "bool",
-          "name": "isCancelled",
-          "type": "bool"
-        },
-        {
-          "internalType": "bool",
-          "name": "isClaimed",
-          "type": "bool"
-        },
-        {
-          "internalType": "address",
-          "name": "l1DepositRefundAddress",
-          "type": "address"
-        },
-        {
-          "internalType": "enum NilConstants.MessageType",
-          "name": "messageType",
-          "type": "uint8"
-        },
-        {
-          "internalType": "bytes",
-          "name": "message",
-          "type": "bytes"
-        },
-        {
-          "components": [
-            {
-              "internalType": "uint256",
-              "name": "nilGasLimit",
-              "type": "uint256"
-            },
-            {
-              "internalType": "uint256",
-              "name": "maxFeePerGas",
-              "type": "uint256"
-            },
-            {
-              "internalType": "uint256",
-              "name": "maxPriorityFeePerGas",
-              "type": "uint256"
-            },
-            {
-              "internalType": "uint256",
-              "name": "feeCredit",
-              "type": "uint256"
-            }
-          ],
-          "internalType": "struct INilGasPriceOracle.FeeCreditData",
-          "name": "feeCreditData",
-          "type": "tuple"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "depositNonce",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
       "inputs": [],
       "name": "getAllAdmins",
       "outputs": [
@@ -828,142 +539,12 @@
     },
     {
       "inputs": [],
-      "name": "getAuthorizedBridges",
+      "name": "getAuthorisedBridges",
       "outputs": [
         {
           "internalType": "address[]",
           "name": "",
           "type": "address[]"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "bytes32",
-          "name": "msgHash",
-          "type": "bytes32"
-        }
-      ],
-      "name": "getDepositMessage",
-      "outputs": [
-        {
-          "components": [
-            {
-              "internalType": "address",
-              "name": "sender",
-              "type": "address"
-            },
-            {
-              "internalType": "address",
-              "name": "target",
-              "type": "address"
-            },
-            {
-              "internalType": "uint256",
-              "name": "value",
-              "type": "uint256"
-            },
-            {
-              "internalType": "uint256",
-              "name": "nonce",
-              "type": "uint256"
-            },
-            {
-              "internalType": "uint256",
-              "name": "expiryTime",
-              "type": "uint256"
-            },
-            {
-              "internalType": "bool",
-              "name": "isCancelled",
-              "type": "bool"
-            },
-            {
-              "internalType": "bool",
-              "name": "isClaimed",
-              "type": "bool"
-            },
-            {
-              "internalType": "address",
-              "name": "l1DepositRefundAddress",
-              "type": "address"
-            },
-            {
-              "internalType": "enum NilConstants.MessageType",
-              "name": "messageType",
-              "type": "uint8"
-            },
-            {
-              "internalType": "bytes",
-              "name": "message",
-              "type": "bytes"
-            },
-            {
-              "components": [
-                {
-                  "internalType": "uint256",
-                  "name": "nilGasLimit",
-                  "type": "uint256"
-                },
-                {
-                  "internalType": "uint256",
-                  "name": "maxFeePerGas",
-                  "type": "uint256"
-                },
-                {
-                  "internalType": "uint256",
-                  "name": "maxPriorityFeePerGas",
-                  "type": "uint256"
-                },
-                {
-                  "internalType": "uint256",
-                  "name": "feeCredit",
-                  "type": "uint256"
-                }
-              ],
-              "internalType": "struct INilGasPriceOracle.FeeCreditData",
-              "name": "feeCreditData",
-              "type": "tuple"
-            }
-          ],
-          "internalType": "struct IL1BridgeMessenger.DepositMessage",
-          "name": "depositMessage",
-          "type": "tuple"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "bytes32",
-          "name": "msgHash",
-          "type": "bytes32"
-        }
-      ],
-      "name": "getMessageType",
-      "outputs": [
-        {
-          "internalType": "enum NilConstants.MessageType",
-          "name": "messageType",
-          "type": "uint8"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "getNextDepositNonce",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
         }
       ],
       "stateMutability": "view",
@@ -1163,13 +744,8 @@
         },
         {
           "internalType": "address",
-          "name": "l1NilRollupAddress",
+          "name": "relayerAddress",
           "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "maxProcessingTimeValue",
-          "type": "uint256"
         }
       ],
       "name": "initialize",
@@ -1235,13 +811,77 @@
       "type": "function"
     },
     {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "bridgeAddress",
+          "type": "address"
+        }
+      ],
+      "name": "isAuthorisedBridge",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
       "inputs": [],
-      "name": "maxProcessingTime",
+      "name": "isFullyInitialised",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "l1MessageHash",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "name": "l2MessageSentTimestamp",
       "outputs": [
         {
           "internalType": "uint256",
           "name": "",
           "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "l2Tol1Root",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
         }
       ],
       "stateMutability": "view",
@@ -1276,19 +916,38 @@
     {
       "inputs": [
         {
-          "internalType": "uint256",
-          "name": "messageCount",
-          "type": "uint256"
-        }
-      ],
-      "name": "popMessages",
-      "outputs": [
+          "internalType": "address",
+          "name": "messageSender",
+          "type": "address"
+        },
         {
-          "internalType": "bytes32[]",
-          "name": "",
-          "type": "bytes32[]"
+          "internalType": "address",
+          "name": "messageTarget",
+          "type": "address"
+        },
+        {
+          "internalType": "enum NilConstants.MessageType",
+          "name": "messageType",
+          "type": "uint8"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "messagNonce",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes",
+          "name": "message",
+          "type": "bytes"
         }
       ],
+      "name": "relayMessage",
+      "outputs": [],
       "stateMutability": "nonpayable",
       "type": "function"
     },
@@ -1369,7 +1028,7 @@
           "type": "address"
         }
       ],
-      "name": "revokeBridgeAuthorization",
+      "name": "revokeBridgeAuthorisation",
       "outputs": [],
       "stateMutability": "nonpayable",
       "type": "function"
@@ -1421,11 +1080,6 @@
     {
       "inputs": [
         {
-          "internalType": "enum NilConstants.MessageType",
-          "name": "messageType",
-          "type": "uint8"
-        },
-        {
           "internalType": "address",
           "name": "messageTarget",
           "type": "address"
@@ -1441,101 +1095,14 @@
           "type": "bytes"
         },
         {
-          "internalType": "address",
-          "name": "l1DepositRefundAddress",
-          "type": "address"
-        },
-        {
-          "internalType": "address",
-          "name": "l2FeeRefundAddress",
-          "type": "address"
-        },
-        {
-          "components": [
-            {
-              "internalType": "uint256",
-              "name": "nilGasLimit",
-              "type": "uint256"
-            },
-            {
-              "internalType": "uint256",
-              "name": "maxFeePerGas",
-              "type": "uint256"
-            },
-            {
-              "internalType": "uint256",
-              "name": "maxPriorityFeePerGas",
-              "type": "uint256"
-            },
-            {
-              "internalType": "uint256",
-              "name": "feeCredit",
-              "type": "uint256"
-            }
-          ],
-          "internalType": "struct INilGasPriceOracle.FeeCreditData",
-          "name": "feeCreditData",
-          "type": "tuple"
-        }
-      ],
-      "name": "sendMessage",
-      "outputs": [],
-      "stateMutability": "payable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "enum NilConstants.MessageType",
-          "name": "messageType",
-          "type": "uint8"
-        },
-        {
-          "internalType": "address",
-          "name": "messageTarget",
-          "type": "address"
-        },
-        {
           "internalType": "uint256",
-          "name": "value",
+          "name": "gasLimit",
           "type": "uint256"
         },
         {
-          "internalType": "bytes",
-          "name": "message",
-          "type": "bytes"
-        },
-        {
           "internalType": "address",
-          "name": "l2FeeRefundAddress",
+          "name": "refundRecipient",
           "type": "address"
-        },
-        {
-          "components": [
-            {
-              "internalType": "uint256",
-              "name": "nilGasLimit",
-              "type": "uint256"
-            },
-            {
-              "internalType": "uint256",
-              "name": "maxFeePerGas",
-              "type": "uint256"
-            },
-            {
-              "internalType": "uint256",
-              "name": "maxPriorityFeePerGas",
-              "type": "uint256"
-            },
-            {
-              "internalType": "uint256",
-              "name": "feeCredit",
-              "type": "uint256"
-            }
-          ],
-          "internalType": "struct INilGasPriceOracle.FeeCreditData",
-          "name": "feeCreditData",
-          "type": "tuple"
         }
       ],
       "name": "sendMessage",

--- a/nil/services/relayer/internal/l2/transaction_sender.go
+++ b/nil/services/relayer/internal/l2/transaction_sender.go
@@ -1,21 +1,159 @@
 package l2
 
 import (
+	"cmp"
 	"context"
 	"errors"
+	"time"
+
+	"github.com/NilFoundation/nil/nil/common/heap"
+	"github.com/NilFoundation/nil/nil/common/logging"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/jonboulle/clockwork"
 )
 
+type TransactionSenderConfig struct {
+	DbPollInterval  time.Duration
+	EventBufferSize int
+}
+
+func (cfg *TransactionSenderConfig) Validate() error {
+	if cfg.DbPollInterval == 0 {
+		return errors.New("no storage poll interval set")
+	}
+	if cfg.EventBufferSize == 0 {
+		return errors.New("no event buffer size for the poll heap is set")
+	}
+	return nil
+}
+
+func DefaultTransactionSenderConfig() *TransactionSenderConfig {
+	return &TransactionSenderConfig{
+		DbPollInterval:  time.Second * 10,
+		EventBufferSize: 500,
+	}
+}
+
+type eventFinalizedProvider interface {
+	EventFinalized() <-chan struct{}
+}
+
 type TransactionSender struct {
-	// TODO poll ready events from finality ensurer || ticker
-	// Sign event with key (add key provider)
-	// Publish event to L2BridgeMessenger contract
-	// Drop event from L2 event storage
+	config           *TransactionSenderConfig
+	clock            clockwork.Clock
+	logger           logging.Logger
+	storage          *EventStorage
+	eventFinProvider eventFinalizedProvider
+	contractBinding  L2Contract
+}
+
+func NewTransactionSender(
+	config *TransactionSenderConfig,
+	storage *EventStorage,
+	logger logging.Logger,
+	clock clockwork.Clock,
+	eventFinProvider eventFinalizedProvider,
+	contractBinding L2Contract,
+) (*TransactionSender, error) {
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+
+	ts := &TransactionSender{
+		config:           config,
+		clock:            clock,
+		storage:          storage,
+		eventFinProvider: eventFinProvider,
+		contractBinding:  contractBinding,
+	}
+	ts.logger = logger.With().Str(logging.FieldComponent, ts.Name()).Logger()
+	return ts, nil
 }
 
 func (ts *TransactionSender) Name() string {
-	return "l2-transaction-sender"
+	return "transaction-sender"
 }
 
 func (ts *TransactionSender) Run(ctx context.Context, started chan<- struct{}) error {
-	return errors.New("not implemented")
+	ts.logger.Info().Msg("initializing component")
+
+	ticker := ts.clock.NewTicker(ts.config.DbPollInterval)
+	close(started)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+
+		case <-ticker.Chan():
+			ts.logger.Debug().Msg("wake up by timer")
+		case <-ts.eventFinProvider.EventFinalized():
+			ts.logger.Debug().Msg("wake up by event emitter")
+		}
+		if err := ts.relayEvents(ctx); err != nil {
+			ts.logger.Error().Err(err).Msg("error occurred during relaying events to L2")
+		}
+	}
+}
+
+func (ts *TransactionSender) relayEvents(ctx context.Context) error {
+	eventBySeqNumber := heap.NewBoundedMaxHeap(
+		ts.config.EventBufferSize,
+		func(a, b *Event) int {
+			return cmp.Compare(a.SequenceNumber, b.SequenceNumber)
+		},
+	)
+
+	eventsIterated := 0
+	if err := ts.storage.IterateEventsByBatch(ctx, 100, func(batch []*Event) error {
+		for _, evt := range batch {
+			eventBySeqNumber.Add(evt)
+		}
+		eventsIterated += len(batch)
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	events := eventBySeqNumber.PopAllSorted()
+
+	if len(events) == 0 {
+		ts.logger.Debug().Msg("no ready events to be relayed to L2")
+		return nil
+	}
+
+	ts.logger.Info().
+		Int("fetched_events_count", len(events)).
+		Int("checked_events_count", eventsIterated).
+		Msg("fetched some events ready to be relayed to L2")
+
+	droppingEvents := make([]common.Hash, 0, len(events))
+
+	defer func() {
+		if len(droppingEvents) == 0 {
+			return
+		}
+		ts.logger.Debug().
+			Int("event_count", len(droppingEvents)).
+			Msg("dropping events from L2 storage")
+
+		if err := ts.storage.DeleteEvents(ctx, droppingEvents); err != nil {
+			ts.logger.Warn().Err(err).Msg("failed to drop events from L2 storage")
+		}
+	}()
+
+	for i, evt := range events {
+		if _, err := ts.contractBinding.RelayMessage(ctx, evt); err != nil {
+			ts.logger.Error().Err(err).
+				Int("event_index", i).
+				Uint64("event_seqno", evt.SequenceNumber).
+				Stringer("event_hash", evt.Hash).
+				Msg("failed to relay event to L2")
+
+			return err
+		}
+		ts.logger.Debug().Stringer("event_hash", evt.Hash).Msg("event relayed to L2")
+		droppingEvents = append(droppingEvents, evt.Hash)
+	}
+
+	return nil
 }

--- a/nil/services/relayer/internal/l2/transaction_sender_test.go
+++ b/nil/services/relayer/internal/l2/transaction_sender_test.go
@@ -1,0 +1,236 @@
+package l2
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/NilFoundation/nil/nil/common"
+	"github.com/NilFoundation/nil/nil/common/logging"
+	"github.com/NilFoundation/nil/nil/internal/db"
+	"github.com/jonboulle/clockwork"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/suite"
+)
+
+type eventFinalizerStub struct {
+	emitter chan struct{}
+}
+
+func newEventFinalizerStub() *eventFinalizerStub {
+	return &eventFinalizerStub{
+		emitter: make(chan struct{}),
+	}
+}
+
+// Can be used by reading routine to look for updates without further delay
+func (efs *eventFinalizerStub) EventFinalized() <-chan struct{} {
+	return efs.emitter
+}
+
+func (efs *eventFinalizerStub) emit() {
+	efs.emitter <- struct{}{}
+}
+
+func (efs *eventFinalizerStub) waitForSenderLoop() {
+	efs.emit()
+
+	// channel is not buffered so by the moment
+	// the emitter is able to exit from the second emit call
+	// testing transaction sender must run at least one full loop iteration
+	efs.emit()
+}
+
+type TransactionSenderTestSuite struct {
+	suite.Suite
+
+	// high-level dependencies
+	database  db.DB
+	logger    logging.Logger
+	l2Storage *EventStorage
+
+	// testing entity
+	transactionSender *TransactionSender
+
+	// mocks
+	contractMock   *L2ContractMock
+	clockMock      *clockwork.FakeClock
+	eventFinalizer *eventFinalizerStub
+
+	// test lifecycle stuff
+	ctx                      context.Context
+	cancel                   context.CancelFunc
+	transactionSenderStopped chan struct{}
+}
+
+func TestTransactionSender(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(TransactionSenderTestSuite))
+}
+
+func (s *TransactionSenderTestSuite) SetupTest() {
+	var err error
+
+	s.ctx, s.cancel = context.WithCancel(context.Background())
+	s.logger = logging.NewFromZerolog(zerolog.New(zerolog.NewConsoleWriter()))
+
+	s.database, err = db.NewBadgerDbInMemory()
+	s.Require().NoError(err, "failed to initialize database")
+
+	s.clockMock = clockwork.NewFakeClock()
+
+	s.contractMock = &L2ContractMock{}
+
+	s.l2Storage = NewEventStorage(s.ctx, s.database, s.clockMock, nil, s.logger)
+
+	cfg := DefaultTransactionSenderConfig()
+
+	s.eventFinalizer = newEventFinalizerStub()
+
+	s.transactionSender, err = NewTransactionSender(
+		cfg,
+		s.l2Storage,
+		s.logger,
+		s.clockMock,
+		s.eventFinalizer,
+		s.contractMock,
+	)
+	s.Require().NoError(err, "failed to initialize transaction sender")
+}
+
+func (s *TransactionSenderTestSuite) TearDownTest() {
+	s.cancel()
+	<-s.transactionSenderStopped
+}
+
+func (s *TransactionSenderTestSuite) runSender() (context.CancelFunc, <-chan struct{}) {
+	s.transactionSenderStopped = make(chan struct{})
+	transactionSenderStarted := make(chan struct{})
+
+	ctx, cancel := context.WithCancel(s.ctx)
+	go func() {
+		if err := s.transactionSender.Run(ctx, transactionSenderStarted); err != nil {
+			s.ErrorIs(err, context.Canceled)
+		}
+		close(s.transactionSenderStopped)
+	}()
+	<-transactionSenderStarted
+
+	return cancel, s.transactionSenderStopped
+}
+
+func (s *TransactionSenderTestSuite) runSenderWithExpectedEvents(sequenceNumbers []uint64, failOnSeqNo *uint64) {
+	s.T().Helper()
+
+	set := make(map[uint64]bool)
+	for _, seqNo := range sequenceNumbers {
+		s.Require().False(set[seqNo])
+		set[seqNo] = false
+	}
+
+	cancel, stopped := s.runSender()
+
+	var seqNoIdx int
+	s.contractMock.RelayMessageFunc = func(ctx context.Context, event *Event) (common.Hash, error) {
+		if failOnSeqNo != nil && event.SequenceNumber == *failOnSeqNo {
+			return common.EmptyHash, fmt.Errorf("managed failure on %d seqno", event.SequenceNumber)
+		}
+		s.Require().Equal(
+			sequenceNumbers[seqNoIdx], event.SequenceNumber,
+			"unexpected order of events (seq number %d)", seqNoIdx,
+		)
+		seqNoIdx++
+		set[event.SequenceNumber] = true
+		return common.EmptyHash, nil
+	}
+
+	s.eventFinalizer.waitForSenderLoop()
+
+	cancel()
+	<-stopped
+
+	for seqNo, invoked := range set {
+		s.True(invoked, "found not forwarded event, seq no %d", seqNo)
+	}
+}
+
+func (s *TransactionSenderTestSuite) TestBasic() {
+	l2Events := []*Event{
+		{
+			Hash:           getMsgHash(1),
+			SequenceNumber: 1,
+		},
+		{
+			Hash:           getMsgHash(2),
+			SequenceNumber: 2,
+		},
+		{
+			Hash:           getMsgHash(3),
+			SequenceNumber: 3,
+		},
+	}
+
+	s.Require().NoError(s.l2Storage.StoreEvents(s.ctx, l2Events))
+
+	s.runSenderWithExpectedEvents([]uint64{1, 2, 3}, nil)
+
+	err := s.l2Storage.IterateEventsByBatch(s.ctx, 3, func(events []*Event) error {
+		s.Fail("not expected events found in L2 event storage", "found %d events", len(events))
+		return nil
+	})
+	s.Require().NoError(err)
+}
+
+func (s *TransactionSenderTestSuite) TestFailure() {
+	l2Events := []*Event{
+		{
+			Hash:           getMsgHash(1),
+			SequenceNumber: 1,
+		},
+		{
+			Hash:           getMsgHash(2),
+			SequenceNumber: 2,
+		},
+		{
+			Hash:           getMsgHash(3),
+			SequenceNumber: 3,
+		},
+		{
+			Hash:           getMsgHash(4),
+			SequenceNumber: 4,
+		},
+		{
+			Hash:           getMsgHash(6),
+			SequenceNumber: 6,
+		},
+	}
+
+	s.Require().NoError(s.l2Storage.StoreEvents(s.ctx, l2Events))
+
+	var failOnSeqNo uint64 = 4
+	s.runSenderWithExpectedEvents([]uint64{1, 2, 3}, &failOnSeqNo)
+
+	err := s.l2Storage.IterateEventsByBatch(s.ctx, 3, func(events []*Event) error {
+		s.Require().Len(events, 2)
+		s.Require().EqualValues(4, events[0].SequenceNumber)
+		s.Require().EqualValues(6, events[1].SequenceNumber)
+		return nil
+	})
+	s.Require().NoError(err)
+
+	s.runSenderWithExpectedEvents([]uint64{4, 6}, nil)
+
+	err = s.l2Storage.IterateEventsByBatch(s.ctx, 3, func(events []*Event) error {
+		s.Fail("not expected events found in L2 event storage", "found %d events", len(events))
+		return nil
+	})
+	s.Require().NoError(err)
+}
+
+func getMsgHash(seqNo int) [32]byte {
+	var hash [32]byte
+	for i := range hash {
+		hash[i] = byte(seqNo)
+	}
+	return hash
+}

--- a/nil/services/relayer/service.go
+++ b/nil/services/relayer/service.go
@@ -2,31 +2,41 @@ package relayer
 
 import (
 	"context"
+	"fmt"
+	"os"
 
+	"github.com/NilFoundation/nil/nil/client"
+	"github.com/NilFoundation/nil/nil/client/rpc"
 	"github.com/NilFoundation/nil/nil/common/logging"
 	"github.com/NilFoundation/nil/nil/internal/db"
 	"github.com/NilFoundation/nil/nil/services/relayer/internal/l1"
 	"github.com/NilFoundation/nil/nil/services/relayer/internal/l2"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/jonboulle/clockwork"
 	"golang.org/x/sync/errgroup"
 )
 
 type RelayerConfig struct {
-	EventListenerConfig           *l1.EventListenerConfig
-	FinalityEnsurerConfig         *l1.FinalityEnsurerConfig
-	L2BridgeMessengerContractAddr string
+	EventListenerConfig     *l1.EventListenerConfig
+	FinalityEnsurerConfig   *l1.FinalityEnsurerConfig
+	TransactionSenderConfig *l2.TransactionSenderConfig
+	L2ContractConfig        *l2.ContractConfig
 }
 
 func DefaultRelayerConfig() *RelayerConfig {
 	return &RelayerConfig{
-		EventListenerConfig:   l1.DefaultEventListenerConfig(),
-		FinalityEnsurerConfig: l1.DefaultFinalityEnsurerConfig(),
+		EventListenerConfig:     l1.DefaultEventListenerConfig(),
+		FinalityEnsurerConfig:   l1.DefaultFinalityEnsurerConfig(),
+		TransactionSenderConfig: l2.DefaultTransactionSenderConfig(),
+		L2ContractConfig:        l2.DefaultContractConfig(),
 	}
 }
 
 type RelayerService struct {
-	L1EventListener   *l1.EventListener
-	L1FinalityEnsurer *l1.FinalityEnsurer
+	Logger              logging.Logger
+	L1EventListener     *l1.EventListener
+	L1FinalityEnsurer   *l1.FinalityEnsurer
+	L2TransactionSender *l2.TransactionSender
 }
 
 func New(
@@ -36,14 +46,16 @@ func New(
 	config *RelayerConfig,
 	l1Client l1.EthClient,
 ) (*RelayerService, error) {
-	logger := logging.NewLogger("relayer")
+	rs := &RelayerService{
+		Logger: logging.NewLogger("relayer"),
+	}
 
 	l1Storage, err := l1.NewEventStorage(
 		ctx,
 		database,
 		clock,
 		nil, // TODO(oclaw) metrics
-		logger,
+		rs.Logger,
 	)
 	if err != nil {
 		return nil, err
@@ -52,19 +64,19 @@ func New(
 	l1Contract, err := l1.NewL1ContractWrapper(
 		l1Client,
 		config.EventListenerConfig.BridgeMessengerContractAddress,
-		config.L2BridgeMessengerContractAddr,
+		config.L2ContractConfig.ContractAddress,
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	l1EventListener, err := l1.NewEventListener(
+	rs.L1EventListener, err = l1.NewEventListener(
 		config.EventListenerConfig,
 		clock,
 		l1Client,
 		l1Contract,
 		l1Storage,
-		logger,
+		rs.Logger,
 	)
 	if err != nil {
 		return nil, err
@@ -75,27 +87,95 @@ func New(
 		database,
 		clock,
 		nil, // TODO(oclaw) metrics
-		logger,
+		rs.Logger,
 	)
 
-	l1FinalityEnsurer, err := l1.NewFinalityEnsurer(
+	rs.L1FinalityEnsurer, err = l1.NewFinalityEnsurer(
 		config.FinalityEnsurerConfig,
 		l1Client,
 		clock,
-		logger,
+		rs.Logger,
 		l1Storage,
 		l2Storage,
-		l1EventListener,
+		rs.L1EventListener,
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	return &RelayerService{
-		L1EventListener:   l1EventListener,
-		L1FinalityEnsurer: l1FinalityEnsurer,
-		// TODO(oclaw) L2 transaction sender
-	}, nil
+	l2Client, err := rs.initL2(ctx, config.L2ContractConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	l2Contract, err := l2.NewL2ContractWrapper(
+		ctx,
+		config.L2ContractConfig,
+		l2Client,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	rs.L2TransactionSender, err = l2.NewTransactionSender(
+		config.TransactionSenderConfig,
+		l2Storage,
+		rs.Logger,
+		clock,
+		rs.L1FinalityEnsurer,
+		l2Contract,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return rs, nil
+}
+
+func (rs *RelayerService) initL2(ctx context.Context, config *l2.ContractConfig) (client.Client, error) {
+	if err := config.Validate(); err != nil {
+		return nil, fmt.Errorf("failed to init L2: invalid config: %w", err)
+	}
+
+	l2Client := rpc.NewClient(
+		config.Endpoint,
+		rs.Logger,
+	)
+	ver, err := l2Client.ClientVersion(ctx)
+	if err != nil {
+		return nil, err
+	}
+	rs.Logger.Info().Str("client_version", ver).Msg("connected to L2")
+
+	var keyExists bool
+	_, err = os.Stat(config.PrivateKeyPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+	} else {
+		keyExists = true
+		rs.Logger.Debug().Str("key_path", config.PrivateKeyPath).Msg("found generated key")
+	}
+
+	if !keyExists {
+		rs.Logger.Info().
+			Str("key_path", config.PrivateKeyPath).
+			Msg("private key not found, generating it")
+
+		if key, err := crypto.GenerateKey(); err != nil {
+			return nil, err
+		} else {
+			if err := crypto.SaveECDSA(config.PrivateKeyPath, key); err != nil {
+				return nil, err
+			}
+		}
+		rs.Logger.Info().Msg("key generated")
+	}
+
+	// TODO deploy relayer's L2 smart account (if it is not exist)
+
+	return l2Client, nil
 }
 
 func (rs *RelayerService) Run(ctx context.Context) error {
@@ -109,6 +189,11 @@ func (rs *RelayerService) Run(ctx context.Context) error {
 	finalityEnsurerStarted := make(chan struct{})
 	eg.Go(func() error {
 		return rs.L1FinalityEnsurer.Run(gCtx, finalityEnsurerStarted)
+	})
+
+	transactionSenderStarted := make(chan struct{})
+	eg.Go(func() error {
+		return rs.L2TransactionSender.Run(ctx, transactionSenderStarted)
 	})
 
 	return eg.Wait()


### PR DESCRIPTION
Implementation of relayer `TransactionSender` component

This component is responsible for:
- Fetching event from L2 storage
- Ordered forwarding of the events to the L2
- Dropping events from L2 storage

PR also contains L2 contract wrapper which provides an interface to interact with `L2BridgeMessenger` contract and some initial config for it (nil RPC endpoint, contract/account address, key). Current version only generates the key (if it is not exists). Other initialization stuff is going to be implemented in the following PRs