### PR TITLE
[release] downgrade supported niljs version to 0.24.0

### DIFF
--- a/nil/services/rpc/internal/http/connection.go
+++ b/nil/services/rpc/internal/http/connection.go
@@ -9,7 +9,7 @@ import (
 const (
 	MaxRequestContentLength  = 1024 * 1024 * 32 // 32MB
 	minSupportedRevision     = 771
-	minSupportedNiljsVersion = "0.25.0"
+	minSupportedNiljsVersion = "0.24.0"
 	niljsClientVersionPrefix = "niljs/"
 )
 


### PR DESCRIPTION
This diff downgrades minimum supported niljs version to 0.24.0