### PR TITLE
Sync Committee: Subgraph Batching

### DIFF
--- a/nil/common/logging/fields.go
+++ b/nil/common/logging/fields.go
@@ -37,6 +37,7 @@ const (
 	FieldBlockMainShardHash = "blockMainShardHash"
 	FieldBlockNumber        = "blockNumber"
 	FieldBatchId            = "batchId"
+	FieldStateRoot          = "stateRoot"
 
 	FieldTaskId         = "taskId"
 	FieldTaskParentId   = "taskParentId"

--- a/nil/services/synccommittee/core/batches/encode/v1/encoder_test.go
+++ b/nil/services/synccommittee/core/batches/encode/v1/encoder_test.go
@@ -52,7 +52,7 @@ func TestEncoderSimple(t *testing.T) {
 
 	deserializedBatch, err := ConvertFromProto(&unwrappedBatch)
 	require.NoError(t, err)
-	require.Len(t, deserializedBatch.Blocks, len(batch.ChildBlocks)+1)
+	require.Len(t, deserializedBatch.Blocks, len(batch.BlockIds()))
 	assert.Equal(t, batch.Id, deserializedBatch.BatchId)
 	assert.ElementsMatch(t, prunedBatch.Blocks, deserializedBatch.Blocks)
 }

--- a/nil/services/synccommittee/core/batches/encode/v1/serialization.go
+++ b/nil/services/synccommittee/core/batches/encode/v1/serialization.go
@@ -77,7 +77,7 @@ func ConvertFromProto(batch *proto.Batch) (*types.PrunedBatch, error) {
 			PrevBlockHash: common.BytesToHash(pblk.PrevBlockHash),
 		}
 		for _, ptx := range pblk.Transactions {
-			tx := &types.PrunedTransaction{
+			tx := types.PrunedTransaction{
 				Flags: coreTypes.NewTransactionFlagsFromBits(uint8(ptx.GetFlags())),
 				Seqno: hexutil.Uint64(ptx.GetSeqNo()),
 				From:  coreTypes.BytesToAddress(ptx.AddrFrom.AddressBytes),

--- a/nil/services/synccommittee/core/block_batch_test.go
+++ b/nil/services/synccommittee/core/block_batch_test.go
@@ -3,8 +3,7 @@ package core
 import (
 	"testing"
 
-	"github.com/NilFoundation/nil/nil/common"
-	"github.com/NilFoundation/nil/nil/services/rpc/jsonrpc"
+	coreTypes "github.com/NilFoundation/nil/nil/internal/types"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/testaide"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
 	"github.com/stretchr/testify/suite"
@@ -20,104 +19,53 @@ func TestBlockBatchTestSuite(t *testing.T) {
 	suite.Run(t, new(BlockBatchTestSuite))
 }
 
-func (s *BlockBatchTestSuite) TestNewBlockBatch() {
-	validBatch := testaide.NewBlockBatch(testaide.ShardsCount)
+func (s *BlockBatchTestSuite) Test_Valid_Batch_No_Error() {
+	mainBlock := testaide.NewMainShardBlock()
+	mainBlock.ChildBlocks = nil
 
-	notReadyBatch := testaide.NewBlockBatch(testaide.ShardsCount)
-	notReadyBatch.MainShardBlock.ChildBlocks[0] = common.EmptyHash
-	notReadyBatch.ChildBlocks[0] = nil
-
-	nilChildBatch := testaide.NewBlockBatch(testaide.ShardsCount)
-	nilChildBatch.ChildBlocks[1] = nil
-
-	redundantChildBatch := testaide.NewBlockBatch(testaide.ShardsCount)
-	redundantChildBatch.ChildBlocks = append(redundantChildBatch.ChildBlocks, testaide.NewExecutionShardBlock())
-
-	hashMismatchBatch := testaide.NewBlockBatch(testaide.ShardsCount)
-	hashMismatchBatch.ChildBlocks[2].Hash = testaide.RandomHash()
-
-	testCases := []struct {
-		name           string
-		mainShardBlock *jsonrpc.RPCBlock
-		childBlocks    []*jsonrpc.RPCBlock
-		errPredicate   func(error)
-	}{
-		{
-			name:           "Valid_Batch_No_Error",
-			mainShardBlock: validBatch.MainShardBlock,
-			childBlocks:    validBatch.ChildBlocks,
-			errPredicate:   func(err error) { s.Require().NoError(err) },
-		},
-		{
-			name:           "Nil_Main_Shard_Block",
-			mainShardBlock: nil,
-			childBlocks:    []*jsonrpc.RPCBlock{},
-			errPredicate:   func(err error) { s.Require().ErrorContains(err, "mainShardBlock") },
-		},
-		{
-			name:           "Valid_Main_Shard_Block_Nil_Child_Blocks",
-			mainShardBlock: testaide.NewMainShardBlock(),
-			childBlocks:    nil,
-			errPredicate:   func(err error) { s.Require().ErrorContains(err, "childBlocks") },
-		},
-		{
-			name:           "Not_Ready_Batch_Child_Hash_Is_Empty",
-			mainShardBlock: notReadyBatch.MainShardBlock,
-			childBlocks:    notReadyBatch.ChildBlocks,
-			errPredicate:   func(err error) { s.Require().ErrorIs(err, types.ErrBatchNotReady) },
-		},
-		{
-			name:           "Valid_Main_Shard_Block_Nil_Child_Block",
-			mainShardBlock: nilChildBatch.MainShardBlock,
-			childBlocks:    nilChildBatch.ChildBlocks,
-			errPredicate: func(err error) {
-				s.Require().NotErrorIs(err, types.ErrBatchNotReady)
-				s.Require().ErrorContains(err, "childBlocks[1] cannot be nil")
-			},
-		},
-		{
-			name:           "Block_Is_Not_From_The_Main_Shard",
-			mainShardBlock: testaide.NewExecutionShardBlock(),
-			childBlocks:    []*jsonrpc.RPCBlock{},
-			errPredicate: func(err error) {
-				s.Require().ErrorContains(err, "mainShardBlock is not from the main shard")
-			},
-		},
-		{
-			name:           "Redundant_Child_Block",
-			mainShardBlock: redundantChildBatch.MainShardBlock,
-			childBlocks:    redundantChildBatch.ChildBlocks,
-			errPredicate:   func(err error) { s.Require().ErrorContains(err, "have different length") },
-		},
-		{
-			name:           "Child_Hash_Mismatch",
-			mainShardBlock: hashMismatchBatch.MainShardBlock,
-			childBlocks:    hashMismatchBatch.ChildBlocks,
-			errPredicate: func(err error) {
-				s.Require().ErrorContains(err, "childBlocks[2].Hash != mainShardBlock.ChildBlocks[2]")
-			},
-		},
+	children := make(map[coreTypes.ShardId]types.ShardChainSegment)
+	for i := range 10 {
+		block := testaide.NewExecutionShardBlock()
+		block.ShardId = coreTypes.ShardId(i + 1)
+		mainBlock.ChildBlocks = append(mainBlock.ChildBlocks, block.Hash)
+		children[block.ShardId] = []*types.Block{block}
 	}
 
-	for _, testCase := range testCases {
-		s.Run(testCase.name, func() {
-			parentBatchId := types.NewBatchId()
-			batch, err := types.NewBlockBatch(&parentBatchId, testCase.mainShardBlock, testCase.childBlocks)
-			testCase.errPredicate(err)
+	subgraph, err := types.NewSubgraph(mainBlock, children)
+	s.Require().NoError(err)
+	s.Require().NotNil(subgraph)
 
-			if err != nil {
-				s.Require().Nil(batch)
-				return
-			}
-
-			s.Require().NotNil(batch)
-			s.Require().Equal(testCase.mainShardBlock, batch.MainShardBlock)
-			s.Require().Equal(testCase.childBlocks, batch.ChildBlocks)
-		})
-	}
+	batch, err := types.NewBlockBatch(nil, *subgraph)
+	s.Require().NoError(err)
+	s.Require().NotNil(batch)
 }
 
-func (s *BlockBatchTestSuite) TestCreateProofTask() {
+func (s *BlockBatchTestSuite) Test_NewSubgraph_Corrupted_Order() {
+	mainBlock := testaide.NewMainShardBlock()
+	mainBlock.ChildBlocks = nil
+
+	shardId := coreTypes.ShardId(1)
+
+	firstBlock := testaide.NewExecutionShardBlock()
+	firstBlock.ShardId = shardId
+
+	secondBlock := testaide.NewExecutionShardBlock()
+	secondBlock.ShardId = shardId
+	secondBlock.Number = firstBlock.Number - 10
+	secondBlock.ParentHash = firstBlock.Hash
+
+	mainBlock.ChildBlocks = append(mainBlock.ChildBlocks, firstBlock.Hash, secondBlock.Hash)
+
+	children := map[coreTypes.ShardId]types.ShardChainSegment{
+		shardId: []*types.Block{firstBlock, secondBlock},
+	}
+
+	subgraph, err := types.NewSubgraph(mainBlock, children)
+	s.Require().ErrorContains(err, "validation failed for shard "+shardId.String())
+	s.Require().Nil(subgraph)
+}
+
+func (s *BlockBatchTestSuite) Test_CreateProofTask() {
 	const childBLockCount = 4
 	batch := testaide.NewBlockBatch(childBLockCount)
 
@@ -125,15 +73,11 @@ func (s *BlockBatchTestSuite) TestCreateProofTask() {
 	s.Require().NoError(err)
 
 	task := taskEntry.Task
+	s.Require().Equal(types.WaitingForExecutor, taskEntry.Status)
 	s.Require().Equal(types.ProofBatch, task.TaskType)
 	s.Require().Equal(batch.Id, task.BatchId)
-	s.Require().Equal(batch.MainShardBlock.Hash, task.BlockIds[0].Hash)
 	s.Require().Nil(task.ParentTaskId)
 
-	for i, childBlock := range batch.ChildBlocks {
-		// `testaide.NewBlockBatch(n)` creates one main shard block and `n` child blocks, each for different shard
-		taskChildBlock := task.BlockIds[i+1]
-
-		s.Require().Equal(childBlock.Hash, taskChildBlock.Hash)
-	}
+	blockIds := batch.BlockIds()
+	s.Require().Equal(blockIds, task.BlockIds)
 }

--- a/nil/services/synccommittee/core/block_fetcher.go
+++ b/nil/services/synccommittee/core/block_fetcher.go
@@ -1,0 +1,19 @@
+package core
+
+import (
+	"context"
+
+	"github.com/NilFoundation/nil/nil/internal/types"
+	"github.com/NilFoundation/nil/nil/services/rpc/jsonrpc"
+)
+
+type RpcBlockFetcher interface {
+	GetBlock(ctx context.Context, shardId types.ShardId, blockId any, fullTx bool) (*jsonrpc.RPCBlock, error)
+	GetBlocksRange(
+		ctx context.Context,
+		shardId types.ShardId,
+		from, to types.BlockNumber,
+		fullTx bool,
+		batchSize int,
+	) ([]*jsonrpc.RPCBlock, error)
+}

--- a/nil/services/synccommittee/core/proposer.go
+++ b/nil/services/synccommittee/core/proposer.go
@@ -10,7 +10,6 @@ import (
 	"github.com/NilFoundation/nil/nil/common/concurrent"
 	"github.com/NilFoundation/nil/nil/common/logging"
 	"github.com/NilFoundation/nil/nil/internal/types"
-	"github.com/NilFoundation/nil/nil/services/rpc/jsonrpc"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/metrics"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/rollupcontract"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/srv"
@@ -25,10 +24,6 @@ type ProposerStorage interface {
 	TryGetNextProposalData(ctx context.Context) (*scTypes.ProposalData, error)
 
 	SetBatchAsProposed(ctx context.Context, id scTypes.BatchId) error
-}
-
-type RpcBlockFetcher interface {
-	GetBlock(ctx context.Context, shardId types.ShardId, blockId any, fullTx bool) (*jsonrpc.RPCBlock, error)
 }
 
 type ProposerMetrics interface {
@@ -303,7 +298,8 @@ func (p *proposer) updateState(
 	validityProof := []byte{0x0A, 0x0B, 0x0C}
 
 	p.logger.Info().
-		Stringer("blockHash", data.MainShardBlockHash).
+		Stringer("oldStateRoot", data.OldProvedStateRoot).
+		Stringer("newStateRoot", data.NewProvedStateRoot).
 		Int("txCount", len(data.Transactions)).
 		Msg("calling UpdateState L1 method")
 

--- a/nil/services/synccommittee/core/service_test.go
+++ b/nil/services/synccommittee/core/service_test.go
@@ -92,8 +92,12 @@ func (s *SyncCommitteeTestSuite) waitMainShardToProcess() {
 	s.T().Helper()
 	s.Require().Eventually(
 		func() bool {
-			lastFetched, err := s.blockStorage.TryGetLatestFetched(s.Context)
-			return err == nil && lastFetched != nil && lastFetched.Number > 0
+			latestFetched, err := s.blockStorage.GetLatestFetched(s.Context)
+			if err != nil {
+				return false
+			}
+			mainRef := latestFetched.TryGetMain()
+			return mainRef != nil && mainRef.Number > 0
 		},
 		5*time.Second,
 		100*time.Millisecond,

--- a/nil/services/synccommittee/core/subgraph_fetcher.go
+++ b/nil/services/synccommittee/core/subgraph_fetcher.go
@@ -1,0 +1,123 @@
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/NilFoundation/nil/nil/common/logging"
+	coreTypes "github.com/NilFoundation/nil/nil/internal/types"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
+)
+
+type subgraphFetcher struct {
+	rpcClient RpcBlockFetcher
+	logger    logging.Logger
+}
+
+func newSubgraphFetcher(
+	rpcClient RpcBlockFetcher,
+	logger logging.Logger,
+) *subgraphFetcher {
+	return &subgraphFetcher{
+		rpcClient: rpcClient,
+		logger:    logger,
+	}
+}
+
+func (f *subgraphFetcher) FetchSubgraph(
+	ctx context.Context,
+	mainShardBlock *types.Block,
+	latestFetched types.BlockRefs,
+) (*types.Subgraph, error) {
+	segments, err := f.fetchShardChainSegments(ctx, mainShardBlock, latestFetched)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch shard chain segments: %w", err)
+	}
+
+	return types.NewSubgraph(mainShardBlock, segments)
+}
+
+func (f *subgraphFetcher) fetchShardChainSegments(
+	ctx context.Context,
+	mainShardBlock *types.Block,
+	latestFetched types.BlockRefs,
+) (map[coreTypes.ShardId]types.ShardChainSegment, error) {
+	childIds, err := types.ChildBlockIds(mainShardBlock)
+	if err != nil {
+		return nil, err
+	}
+
+	segments := make(map[coreTypes.ShardId]types.ShardChainSegment)
+
+	for _, childId := range childIds {
+		latestFetchedInShard := latestFetched.TryGet(childId.ShardId)
+		segment, err := f.fetchShardChainSegment(ctx, latestFetchedInShard, childId)
+		if err != nil {
+			return nil, fmt.Errorf("error fetching shard chain segment, childId=%s: %w", childId, err)
+		}
+		if len(segment) == 0 {
+			f.logger.Warn().
+				Stringer(logging.FieldShardId, childId.ShardId).
+				Stringer(logging.FieldBlockHash, childId.Hash).
+				Msg("received empty chain segment, skipping")
+			continue
+		}
+
+		segments[childId.ShardId] = segment
+	}
+
+	return segments, nil
+}
+
+func (f *subgraphFetcher) fetchShardChainSegment(
+	ctx context.Context,
+	latestFetched *types.BlockRef,
+	latestInSubgraph types.BlockId,
+) (types.ShardChainSegment, error) {
+	latestSubBlock, err := f.getBlockById(ctx, latestInSubgraph)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := latestFetched.ValidateDescendant(types.BlockToRef(latestSubBlock)); err != nil {
+		return nil, fmt.Errorf("cannot fetch chain segment: %w", err)
+	}
+
+	var fetchStartingNumber coreTypes.BlockNumber
+	if latestFetched != nil {
+		fetchStartingNumber = latestFetched.Number + 1
+	} else {
+		fetchStartingNumber = 0
+	}
+
+	f.logger.Debug().
+		Stringer(logging.FieldShardId, latestInSubgraph.ShardId).
+		Msgf(
+			"Fetching chain segment [%d, %d] from shard %d",
+			fetchStartingNumber, latestSubBlock.Number, latestInSubgraph.ShardId,
+		)
+
+	const requestBatchSize = 20
+	blocks, err := f.rpcClient.GetBlocksRange(
+		ctx, latestInSubgraph.ShardId, fetchStartingNumber, latestSubBlock.Number, true, requestBatchSize,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching chain segment from shard %d: %w", latestInSubgraph.ShardId, err)
+	}
+
+	blocks = append(blocks, latestSubBlock)
+	return blocks, nil
+}
+
+func (f *subgraphFetcher) getBlockById(ctx context.Context, id types.BlockId) (*types.Block, error) {
+	latestChild, err := f.rpcClient.GetBlock(ctx, id.ShardId, id.Hash, false)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching latest child block from shard %d: %w", id.ShardId, err)
+	}
+	if latestChild == nil {
+		return nil, fmt.Errorf(
+			"%w: latest child block not found in chain, id=%s: %w", types.ErrBlockNotFound, id, err,
+		)
+	}
+	return latestChild, nil
+}

--- a/nil/services/synccommittee/core/subgraph_fetcher_test.go
+++ b/nil/services/synccommittee/core/subgraph_fetcher_test.go
@@ -1,0 +1,86 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/NilFoundation/nil/nil/client"
+	"github.com/NilFoundation/nil/nil/common/logging"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/testaide"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
+	"github.com/stretchr/testify/suite"
+)
+
+type SubgraphFetcherTestSuite struct {
+	suite.Suite
+
+	ctx          context.Context
+	cancellation context.CancelFunc
+
+	logger        logging.Logger
+	rpcClientMock *client.ClientMock
+	fetcher       *subgraphFetcher
+}
+
+func TestSubgraphFetcherTestSuite(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(SubgraphFetcherTestSuite))
+}
+
+func (s *SubgraphFetcherTestSuite) SetupSuite() {
+	s.ctx, s.cancellation = context.WithCancel(context.Background())
+	s.logger = logging.NewLogger("subgraph_fetcher_test")
+}
+
+func (s *SubgraphFetcherTestSuite) SetupTest() {
+	s.rpcClientMock = &client.ClientMock{}
+	s.fetcher = newSubgraphFetcher(s.rpcClientMock, s.logger)
+}
+
+func (s *SubgraphFetcherTestSuite) TearDownSuite() {
+	s.cancellation()
+}
+
+func (s *SubgraphFetcherTestSuite) Test_Child_Does_Not_Exist() {
+	batches := testaide.NewBatchesSequence(3)
+	testaide.ClientMockSetBatches(s.rpcClientMock, batches)
+
+	unknownMainBlock := testaide.NewMainShardBlock()
+	emptyRefs := make(types.BlockRefs)
+
+	subgraph, err := s.fetcher.FetchSubgraph(s.ctx, unknownMainBlock, emptyRefs)
+	s.Require().ErrorIs(err, types.ErrBlockNotFound)
+	s.Require().Nil(subgraph)
+}
+
+func (s *SubgraphFetcherTestSuite) Test_Child_Fetched_Mismatch() {
+	batches := testaide.NewBatchesSequence(3)
+	testaide.ClientMockSetBatches(s.rpcClientMock, batches)
+	targetBatch := batches[len(batches)-1]
+
+	mainBlock := targetBatch.LatestMainBlock()
+
+	// emulating SyncCommittee getting ahead of the cluster in shard 1
+	refs := targetBatch.LatestRefs()
+	refs[1] = types.NewBlockRef(refs[1].ShardId, refs[1].Hash, refs[1].Number+10)
+
+	subgraph, err := s.fetcher.FetchSubgraph(s.ctx, mainBlock, refs)
+	s.Require().ErrorIs(err, types.ErrBlockMismatch)
+	s.Require().Nil(subgraph)
+}
+
+func (s *SubgraphFetcherTestSuite) Test_Fetch_No_Latest_Refs() {
+	batches := testaide.NewBatchesSequence(1)
+	testaide.ClientMockSetBatches(s.rpcClientMock, batches)
+	targetBatch := batches[len(batches)-1]
+
+	mainBlock := targetBatch.LatestMainBlock()
+	emptyRefs := make(types.BlockRefs)
+
+	subgraph, err := s.fetcher.FetchSubgraph(s.ctx, mainBlock, emptyRefs)
+	s.Require().NoError(err)
+	s.Require().NotNil(subgraph)
+
+	expectedSubgraph := targetBatch.Subgraphs[len(targetBatch.Subgraphs)-1]
+	s.Require().Equal(expectedSubgraph, *subgraph)
+}

--- a/nil/services/synccommittee/internal/metrics/sync_committee_metrics.go
+++ b/nil/services/synccommittee/internal/metrics/sync_committee_metrics.go
@@ -119,7 +119,7 @@ func (h *SyncCommitteeMetricsHandler) RecordBatchProved(ctx context.Context) {
 func (h *SyncCommitteeMetricsHandler) RecordProposerTxSent(ctx context.Context, proposalData *types.ProposalData) {
 	h.totalL1TxSent.Add(ctx, 1, h.attributes)
 
-	totalTimeMs := time.Since(proposalData.MainBlockFetchedAt).Milliseconds()
+	totalTimeMs := time.Since(proposalData.FirstBlockFetchedAt).Milliseconds()
 	h.blockTotalTimeMs.Record(ctx, totalTimeMs, h.attributes)
 
 	txCount := int64(len(proposalData.Transactions))

--- a/nil/services/synccommittee/internal/storage/block_storage_entries.go
+++ b/nil/services/synccommittee/internal/storage/block_storage_entries.go
@@ -8,48 +8,59 @@ import (
 	"time"
 
 	"github.com/NilFoundation/nil/nil/common"
+	"github.com/NilFoundation/nil/nil/common/check"
 	"github.com/NilFoundation/nil/nil/internal/types"
-	"github.com/NilFoundation/nil/nil/services/rpc/jsonrpc"
 	scTypes "github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
 )
 
-var mainShardKey = makeShardKey(types.MainShardId)
+var mainShardKey = marshallShardId(types.MainShardId)
 
 type batchEntry struct {
-	Id                  scTypes.BatchId  `json:"batchId"`
-	ParentId            *scTypes.BatchId `json:"parentBatchId,omitempty"`
-	MainParentBlockHash common.Hash      `json:"mainParentHash"`
+	Id       scTypes.BatchId  `json:"batchId"`
+	ParentId *scTypes.BatchId `json:"parentBatchId,omitempty"`
 
-	MainBlockId  scTypes.BlockId   `json:"mainBlockId"`
-	ExecBlockIds []scTypes.BlockId `json:"execBlockIds"`
+	ParentRefs          map[types.ShardId]*scTypes.BlockRef `json:"parentRefs"`
+	LatestMainBlockHash common.Hash                         `json:"latestMainBlockHash"`
+	BlockIds            []scTypes.BlockId                   `json:"blockIds"`
 
 	IsProved  bool      `json:"isProved,omitempty"`
 	CreatedAt time.Time `json:"createdAt"`
 }
 
 func newBatchEntry(batch *scTypes.BlockBatch, createdAt time.Time) *batchEntry {
-	execBlockIds := make([]scTypes.BlockId, 0, len(batch.ChildBlocks))
-	for _, childBlock := range batch.ChildBlocks {
-		execBlockIds = append(execBlockIds, scTypes.IdFromBlock(childBlock))
-	}
+	parentRefs := batch.ParentRefs()
+	mainRef, ok := parentRefs[types.MainShardId]
+	check.PanicIfNotf(ok && mainRef != nil, "batch must have a parent ref for main shard, id=%s", batch.Id)
 
 	return &batchEntry{
-		Id:                  batch.Id,
-		ParentId:            batch.ParentId,
-		MainParentBlockHash: batch.MainShardBlock.ParentHash,
-		MainBlockId:         scTypes.IdFromBlock(batch.MainShardBlock),
-		ExecBlockIds:        execBlockIds,
-		CreatedAt:           createdAt,
+		Id:       batch.Id,
+		ParentId: batch.ParentId,
+
+		ParentRefs:          batch.ParentRefs(),
+		LatestMainBlockHash: batch.LatestMainBlock().Hash,
+		BlockIds:            batch.BlockIds(),
+
+		IsProved:  false,
+		CreatedAt: createdAt,
 	}
+}
+
+func (e *batchEntry) IsValidProposalCandidate(currentStateRoot common.Hash) bool {
+	mainParentRef, ok := e.ParentRefs[types.MainShardId]
+	if !ok {
+		return false
+	}
+
+	return e.IsProved && mainParentRef.Hash == currentStateRoot
 }
 
 type blockEntry struct {
-	Block     jsonrpc.RPCBlock `json:"block"`
-	BatchId   scTypes.BatchId  `json:"batchId"`
-	FetchedAt time.Time        `json:"fetchedAt"`
+	Block     scTypes.Block   `json:"block"`
+	BatchId   scTypes.BatchId `json:"batchId"`
+	FetchedAt time.Time       `json:"fetchedAt"`
 }
 
-func newBlockEntry(block *jsonrpc.RPCBlock, containingBatch *scTypes.BlockBatch, fetchedAt time.Time) *blockEntry {
+func newBlockEntry(block *scTypes.Block, containingBatch *scTypes.BlockBatch, fetchedAt time.Time) *blockEntry {
 	return &blockEntry{
 		Block:     *block,
 		BatchId:   containingBatch.Id,
@@ -79,8 +90,12 @@ func unmarshallEntry[E any](key []byte, val []byte) (*E, error) {
 	return entry, nil
 }
 
-func makeShardKey(shardId types.ShardId) []byte {
+func marshallShardId(shardId types.ShardId) []byte {
 	key := make([]byte, 4)
 	binary.LittleEndian.PutUint32(key, uint32(shardId))
 	return key
+}
+
+func unmarshallShardId(key []byte) types.ShardId {
+	return types.ShardId(binary.LittleEndian.Uint32(key))
 }

--- a/nil/services/synccommittee/internal/storage/block_storage_op_batch.go
+++ b/nil/services/synccommittee/internal/storage/block_storage_op_batch.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"iter"
 
-	"github.com/NilFoundation/nil/nil/common/logging"
 	"github.com/NilFoundation/nil/nil/internal/db"
 	scTypes "github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
 )
@@ -16,10 +15,6 @@ const (
 	// batchesTable stores blocks batches produced by the Sync Committee.
 	// Key: scTypes.BatchId, Value: batchEntry.
 	batchesTable db.TableName = "batches"
-
-	// batchParentIdxTable is used for indexing batches by their parent ids.
-	// Key: scTypes.BatchId (batch's parent id), Value: scTypes.BatchId (batch's own id);
-	batchParentIdxTable db.TableName = "blocks_parent_hash_idx"
 )
 
 // batchOp represents the set of operations related to batches within the storage.
@@ -70,47 +65,47 @@ func (batchOp) getBatchBytesId(tx db.RoTx, idBytes []byte, required bool) (*batc
 	return entry, nil
 }
 
-// getBatchesSequence iterates through a chain of batches, starting from the batch with the given id.
-// It uses batchParentIdxTable to retrieve parent-child connections between batches.
-func (t batchOp) getBatchesSequence(tx db.RoTx, startingId scTypes.BatchId) iter.Seq2[*batchEntry, error] {
+// getBatchesSeqReversed iterates through a chain of batches between two ids (boundaries included) in reverse order.
+// Batch `from` is expected to be a descendant of the batch `to`.
+func (t batchOp) getBatchesSeqReversed(
+	tx db.RoTx, from scTypes.BatchId, to scTypes.BatchId,
+) iter.Seq2[*batchEntry, error] {
 	return func(yield func(*batchEntry, error) bool) {
-		startBatch, err := t.getBatch(tx, startingId)
+		startBatch, err := t.getBatch(tx, from)
 		if err != nil {
 			yield(nil, err)
 			return
 		}
 
-		if !yield(startBatch, nil) {
+		if !yield(startBatch, nil) || from == to {
 			return
 		}
 
-		seenParentIds := make(map[scTypes.BatchId]bool)
-		nextParentId := startBatch.Id
+		seenBatches := make(map[scTypes.BatchId]bool)
+		nextBatchId := startBatch.ParentId
 		for {
-			if seenParentIds[nextParentId] {
-				yield(nil, fmt.Errorf("cycle detected in the batch chain, parentId=%s", nextParentId))
+			if nextBatchId == nil {
+				yield(nil, fmt.Errorf("unable to restore batch sequence [%s, %s]", from, to))
 				return
 			}
-			seenParentIds[nextParentId] = true
 
-			nextIdBytes, err := tx.Get(batchParentIdxTable, nextParentId.Bytes())
-			if err != nil && !errors.Is(err, db.ErrKeyNotFound) {
-				yield(nil, fmt.Errorf("failed to get parent batch idx entry, parentId=%s: %w", nextParentId, err))
+			if seenBatches[*nextBatchId] {
+				yield(nil, fmt.Errorf("cycle detected in the batch chain, parentId=%s", nextBatchId))
 				return
 			}
-			if nextIdBytes == nil {
-				break
-			}
-			nextBatchEntry, err := t.getBatchBytesId(tx, nextIdBytes, true)
+			seenBatches[*nextBatchId] = true
+
+			nextBatchEntry, err := t.getBatch(tx, *nextBatchId)
 			if err != nil {
 				yield(nil, err)
 				return
 			}
 
-			if !yield(nextBatchEntry, nil) {
+			if !yield(nextBatchEntry, nil) || nextBatchEntry.Id == to {
 				return
 			}
-			nextParentId = nextBatchEntry.Id
+
+			nextBatchId = nextBatchEntry.ParentId
 		}
 	}
 }
@@ -144,55 +139,10 @@ func (batchOp) getStoredBatchesSeq(tx db.RoTx) iter.Seq2[*batchEntry, error] {
 	}
 }
 
-func (batchOp) putBatchParentIndexEntry(tx db.RwTx, batch *scTypes.BlockBatch) error {
-	if batch.ParentId == nil {
-		return nil
-	}
-
-	err := tx.Put(batchParentIdxTable, batch.ParentId.Bytes(), batch.Id.Bytes())
-	if err != nil {
-		return fmt.Errorf(
-			"failed to put parent batch idx entry, batchId=%s, parentId=%s,: %w", batch.Id, batch.ParentId, err,
-		)
-	}
-
-	return nil
-}
-
-func (t batchOp) deleteBatch(tx db.RwTx, batch *batchEntry, logger logging.Logger) error {
+func (t batchOp) deleteBatch(tx db.RwTx, batch *batchEntry) error {
 	if err := tx.Delete(batchesTable, batch.Id.Bytes()); err != nil {
 		return fmt.Errorf("failed to delete batch with id=%s: %w", batch.Id, err)
 	}
 
-	if err := t.deleteBatchParentIndexEntry(tx, batch, logger); err != nil {
-		return err
-	}
-
 	return nil
-}
-
-func (batchOp) deleteBatchParentIndexEntry(tx db.RwTx, batch *batchEntry, logger logging.Logger) error {
-	if batch.ParentId == nil {
-		return nil
-	}
-
-	err := tx.Delete(batchParentIdxTable, batch.ParentId.Bytes())
-
-	switch {
-	case err == nil:
-		return nil
-
-	case errors.Is(err, context.Canceled):
-		return err
-
-	case errors.Is(err, db.ErrKeyNotFound):
-		logger.Warn().Err(err).
-			Stringer(logging.FieldBatchId, batch.Id).
-			Stringer("parentBatchId", batch.ParentId).
-			Msg("parent batch idx entry is not found")
-		return nil
-
-	default:
-		return fmt.Errorf("failed to delete parent batch idx entry, parentId=%s: %w", batch.ParentId, err)
-	}
 }

--- a/nil/services/synccommittee/internal/storage/block_storage_op_blocks_latest_fetched.go
+++ b/nil/services/synccommittee/internal/storage/block_storage_op_blocks_latest_fetched.go
@@ -2,81 +2,99 @@ package storage
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 
 	"github.com/NilFoundation/nil/nil/internal/db"
 	"github.com/NilFoundation/nil/nil/internal/types"
-	"github.com/NilFoundation/nil/nil/services/rpc/jsonrpc"
 	scTypes "github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
 )
 
 const (
 	// latestFetchedTable stores reference to the latest main shard block.
-	// Key: mainShardKey, Value: scTypes.MainBlockRef.
+	// Key: types.ShardId, Value: scTypes.BlockRef.
 	latestFetchedTable db.TableName = "latest_fetched"
 )
 
 // blockLatestFetchedOp represents the set of operations related to latest fetched blocks within the storage.
 type blockLatestFetchedOp struct{}
 
-func (blockLatestFetchedOp) getLatestFetchedMain(tx db.RoTx) (*scTypes.MainBlockRef, error) {
-	value, err := tx.Get(latestFetchedTable, mainShardKey)
-	if errors.Is(err, db.ErrKeyNotFound) {
-		return nil, nil
-	}
+func (blockLatestFetchedOp) getLatestFetched(tx db.RoTx) (scTypes.BlockRefs, error) {
+	iter, err := tx.Range(latestFetchedTable, nil, nil)
 	if err != nil {
 		return nil, err
 	}
+	defer iter.Close()
 
-	var blockRef *scTypes.MainBlockRef
-	err = json.Unmarshal(value, &blockRef)
-	if err != nil {
-		return nil, fmt.Errorf("%w: %w", ErrSerializationFailed, err)
+	refs := make(scTypes.BlockRefs)
+
+	for iter.HasNext() {
+		key, value, err := iter.Next()
+		if err != nil {
+			return nil, err
+		}
+
+		shardId := unmarshallShardId(key)
+
+		var blockRef scTypes.BlockRef
+		err = json.Unmarshal(value, &blockRef)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %w", ErrSerializationFailed, err)
+		}
+
+		refs[shardId] = blockRef
 	}
-	return blockRef, nil
+
+	return refs, nil
 }
 
-func (blockLatestFetchedOp) putLatestFetchedBlock(
-	tx db.RwTx,
-	shardId types.ShardId,
-	block *scTypes.MainBlockRef,
-) error {
-	bytes, err := json.Marshal(block)
+func (blockLatestFetchedOp) putLatestFetchedRef(tx db.RwTx, shardId types.ShardId, blockRef *scTypes.BlockRef) error {
+	key := marshallShardId(shardId)
+
+	if blockRef == nil {
+		if err := tx.Delete(latestFetchedTable, key); err != nil {
+			return fmt.Errorf("failed to delete latest fetched ref, shardId=%d: %w", shardId, err)
+		}
+		return nil
+	}
+
+	bytes, err := json.Marshal(blockRef)
 	if err != nil {
 		return fmt.Errorf(
-			"%w: failed to encode block ref with hash=%s: %w", ErrSerializationFailed, block.Hash.String(), err,
+			"%w: failed to encode block ref with hash=%s: %w", ErrSerializationFailed, blockRef.Hash.String(), err,
 		)
 	}
-	err = tx.Put(latestFetchedTable, makeShardKey(shardId), bytes)
+	err = tx.Put(latestFetchedTable, key, bytes)
 	if err != nil {
-		return fmt.Errorf("failed to put block ref with hash=%s: %w", block.Hash.String(), err)
+		return fmt.Errorf("failed to put block ref with hash=%s: %w", blockRef.Hash.String(), err)
 	}
 	return nil
 }
 
-func (t blockLatestFetchedOp) updateLatestFetched(tx db.RwTx, block *jsonrpc.RPCBlock) error {
-	if block.ShardId != types.MainShardId {
-		return nil
+func (t blockLatestFetchedOp) putLatestFetchedRefs(tx db.RwTx, refs scTypes.BlockRefs) error {
+	for _, ref := range refs {
+		if err := t.putLatestFetchedRef(tx, ref.ShardId, &ref); err != nil {
+			return err
+		}
 	}
+	return nil
+}
 
-	latestFetched, err := t.getLatestFetchedMain(tx)
+func (t blockLatestFetchedOp) resetLatestFetched(tx db.RwTx) error {
+	iter, err := tx.Range(latestFetchedTable, nil, nil)
 	if err != nil {
 		return err
 	}
+	defer iter.Close()
 
-	if latestFetched.Equals(block) {
-		return nil
+	for iter.HasNext() {
+		key, _, err := iter.Next()
+		if err != nil {
+			return err
+		}
+		if err := tx.Delete(latestFetchedTable, key); err != nil {
+			return err
+		}
 	}
 
-	if err := latestFetched.ValidateChild(block); err != nil {
-		return fmt.Errorf("unable to update latest fetched block: %w", err)
-	}
-
-	newLatestFetched, err := scTypes.NewBlockRef(block)
-	if err != nil {
-		return err
-	}
-
-	return t.putLatestFetchedBlock(tx, block.ShardId, newLatestFetched)
+	return nil
 }

--- a/nil/services/synccommittee/internal/storage/block_storage_op_state_root.go
+++ b/nil/services/synccommittee/internal/storage/block_storage_op_state_root.go
@@ -12,10 +12,6 @@ const (
 	// stateRootTable stores the latest ProvedStateRoot (single value).
 	// Key: mainShardKey, Value: common.Hash.
 	stateRootTable db.TableName = "state_root"
-
-	// nextToProposeTable stores parent's hash of the next block to propose (single value).
-	// Key: mainShardKey, Value: common.Hash.
-	nextToProposeTable db.TableName = "next_to_propose_parent_hash"
 )
 
 // stateRootOp represents the set of operations related to latest fetched blocks within the storage.
@@ -40,29 +36,4 @@ func (stateRootOp) getProvedStateRoot(tx db.RoTx) (*common.Hash, error) {
 
 	hash := common.BytesToHash(hashBytes)
 	return &hash, nil
-}
-
-// getParentOfNextToPropose retrieves parent's hash of the next block to propose
-func (stateRootOp) getParentOfNextToPropose(tx db.RoTx) (*common.Hash, error) {
-	hashBytes, err := tx.Get(nextToProposeTable, mainShardKey)
-
-	if errors.Is(err, db.ErrKeyNotFound) {
-		return nil, nil
-	}
-
-	if err != nil {
-		return nil, fmt.Errorf("failed to get next to propose parent hash: %w", err)
-	}
-
-	hash := common.BytesToHash(hashBytes)
-	return &hash, nil
-}
-
-// setParentOfNextToPropose sets parent's hash of the next block to propose
-func (stateRootOp) setParentOfNextToPropose(tx db.RwTx, hash common.Hash) error {
-	err := tx.Put(nextToProposeTable, mainShardKey, hash.Bytes())
-	if err != nil {
-		return fmt.Errorf("failed to put next to propose parent hash: %w", err)
-	}
-	return nil
 }

--- a/nil/services/synccommittee/internal/testaide/client_mock_block_setter.go
+++ b/nil/services/synccommittee/internal/testaide/client_mock_block_setter.go
@@ -1,0 +1,83 @@
+package testaide
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"log"
+	"slices"
+
+	"github.com/NilFoundation/nil/nil/client"
+	"github.com/NilFoundation/nil/nil/common"
+	"github.com/NilFoundation/nil/nil/internal/types"
+	scTypes "github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
+)
+
+func ClientMockSetBatches(client *client.ClientMock, batches []*scTypes.BlockBatch) {
+	blocksIter := func(yield func(*scTypes.Block) bool) {
+		for _, batch := range batches {
+			for block := range batch.BlocksIter() {
+				if !yield(block) {
+					return
+				}
+			}
+		}
+	}
+
+	ClientMockSetBlocks(client, blocksIter)
+}
+
+func ClientMockSetBlocks(client *client.ClientMock, blocks iter.Seq[*scTypes.Block]) {
+	idToBlocks := make(map[scTypes.BlockId]*scTypes.Block)
+	shardsToBlocks := make(map[types.ShardId][]*scTypes.Block)
+
+	for block := range blocks {
+		blockId := scTypes.IdFromBlock(block)
+		if _, ok := idToBlocks[blockId]; ok {
+			log.Panicf("block id duplicated in batches: %s", blockId)
+		}
+
+		idToBlocks[blockId] = block
+
+		blockSlice := shardsToBlocks[block.ShardId]
+		blockSlice = append(blockSlice, block)
+		shardsToBlocks[block.ShardId] = blockSlice
+	}
+
+	for _, blockSlice := range shardsToBlocks {
+		slices.SortFunc(blockSlice, func(a, b *scTypes.Block) int {
+			return int(a.Number - b.Number)
+		})
+	}
+
+	client.GetBlockFunc = func(
+		_ context.Context, shardId types.ShardId, blockId any, fullTx bool,
+	) (*scTypes.Block, error) {
+		if strId, ok := blockId.(string); ok && strId == "latest" {
+			shardSlice := shardsToBlocks[shardId]
+			if len(shardSlice) == 0 {
+				return nil, nil
+			}
+			return shardSlice[len(shardSlice)-1], nil
+		}
+
+		blockHash, ok := blockId.(common.Hash)
+		if !ok {
+			return nil, fmt.Errorf("unexpected blockId type: %v", blockId)
+		}
+		id := scTypes.NewBlockId(shardId, blockHash)
+		return idToBlocks[id], nil
+	}
+
+	client.GetBlocksRangeFunc = func(
+		_ context.Context, shardId types.ShardId, from types.BlockNumber, to types.BlockNumber, _ bool, _ int,
+	) ([]*scTypes.Block, error) {
+		blockRange := make([]*scTypes.Block, 0)
+		for _, block := range shardsToBlocks[shardId] {
+			if block.Number >= from && block.Number < to {
+				blockRange = append(blockRange, block)
+			}
+		}
+		return blockRange, nil
+	}
+}

--- a/nil/services/synccommittee/internal/types/block_subgraph.go
+++ b/nil/services/synccommittee/internal/types/block_subgraph.go
@@ -1,0 +1,95 @@
+package types
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/NilFoundation/nil/nil/internal/types"
+)
+
+// ShardChainSegment represents a sequence of blocks in a shard
+type ShardChainSegment []*Block
+
+// Earliest retrieves the first block in the segment
+func (s ShardChainSegment) Earliest() *Block {
+	if len(s) == 0 {
+		return nil
+	}
+	return s[0]
+}
+
+// Latest retrieves the last block in the segment
+func (s ShardChainSegment) Latest() *Block {
+	if len(s) == 0 {
+		return nil
+	}
+	return s[len(s)-1]
+}
+
+// Subgraph represents a structure containing a main blockchain segment and its associated exec shard blocks
+type Subgraph struct {
+	Main     *Block
+	Children map[types.ShardId]ShardChainSegment
+}
+
+func NewSubgraph(main *Block, children map[types.ShardId]ShardChainSegment) (*Subgraph, error) {
+	if err := validateSubgraph(main, children); err != nil {
+		return nil, err
+	}
+
+	return &Subgraph{
+		Main:     main,
+		Children: children,
+	}, nil
+}
+
+func (s *Subgraph) BlocksCount() uint32 {
+	res := uint32(1) // single main block
+	for _, segment := range s.Children {
+		res += uint32(len(segment))
+	}
+	return res
+}
+
+func validateSubgraph(mainShardBlock *Block, children map[types.ShardId]ShardChainSegment) error {
+	switch {
+	case mainShardBlock == nil:
+		return errors.New("mainShardBlock cannot be nil")
+
+	case mainShardBlock.ShardId != types.MainShardId:
+		return fmt.Errorf("mainShardBlock is not from the mainShardBlock shard: %d", mainShardBlock.ShardId)
+	}
+
+	for shardId, segment := range children {
+		if err := validateSegment(segment); err != nil {
+			return fmt.Errorf("segment validation failed for shard %d: %w", shardId, err)
+		}
+	}
+
+	return nil
+}
+
+func validateSegment(segment ShardChainSegment) error {
+	if len(segment) == 0 {
+		return errors.New("segment cannot be empty")
+	}
+
+	shardId := segment[0].ShardId
+
+	for i, block := range segment {
+		if block.ShardId != shardId {
+			return fmt.Errorf("shardId mismatch at index %d: %d != %d", i, block.ShardId, shardId)
+		}
+
+		if i == 0 {
+			continue
+		}
+
+		parentRef := BlockToRef(segment[i-1])
+		if err := parentRef.ValidateNext(block); err != nil {
+			return fmt.Errorf("parent-child mismatch at index %d: %w", i, err)
+		}
+	}
+
+	return nil
+}

--- a/nil/services/synccommittee/internal/types/prover_tasks.go
+++ b/nil/services/synccommittee/internal/types/prover_tasks.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/NilFoundation/nil/nil/common"
 	"github.com/NilFoundation/nil/nil/common/check"
-	"github.com/NilFoundation/nil/nil/services/rpc/jsonrpc"
 	"github.com/google/uuid"
 )
 
@@ -280,16 +279,10 @@ func (t *Task) AsNewChildEntry(currentTime time.Time) *TaskEntry {
 }
 
 func NewBatchProofTaskEntry(
-	batchId BatchId, orderedBlocks []*jsonrpc.RPCBlock, currentTime time.Time,
+	batchId BatchId, blockIds []BlockId, currentTime time.Time,
 ) (*TaskEntry, error) {
-	if len(orderedBlocks) == 0 {
+	if len(blockIds) == 0 {
 		return nil, errors.New("no blocks for create proof batch task")
-	}
-
-	blockIds := make([]BlockId, len(orderedBlocks))
-	for i, b := range orderedBlocks {
-		blockIds[i].ShardId = b.ShardId
-		blockIds[i].Hash = b.Hash
 	}
 
 	task := Task{

--- a/nil/services/synccommittee/proofprovider/task_handler_test.go
+++ b/nil/services/synccommittee/proofprovider/task_handler_test.go
@@ -90,7 +90,7 @@ func (s *TaskHandlerTestSuite) TestHandleBatchProofTask() {
 	now := s.clock.Now()
 	executorId := testaide.RandomExecutorId()
 	batch := testaide.NewBlockBatch(testaide.ShardsCount)
-	taskEntry, err := types.NewBatchProofTaskEntry(types.NewBatchId(), batch.AllBlocks(), now)
+	taskEntry, err := batch.CreateProofTask(now)
 	s.Require().NoError(err)
 
 	err = s.taskHandler.Handle(s.context, executorId, &taskEntry.Task)


### PR DESCRIPTION
## `Batches / Subgraphs`
* Declared a new `Subgraph` type representing a dedicated subset of blocks, with the main shard block as the root;
* Updated the `BlockBatch` type to include multiple sequential subgraphs;
* Extended the `BlockBatch` exported API to simplify block traversal;

## `BlockStorage`
* Updated the `blockEntry` type to align with the modified `BlockBatch`;

#### `LatestFetched`
* `BlockStorage.GetLatestFetched()` now returns `BlockRefs` — a map instead of a single main reference;  
* Reimplemented methods in `block_storage_op_blocks_latest_fetched.go` to support multi-shard tracking of fetched references;  

#### Batch State Reset
* Removed the `ParentId` secondary index (methods: `putBatchParentIndexEntry` and `deleteBatchParentIndexEntry`; table: `blocks_parent_hash_idx`);  
* During a partial reset, batches are now traversed in reverse order, starting from the latest created batch, eliminating the need for an additional index;  

#### Proposal Data Collection
* Removed the `getParentOfNextToPropose` and `setParentOfNextToPropose` methods, along with the corresponding `next_to_propose_parent_hash` table;  
* Now, only the proved state root value is used to maintain the correct order of batch proposals;  


## `Aggregator`
* Declared `subgraphFetcher` type, responsible for fetching individual subgraphs during batch construction;
* Subgraph fetching is determined by `MainShardBlock` and the latest fetched `BlockRefs` map;  
* For now, each individual batch is limited to containing exactly one `Subgraph`;  
* Implemented test helper functions `ClientMockSetBatches(...)` and `ClientMockSetBlocks(...)` to configure `client.ClientMock` with the provided batches or individual blocks;  