### PR TITLE
[docs] fix docs_ai_back build by adjusting typescript config

### DIFF
--- a/docs_ai_backend/tsconfig.json
+++ b/docs_ai_backend/tsconfig.json
@@ -23,6 +23,9 @@
       {
         "name": "next"
       }
+    ],
+    "types": [
+      "@hapi/shot"
     ]
   },
   "include": [


### PR DESCRIPTION
We can not build `docs_ai_backend` because of the error `Type error: Cannot find type definition file for 'hapi__shot'`. It's not clear why the error appeared, but i bet it is again because of `package-lock.json` issues.
Anyway, this diff introduces a simple fix - implicit type reference in `tsconfig.json`.