### PR TITLE
feat: implemented system commads for getting `chain-id`, `gas-price`, `shards`

### DIFF
--- a/clijs/package.json
+++ b/clijs/package.json
@@ -18,7 +18,8 @@
     "ini": "^5.0.0",
     "pino": "^9.5.0",
     "pino-pretty": "^13.0.0",
-    "postject": "^1.0.0-alpha.6"
+    "postject": "^1.0.0-alpha.6",
+    "vitest": "^3.0.9"
   },
   "devDependencies": {
     "@oclif/test": "^4",

--- a/clijs/package.json
+++ b/clijs/package.json
@@ -8,6 +8,7 @@
   },
   "bugs": "https://github.com/nil-blockchain/issues",
   "dependencies": {
+    "@libp2p/crypto": "^5.0.15",
     "@libp2p/peer-id": "^5.0.9",
     "@nilfoundation/niljs": "0.25.0",
     "@oclif/core": "^4",

--- a/clijs/package.json
+++ b/clijs/package.json
@@ -8,7 +8,6 @@
   },
   "bugs": "https://github.com/nil-blockchain/issues",
   "dependencies": {
-    "@libp2p/crypto": "^5.0.15",
     "@libp2p/peer-id": "^5.0.9",
     "@nilfoundation/niljs": "0.25.0",
     "@oclif/core": "^4",

--- a/clijs/src/commands/system/chain-id.ts
+++ b/clijs/src/commands/system/chain-id.ts
@@ -1,0 +1,21 @@
+import { BaseCommand } from "../../base.js";
+
+export default class ChainId extends BaseCommand {
+    static override description = "Get network chain ID";
+
+    static override examples = ["$ nil system chain-id"];
+
+    async run(): Promise<void> {
+        const { rpcClient } = this;
+        if (!rpcClient) {
+            this.error("RPC client is not initialized");
+        }
+
+        try {
+            const chainId = await rpcClient.chainId();
+            this.info(chainId.toString());
+        } catch (error) {
+            this.error(`Failed to get chain ID: ${error}`);
+        }
+    }
+} 

--- a/clijs/src/commands/system/chain-id.ts
+++ b/clijs/src/commands/system/chain-id.ts
@@ -13,7 +13,7 @@ export default class ChainId extends BaseCommand {
 
         try {
             const chainId = await rpcClient.chainId();
-            this.info(chainId.toString());
+            this.log(chainId.toString());
         } catch (error) {
             this.error(`Failed to get chain ID: ${error}`);
         }

--- a/clijs/src/commands/system/chain-id.ts
+++ b/clijs/src/commands/system/chain-id.ts
@@ -13,7 +13,6 @@ export default class ChainId extends BaseCommand {
 
         try {
             const chainId = await rpcClient.chainId();
-            this.log(chainId.toString());
             return chainId;
         } catch (error) {
             this.error(`Failed to get chain ID: ${error}`);

--- a/clijs/src/commands/system/chain-id.ts
+++ b/clijs/src/commands/system/chain-id.ts
@@ -5,7 +5,7 @@ export default class ChainId extends BaseCommand {
 
     static override examples = ["$ nil system chain-id"];
 
-    async run(): Promise<void> {
+    async run(): Promise<number> {
         const { rpcClient } = this;
         if (!rpcClient) {
             this.error("RPC client is not initialized");
@@ -14,6 +14,7 @@ export default class ChainId extends BaseCommand {
         try {
             const chainId = await rpcClient.chainId();
             this.log(chainId.toString());
+            return chainId;
         } catch (error) {
             this.error(`Failed to get chain ID: ${error}`);
         }

--- a/clijs/src/commands/system/gas-price.ts
+++ b/clijs/src/commands/system/gas-price.ts
@@ -24,7 +24,6 @@ export default class GasPrice extends BaseCommand {
 
         try {
             const gasPrice = await rpcClient.getGasPrice(shardId);
-            this.log(gasPrice.toString());
             return gasPrice;
         } catch (error) {
             this.error(`Failed to get gas price: ${error}`);

--- a/clijs/src/commands/system/gas-price.ts
+++ b/clijs/src/commands/system/gas-price.ts
@@ -1,0 +1,32 @@
+import { Args } from "@oclif/core";
+import { BaseCommand } from "../../base.js";
+
+export default class GasPrice extends BaseCommand {
+    static override description = "Get network gas price";
+
+    static override examples = ["$ nil system gas-price <shard-id>"];
+
+    static args = {
+        shardId: Args.integer({
+            description: "Shard number",
+            required: true,
+        }),
+    };
+
+    async run(): Promise<void> {
+        const { rpcClient } = this;
+        if (!rpcClient) {
+            this.error("RPC client is not initialized");
+        }
+
+        const { args } = await this.parse(GasPrice);
+        const { shardId } = args;
+
+        try {
+            const gasPrice = await rpcClient.getGasPrice(shardId);
+            this.info(gasPrice.toString());
+        } catch (error) {
+            this.error(`Failed to get gas price: ${error}`);
+        }
+    }
+} 

--- a/clijs/src/commands/system/gas-price.ts
+++ b/clijs/src/commands/system/gas-price.ts
@@ -24,7 +24,7 @@ export default class GasPrice extends BaseCommand {
 
         try {
             const gasPrice = await rpcClient.getGasPrice(shardId);
-            this.info(gasPrice.toString());
+            this.log(gasPrice.toString());
         } catch (error) {
             this.error(`Failed to get gas price: ${error}`);
         }

--- a/clijs/src/commands/system/gas-price.ts
+++ b/clijs/src/commands/system/gas-price.ts
@@ -13,7 +13,7 @@ export default class GasPrice extends BaseCommand {
         }),
     };
 
-    async run(): Promise<void> {
+    async run(): Promise<bigint> {
         const { rpcClient } = this;
         if (!rpcClient) {
             this.error("RPC client is not initialized");
@@ -25,6 +25,7 @@ export default class GasPrice extends BaseCommand {
         try {
             const gasPrice = await rpcClient.getGasPrice(shardId);
             this.log(gasPrice.toString());
+            return gasPrice;
         } catch (error) {
             this.error(`Failed to get gas price: ${error}`);
         }

--- a/clijs/src/commands/system/index.ts
+++ b/clijs/src/commands/system/index.ts
@@ -1,0 +1,9 @@
+import { Command } from "@oclif/core";
+
+export default class SystemCommand extends Command {
+    static override description = "Get system information";
+
+    async run(): Promise<void> {
+        await this.config.runCommand("help", ["system"]);
+    }
+}

--- a/clijs/src/commands/system/shards.ts
+++ b/clijs/src/commands/system/shards.ts
@@ -13,7 +13,6 @@ export default class Shards extends BaseCommand {
 
         try {
             const shards = await rpcClient.getShardIdList();
-            this.log(JSON.stringify(shards, null, 2));
             return shards;
         } catch (error) {
             this.error(`Failed to get shards: ${error}`);

--- a/clijs/src/commands/system/shards.ts
+++ b/clijs/src/commands/system/shards.ts
@@ -5,7 +5,7 @@ export default class Shards extends BaseCommand {
 
     static override examples = ["$ nil system shards"];
 
-    async run(): Promise<void> {
+    async run(): Promise<number[]> {
         const { rpcClient } = this;
         if (!rpcClient) {
             this.error("RPC client is not initialized");
@@ -13,7 +13,8 @@ export default class Shards extends BaseCommand {
 
         try {
             const shards = await rpcClient.getShardIdList();
-            this.info(JSON.stringify(shards, null, 2));
+            this.log(JSON.stringify(shards, null, 2));
+            return shards;
         } catch (error) {
             this.error(`Failed to get shards: ${error}`);
         }

--- a/clijs/src/commands/system/shards.ts
+++ b/clijs/src/commands/system/shards.ts
@@ -1,0 +1,21 @@
+import { BaseCommand } from "../../base.js";
+
+export default class Shards extends BaseCommand {
+    static override description = "Print the list of shards";
+
+    static override examples = ["$ nil system shards"];
+
+    async run(): Promise<void> {
+        const { rpcClient } = this;
+        if (!rpcClient) {
+            this.error("RPC client is not initialized");
+        }
+
+        try {
+            const shards = await rpcClient.getShardIdList();
+            this.info(JSON.stringify(shards, null, 2));
+        } catch (error) {
+            this.error(`Failed to get shards: ${error}`);
+        }
+    }
+} 

--- a/clijs/src/sea.ts
+++ b/clijs/src/sea.ts
@@ -10,6 +10,10 @@ import AbiCommand from "./commands/abi";
 import AbiDecode from "./commands/abi/decode";
 import AbiEncode from "./commands/abi/encode";
 import BlockCommand from "./commands/block";
+import SystemCommand from "./commands/system";
+import ChainId from "./commands/system/chain-id";
+import GasPrice from "./commands/system/gas-price";
+import Shards from "./commands/system/shards";
 import SmartAccountBalance from "./commands/smart-account/balance.js";
 import SmartAccountCallReadOnly from "./commands/smart-account/call-readonly";
 import SmartAccountDeploy from "./commands/smart-account/deploy.js";
@@ -44,6 +48,11 @@ export const COMMANDS: Record<string, Command.Class> = {
   "smart-account:send-transaction": SmartAccountSendTransaction,
   "smart-account:seqno": SmartAccountSeqno,
   "smart-account:top-up": SmartAccountTopup,
+
+  system: SystemCommand,
+  "system:chain-id": ChainId,
+  "system:gas-price": GasPrice,
+  "system:shards": Shards,
 };
 
 export async function run() {

--- a/clijs/test/commands/system/chain-id.test.ts
+++ b/clijs/test/commands/system/chain-id.test.ts
@@ -2,13 +2,12 @@ import { expect, vi } from "vitest";
 import { PublicClient } from "@nilfoundation/niljs";
 import { CliTest } from "../../setup.js";
 
-CliTest("system chain-id command", async ({ runCommand, rpcClient }: { runCommand: (args: string[]) => Promise<any>, rpcClient: PublicClient }) => {
-    // Mock the chainId response
-    const mockChainId = 123n;
-    vi.spyOn(rpcClient, "chainId").mockResolvedValue(Number(mockChainId));
-
-    const result = await runCommand(["system", "chain-id"]);
-    expect(result.stdout).toContain(mockChainId.toString());
-    expect(result.stderr).toBe("");
-    expect(result.error).toBeUndefined();
+describe("system:chain-id command", () => {
+    CliTest("system chain-id command", async ({ runCommand }: { runCommand: (args: string[]) => Promise<any> }) => {
+        const result = await runCommand(["system", "chain-id"]);
+        expect(typeof result.result).toBe("number");
+        expect(result.result).toBeGreaterThanOrEqual(0);
+        expect(result.stderr).toBe("");
+        expect(result.stdout).toBe("");
+    });
 });

--- a/clijs/test/commands/system/chain-id.test.ts
+++ b/clijs/test/commands/system/chain-id.test.ts
@@ -1,0 +1,14 @@
+import { expect, vi } from "vitest";
+import { PublicClient } from "@nilfoundation/niljs";
+import { CliTest } from "../../setup.js";
+
+CliTest("system chain-id command", async ({ runCommand, rpcClient }: { runCommand: (args: string[]) => Promise<any>, rpcClient: PublicClient }) => {
+    // Mock the chainId response
+    const mockChainId = 123n;
+    vi.spyOn(rpcClient, "chainId").mockResolvedValue(Number(mockChainId));
+
+    const result = await runCommand(["system", "chain-id"]);
+    expect(result.stdout).toContain(mockChainId.toString());
+    expect(result.stderr).toBe("");
+    expect(result.error).toBeUndefined();
+});

--- a/clijs/test/commands/system/gas-price.test.ts
+++ b/clijs/test/commands/system/gas-price.test.ts
@@ -1,0 +1,14 @@
+import { expect, vi } from "vitest";
+import { PublicClient } from "@nilfoundation/niljs";
+import { CliTest } from "../../setup.js";
+
+CliTest("system gas-price command", async ({ runCommand, rpcClient }: { runCommand: (args: string[]) => Promise<any>, rpcClient: PublicClient }) => {
+    // Mock the getGasPrice response
+    const mockGasPrice = 1000000000n;
+    vi.spyOn(rpcClient, "getGasPrice").mockResolvedValue(mockGasPrice);
+
+    const result = await runCommand(["system", "gas-price", "0"]);
+    expect(result.stdout).toContain(mockGasPrice.toString());
+    expect(result.stderr).toBe("");
+    expect(result.error).toBeUndefined();
+});

--- a/clijs/test/commands/system/gas-price.test.ts
+++ b/clijs/test/commands/system/gas-price.test.ts
@@ -3,12 +3,9 @@ import { PublicClient } from "@nilfoundation/niljs";
 import { CliTest } from "../../setup.js";
 
 CliTest("system gas-price command", async ({ runCommand, rpcClient }: { runCommand: (args: string[]) => Promise<any>, rpcClient: PublicClient }) => {
-    // Mock the getGasPrice response
-    const mockGasPrice = 1000000000n;
-    vi.spyOn(rpcClient, "getGasPrice").mockResolvedValue(mockGasPrice);
-
     const result = await runCommand(["system", "gas-price", "0"]);
-    expect(result.stdout).toContain(mockGasPrice.toString());
+    expect(typeof result.result).toBe("bigint");
+    expect(result.result).toBeGreaterThan(0n);
     expect(result.stderr).toBe("");
-    expect(result.error).toBeUndefined();
+    expect(result.stdout).toBe("");
 });

--- a/clijs/test/commands/system/shards.test.ts
+++ b/clijs/test/commands/system/shards.test.ts
@@ -1,0 +1,14 @@
+import { expect, vi } from "vitest";
+import { PublicClient } from "@nilfoundation/niljs";
+import { CliTest } from "../../setup.js";
+
+CliTest("system shards command", async ({ runCommand, rpcClient }: { runCommand: (args: string[]) => Promise<any>, rpcClient: PublicClient }) => {
+    // Mock the getShardIdList response
+    const mockShards = [0, 1, 2, 3];
+    vi.spyOn(rpcClient, "getShardIdList").mockResolvedValue(mockShards);
+
+    const result = await runCommand(["system", "shards"]);
+    expect(result.stdout).toBe(JSON.stringify(mockShards, null, 2));
+    expect(result.stderr).toBe("");
+    expect(result.error).toBeUndefined();
+});

--- a/clijs/test/commands/system/shards.test.ts
+++ b/clijs/test/commands/system/shards.test.ts
@@ -3,12 +3,9 @@ import { PublicClient } from "@nilfoundation/niljs";
 import { CliTest } from "../../setup.js";
 
 CliTest("system shards command", async ({ runCommand, rpcClient }: { runCommand: (args: string[]) => Promise<any>, rpcClient: PublicClient }) => {
-    // Mock the getShardIdList response
-    const mockShards = [0, 1, 2, 3];
-    vi.spyOn(rpcClient, "getShardIdList").mockResolvedValue(mockShards);
-
     const result = await runCommand(["system", "shards"]);
-    expect(result.stdout).toBe(JSON.stringify(mockShards, null, 2));
+    expect(Array.isArray(result.result)).toBe(true);
+    expect(result.result.length).toBeGreaterThan(0);
     expect(result.stderr).toBe("");
-    expect(result.error).toBeUndefined();
+    expect(result.stdout).toBe("");
 });


### PR DESCRIPTION
# System Commands Implementation

## Description
This PR implements a new set of system commands for the NIL CLI tool, providing essential network information retrieval functionality. The implementation adds three new commands under the `system` namespace.

## New Commands

### `nil system chain-id`
Retrieves the current network chain ID.

### `nil system gas-price <shard-id>`
Gets the gas price for a specific shard. Requires a shard ID parameter.

### `nil system shards`
Lists all available shards in the network.

## Usage Examples
```bash
# Get chain ID
nil system chain-id

# Get gas price for shard 0
nil system gas-price 0

# List all shards
nil system shards
```

## Closes #459 
