### PR TITLE
Feat: Reveal Private Key in wallet Setting

### DIFF
--- a/wallet-extension/public/icons/privatekey.svg
+++ b/wallet-extension/public/icons/privatekey.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11.4341 12.1494C12.7053 13.397 13.2069 15.2265 12.7486 16.9434C12.2902 18.6603 10.9422 20.0012 9.21627 20.4571C7.49032 20.913 5.65111 20.414 4.39688 19.1496C2.51104 17.2073 2.53801 14.1199 4.45749 12.2106C6.37698 10.3012 9.48066 10.2744 11.4332 12.1503L11.4341 12.1494Z" stroke="#F1F1F1" stroke-linejoin="round"/>
+<path d="M11.5 12L20 3.5" stroke="#F1F1F1" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M15.1523 8.44981L17.8666 11.1498L21.0333 7.99981L18.319 5.2998L15.1523 8.44981Z" stroke="#F1F1F1" stroke-linejoin="round"/>
+</svg>

--- a/wallet-extension/public/locales/en/translation.json
+++ b/wallet-extension/public/locales/en/translation.json
@@ -74,6 +74,12 @@
       "copiedButton": "Copied",
       "getEndpointButton": "Open RPC Bot"
     },
+    "privateKeyPage": {
+      "title": "View Private Key",
+      "inputPlaceholder": "Private Key",
+      "copyButton": "Copy",
+      "copiedButton": "Copied"
+    },
     "connectionPage": {
       "title": "Manage DApps"
     },
@@ -97,6 +103,7 @@
     "settingsPage": {
       "title": "Settings",
       "endpointSection": "View endpoint",
+      "privateKeySection": "View private key",
       "getSupport": "Get support",
       "manageConnection": "Manage DApps",
       "feedback": "Share Feedback",

--- a/wallet-extension/src/pages/wallet/Privatekey.tsx
+++ b/wallet-extension/src/pages/wallet/Privatekey.tsx
@@ -20,6 +20,11 @@ export const PrivateKey = () => {
 
   // Copy the private key to clipboard
   const handleCopyPrivateKey = async () => {
+    if (!privateKeyValue) {
+      console.error("No private key found");
+      return;
+    }
+
     // Only copy if there's something in privateKeyValue
     if (privateKeyValue.trim()) {
       setIsLoading(true); // Set loading state to true
@@ -67,7 +72,7 @@ export const PrivateKey = () => {
         <Input
           id="walletAddress"
           placeholder={t("wallet.privateKeyPage.inputPlaceholder")}
-          value={privateKeyValue}
+          value={privateKeyValue || ""}
           readOnly
           overrides={{
             Root: {

--- a/wallet-extension/src/pages/wallet/Privatekey.tsx
+++ b/wallet-extension/src/pages/wallet/Privatekey.tsx
@@ -4,50 +4,40 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import CheckmarkIcon from "../../../public/icons/checkmark.svg";
 import { Box, Icon, ScreenHeader } from "../../features/components/shared";
-import { $endpoint } from "../../features/store/model/endpoint";
+import { $privateKey } from "../../features/store/model/privateKey";
 import { WalletRoutes } from "../../router";
 
-export const Endpoint = () => {
+export const PrivateKey = () => {
   const { t } = useTranslation("translation");
 
-  // Get the current endpoint from Effector
-  const endpointValue = useStore($endpoint);
+  // Get the current private key from Effector
+  const privateKeyValue = useStore($privateKey);
 
   // State for button loading and text
   const [showCheckmark, setShowCheckmark] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
-  const [buttonText, setButtonText] = useState(t("wallet.endpointPage.copyButton"));
+  const [buttonText, setButtonText] = useState(t("wallet.privateKeyPage.copyButton"));
 
-  // Called when user clicks "Get Endpoint" (opens a new tab)
-  const handleGetEndpoint = async () => {
-    const endpointUrl = import.meta.env.VITE_GET_ENDPOINT_URL;
-    if (endpointUrl) {
-      await chrome.tabs.create({ url: endpointUrl });
-    } else {
-      console.error("Environment variable VITE_GET_ENDPOINT_URL is not set.");
-    }
-  };
-
-  // Copy the endpoint to clipboard
-  const handleCopyEndpoint = async () => {
-    // Only copy if there's something in endpointValue
-    if (endpointValue.trim()) {
+  // Copy the private key to clipboard
+  const handleCopyPrivateKey = async () => {
+    // Only copy if there's something in privateKeyValue
+    if (privateKeyValue.trim()) {
       setIsLoading(true); // Set loading state to true
       try {
-        await navigator.clipboard.writeText(endpointValue); // Copy to clipboard
-        console.log("Endpoint copied:", endpointValue);
+        await navigator.clipboard.writeText(privateKeyValue); // Copy to clipboard
+        console.log("Private key copied");
 
         // Update the button text to "Copied"
-        setButtonText(t("wallet.endpointPage.copiedButton"));
+        setButtonText(t("wallet.privateKeyPage.copiedButton"));
         setShowCheckmark(true);
 
         // Reset button text and hide checkmark after 10 seconds
         setTimeout(() => {
-          setButtonText(t("wallet.endpointPage.copyButton"));
+          setButtonText(t("wallet.privateKeyPage.copyButton"));
           setShowCheckmark(false);
         }, 10000);
       } catch (error) {
-        console.error("Error copying endpoint:", error);
+        console.error("Error copying private key:", error);
       } finally {
         setIsLoading(false);
       }
@@ -65,7 +55,7 @@ export const Endpoint = () => {
       }}
     >
       {/* Header */}
-      <ScreenHeader route={WalletRoutes.WALLET.SETTINGS} title={t("wallet.endpointPage.title")} />
+      <ScreenHeader route={WalletRoutes.WALLET.SETTINGS} title={t("wallet.privateKeyPage.title")} />
 
       {/* Input + Copy Button */}
       <Box
@@ -76,8 +66,8 @@ export const Endpoint = () => {
       >
         <Input
           id="walletAddress"
-          placeholder={t("wallet.endpointPage.inputPlaceholder")}
-          value={endpointValue}
+          placeholder={t("wallet.privateKeyPage.inputPlaceholder")}
+          value={privateKeyValue}
           readOnly
           overrides={{
             Root: {
@@ -94,7 +84,7 @@ export const Endpoint = () => {
         />
 
         <Button
-          onClick={handleCopyEndpoint}
+          onClick={handleCopyPrivateKey}
           isLoading={isLoading}
           overrides={{
             Root: {
@@ -126,28 +116,6 @@ export const Endpoint = () => {
           ) : (
             buttonText
           )}
-        </Button>
-      </Box>
-
-      {/* Button Section */}
-      <Box $style={{ marginTop: "auto", width: "100%" }}>
-        <Button
-          onClick={handleGetEndpoint}
-          overrides={{
-            Root: {
-              style: {
-                width: "100%",
-                height: "48px",
-                backgroundColor: COLORS.gray800,
-                color: COLORS.gray200,
-                ":hover": {
-                  backgroundColor: COLORS.gray700,
-                },
-              },
-            },
-          }}
-        >
-          {t("wallet.endpointPage.getEndpointButton")}
         </Button>
       </Box>
     </Box>

--- a/wallet-extension/src/pages/wallet/Settings.tsx
+++ b/wallet-extension/src/pages/wallet/Settings.tsx
@@ -96,7 +96,6 @@ export const Settings = () => {
           cursor: "pointer",
           color: COLORS.gray50,
           ":hover": { color: COLORS.gray200 },
-          marginTop: "48px",
           marginBottom: "24px",
         }}
         onClick={handlePrivateKey}

--- a/wallet-extension/src/pages/wallet/Settings.tsx
+++ b/wallet-extension/src/pages/wallet/Settings.tsx
@@ -5,6 +5,7 @@ import communityIcon from "../../../public/icons/community.svg";
 import endpointIcon from "../../../public/icons/endpoint.svg";
 import feedbackIcon from "../../../public/icons/feedback.svg";
 import connectionIcon from "../../../public/icons/linked.svg";
+import privateKeyIcon from "../../../public/icons/privatekey.svg";
 import supportIcon from "../../../public/icons/support.svg";
 import { Box, Icon, ScreenHeader } from "../../features/components/shared";
 import { WalletRoutes } from "../../router";
@@ -39,6 +40,10 @@ export const Settings = () => {
 
   const handleConnection = () => {
     navigate(WalletRoutes.WALLET.CONNECTIONS);
+  };
+
+  const handlePrivateKey = () => {
+    navigate(WalletRoutes.WALLET.PRIVATE_KEY);
   };
 
   return (
@@ -78,6 +83,33 @@ export const Settings = () => {
         />
         <ParagraphSmall $style={{ color: "inherit" }}>
           {t("wallet.settingsPage.endpointSection")}
+        </ParagraphSmall>
+      </Box>
+
+      {/* Private Key Section */}
+      <Box
+        $align="center"
+        $gap="8px"
+        $padding="0"
+        $style={{
+          flexDirection: "row",
+          cursor: "pointer",
+          color: COLORS.gray50,
+          ":hover": { color: COLORS.gray200 },
+          marginTop: "48px",
+          marginBottom: "24px",
+        }}
+        onClick={handlePrivateKey}
+      >
+        <Icon
+          src={privateKeyIcon}
+          alt={"private key icon"}
+          size={24}
+          iconSize="100%"
+          background="transparent"
+        />
+        <ParagraphSmall $style={{ color: "inherit" }}>
+          {t("wallet.settingsPage.privateKeySection")}
         </ParagraphSmall>
       </Box>
 
@@ -130,12 +162,12 @@ export const Settings = () => {
             >
               <Icon
                 src={link.icon}
-                alt={t(link.titleKey)}
+                alt={link.titleKey}
                 size={24}
                 iconSize="100%"
                 background="transparent"
               />
-              <ParagraphSmall $style={{ color: "inherit" }}>{t(link.titleKey)}</ParagraphSmall>
+              <ParagraphSmall $style={{ color: "inherit" }}>{link.titleKey}</ParagraphSmall>
             </Box>
           </a>
         ))}

--- a/wallet-extension/src/router/Wallet.tsx
+++ b/wallet-extension/src/router/Wallet.tsx
@@ -20,6 +20,7 @@ import {
 } from "../pages/wallet";
 import { AddCustomToken } from "../pages/wallet/AddCustomToken.tsx";
 import { ManageTokens } from "../pages/wallet/ManageTokens.tsx";
+import { PrivateKey } from "../pages/wallet/Privatekey.tsx";
 import { ErrorScreen } from "./Error.tsx";
 import { WalletRoutes } from "./routes.ts";
 
@@ -54,6 +55,9 @@ export const WalletRouter = () => {
     </Route>,
     <Route key="wallet-endpoint" path={WalletRoutes.WALLET.ENDPOINT}>
       <Route index element={<Endpoint />} />
+    </Route>,
+    <Route key="wallet-privatekey" path={WalletRoutes.WALLET.PRIVATE_KEY}>
+      <Route index element={<PrivateKey />} />
     </Route>,
     <Route key="wallet-testnet" path={WalletRoutes.WALLET.TESTNET}>
       <Route index element={<Testnet />} />

--- a/wallet-extension/src/router/routes.ts
+++ b/wallet-extension/src/router/routes.ts
@@ -12,6 +12,7 @@ export const WalletRoutes = {
     TOP_UP: "/top-up",
     SEND: "/send",
     ENDPOINT: "/endpoint",
+    PRIVATE_KEY: "/private-key",
     TESTNET: "/testnet",
     ERROR: "/error",
     MANAGE_TOKENS: "/manage-tokens",


### PR DESCRIPTION
# Add Private Key Viewing Feature to Wallet Extension

## Description
Adds a new feature allowing users to view and copy their wallet's private key from the settings page.

⚠️ **SECURITY CONCERN**: This implementation lacks proper security measures. The private key page is directly accessible without authentication, posing significant security risks.

## Changes
- New `PrivateKey` component with read-only display and copy functionality
- Added private key section to Settings page
- New route and translations for private key feature
- UI improvements for consistent styling

## Closes #356 

## Required Security Improvements
Before production:
1. Implement password/biometric verification
2. Add session validation
3. Add security warnings and user acknowledgments
4. Implement rate limiting and cooldown periods
5. Add audit logging

## Screenshots
<img width="419" alt="Screenshot 2025-03-24 at 7 30 47 AM" src="https://github.com/user-attachments/assets/e9cddaef-4f06-4678-9c8e-7d7922682b66" />
<img width="453" alt="Screenshot 2025-03-24 at 7 30 57 AM" src="https://github.com/user-attachments/assets/743a2918-83b2-48e5-9553-62596453c42b" />

