### PR TITLE
[collate] make validator more verbose

### DIFF
--- a/nil/internal/types/block.go
+++ b/nil/internal/types/block.go
@@ -6,6 +6,7 @@ import (
 
 	fastssz "github.com/NilFoundation/fastssz"
 	"github.com/NilFoundation/nil/nil/common"
+	"github.com/NilFoundation/nil/nil/common/hexutil"
 	"github.com/NilFoundation/nil/nil/common/sszx"
 	"github.com/NilFoundation/nil/nil/internal/crypto/bls"
 )
@@ -83,13 +84,13 @@ type RawBlockWithExtractedData struct {
 
 type BlockWithExtractedData struct {
 	*Block
-	InTransactions  []*Transaction         `json:"inTransactions"`
-	OutTransactions []*Transaction         `json:"outTransactions"`
-	Receipts        []*Receipt             `json:"receipts"`
-	Errors          map[common.Hash]string `json:"errors,omitempty"`
-	ChildBlocks     []common.Hash          `json:"childBlocks"`
-	DbTimestamp     uint64                 `json:"dbTimestamp"`
-	Config          map[string][]byte      `json:"config"`
+	InTransactions  []*Transaction           `json:"inTransactions"`
+	OutTransactions []*Transaction           `json:"outTransactions"`
+	Receipts        []*Receipt               `json:"receipts"`
+	Errors          map[common.Hash]string   `json:"errors,omitempty"`
+	ChildBlocks     []common.Hash            `json:"childBlocks"`
+	DbTimestamp     uint64                   `json:"dbTimestamp"`
+	Config          map[string]hexutil.Bytes `json:"config"`
 }
 
 // interfaces
@@ -134,7 +135,9 @@ func (b *RawBlockWithExtractedData) DecodeSSZ() (*BlockWithExtractedData, error)
 		Errors:          b.Errors,
 		ChildBlocks:     b.ChildBlocks,
 		DbTimestamp:     b.DbTimestamp,
-		Config:          b.Config,
+		Config: common.TransformMap(b.Config, func(k string, v []byte) (string, hexutil.Bytes) {
+			return k, hexutil.Bytes(v)
+		}),
 	}, nil
 }
 
@@ -163,7 +166,9 @@ func (b *BlockWithExtractedData) EncodeSSZ() (*RawBlockWithExtractedData, error)
 		Errors:          b.Errors,
 		ChildBlocks:     b.ChildBlocks,
 		DbTimestamp:     b.DbTimestamp,
-		Config:          b.Config,
+		Config: common.TransformMap(b.Config, func(k string, v hexutil.Bytes) (string, []byte) {
+			return k, []byte(v)
+		}),
 	}, nil
 }
 

--- a/nil/services/synccommittee/prover/tracer/tracer_mock_client_test.go
+++ b/nil/services/synccommittee/prover/tracer/tracer_mock_client_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/NilFoundation/nil/nil/client"
 	"github.com/NilFoundation/nil/nil/common"
+	"github.com/NilFoundation/nil/nil/common/hexutil"
 	"github.com/NilFoundation/nil/nil/common/logging"
 	"github.com/NilFoundation/nil/nil/internal/mpt"
 	"github.com/NilFoundation/nil/nil/internal/types"
@@ -113,7 +114,7 @@ func (s *TracerMockClientTestSuite) makeClient() client.Client {
 		blockWithData := &types.BlockWithExtractedData{
 			Block:          block,
 			InTransactions: s.inMsgs,
-			Config:         make(map[string][]byte),
+			Config:         make(map[string]hexutil.Bytes),
 		}
 		rawBlock, err := blockWithData.EncodeSSZ()
 		s.Require().NoError(err)


### PR DESCRIPTION
In case of difference in config roots let's dump all config content to be able to debug problematic value. In logic below we dump all block header but it's not enough to see only that two hashes is different.