### PR TITLE
[build] change deb compression to xz

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -141,7 +141,7 @@
                 bash ${
                   ./scripts/binary_patch_version.sh
                 } ./usr/bin/cometa ${versionFull}
-                ${pkgs.fpm}/bin/fpm -s dir -t deb --name ${pkg.pname} -v ${version} --deb-use-file-permissions usr
+                ${pkgs.fpm}/bin/fpm -s dir -t deb --name ${pkg.pname} -v ${version} --deb-compression xz --deb-use-file-permissions usr
               '';
               installPhase = ''
                 mkdir -p $out


### PR DESCRIPTION
Default gzip doesn't support parallel compression while xz does. On my own laptop results of building deb with only nil binaries:

gzip (3 min) vs xz (2:30 min).

That's very important and useful when you debug something on dev/local stand.

Also size after compression is important. Here xz also wins: 470mb (gzip) vs 315 (xz).