### PR TITLE
[global refactoring] rename `cometaService`  to  `cometaClient`

### DIFF
--- a/clijs/test/setup.ts
+++ b/clijs/test/setup.ts
@@ -54,7 +54,7 @@ export const CliTest = test.extend<CliTestFixture>({
     configManager.updateConfig(
       ConfigKeys.NilSection,
       ConfigKeys.CometaEndpoint,
-      testEnv.cometaServiceEndpoint,
+      testEnv.cometaClientEndpoint,
     );
     configManager.updateConfig(
       ConfigKeys.NilSection,
@@ -82,7 +82,7 @@ export const CliTest = test.extend<CliTestFixture>({
 
   cometaClient: new CometaClient({
     transport: new HttpTransport({
-      endpoint: testEnv.cometaServiceEndpoint,
+      endpoint: testEnv.cometaClientEndpoint,
     }),
   }),
 

--- a/clijs/test/testEnv.ts
+++ b/clijs/test/testEnv.ts
@@ -1,10 +1,10 @@
 const defaultRpcEndpoint = "http://127.0.0.1:8529";
 const defaultFaucetServiceEndpoint = "http://127.0.0.1:8529";
-const defaultCometaServiceEndpoint = "http://127.0.0.1:8529";
+const defaultCometaClientEndpoint = "http://127.0.0.1:8529";
 const testEnv = {
   endpoint: process.env.RPC_ENDPOINT ?? defaultRpcEndpoint,
   faucetServiceEndpoint: process.env.FAUCET_SERVICE_ENDPOINT ?? defaultFaucetServiceEndpoint,
-  cometaServiceEndpoint: process.env.COMETA_SERVICE_ENDPOINT ?? defaultCometaServiceEndpoint,
+  cometaClientEndpoint: process.env.COMETA_SERVICE_ENDPOINT ?? defaultCometaClientEndpoint,
 } as const;
 
 export { testEnv };

--- a/niljs/test/testEnv.ts
+++ b/niljs/test/testEnv.ts
@@ -2,12 +2,12 @@ import "dotenv/config";
 
 const defaultRpcEndpoint = "http://127.0.0.1:8529";
 const defaultFaucetServiceEndpoint = "http://127.0.0.1:8529";
-const defaultCometaServiceEndpoint = "http://127.0.0.1:8529";
+const defaultCometaClientEndpoint = "http://127.0.0.1:8529";
 
 const testEnv = {
   endpoint: process.env.RPC_ENDPOINT ?? defaultRpcEndpoint,
   faucetServiceEndpoint: process.env.FAUCET_SERVICE_ENDPOINT ?? defaultFaucetServiceEndpoint,
-  cometaServiceEndpoint: process.env.COMETA_SERVICE_ENDPOINT ?? defaultCometaServiceEndpoint,
+  cometaClientEndpoint: process.env.COMETA_SERVICE_ENDPOINT ?? defaultCometaClientEndpoint,
 } as const;
 
 export { testEnv };

--- a/wallet-extension/test/testEnv.ts
+++ b/wallet-extension/test/testEnv.ts
@@ -1,11 +1,11 @@
 const defaultRpcEndpoint = "http://127.0.0.1:8529";
 const defaultFaucetServiceEndpoint = "http://127.0.0.1:8529";
-const defaultCometaServiceEndpoint = "http://127.0.0.1:8529";
+const defaultCometaClientEndpoint = "http://127.0.0.1:8529";
 
 const testEnv = {
   endpoint: process.env.RPC_ENDPOINT ?? defaultRpcEndpoint,
   faucetServiceEndpoint: process.env.FAUCET_SERVICE_ENDPOINT ?? defaultFaucetServiceEndpoint,
-  cometaServiceEndpoint: process.env.COMETA_SERVICE_ENDPOINT ?? defaultCometaServiceEndpoint,
+  cometaClientEndpoint: process.env.COMETA_SERVICE_ENDPOINT ?? defaultCometaClientEndpoint,
 } as const;
 
 export { testEnv };


### PR DESCRIPTION
global refactoring referencing the previous PR #574 to ensure a consistent rename from `cometaService` to `cometaClient`
