### PR TITLE
Limit number of tasks for proof provider

### DIFF
--- a/nil/cmd/proof_provider/main.go
+++ b/nil/cmd/proof_provider/main.go
@@ -76,6 +76,12 @@ func addFlags(cmd *cobra.Command, cfg *cmdConfig) {
 		cfg.SkipRate,
 		"rate of skip tasks, will skip N from 10, where N is value of option (0 means no skip)."+
 			" Possible values: [0,10]")
+	cmd.Flags().Uint32Var(
+		&cfg.MaxConcurrentBatches,
+		"max-concurrent-batches",
+		cfg.MaxConcurrentBatches,
+		"maximum value of batches that proof provider can handle concurrently",
+	)
 	logLevel := cmd.Flags().String(
 		"log-level",
 		"info",

--- a/nil/services/synccommittee/internal/api/task_handler.go
+++ b/nil/services/synccommittee/internal/api/task_handler.go
@@ -8,6 +8,7 @@ import (
 
 type TaskHandler interface {
 	Handle(ctx context.Context, executorId types.TaskExecutorId, task *types.Task) error
+	IsReadyToHandle(ctx context.Context) (bool, error)
 }
 
 //go:generate bash ../scripts/generate_mock.sh TaskHandler

--- a/nil/services/synccommittee/internal/executor/task_executor.go
+++ b/nil/services/synccommittee/internal/executor/task_executor.go
@@ -87,6 +87,15 @@ func (p *taskExecutorImpl) runIteration(ctx context.Context) {
 }
 
 func (p *taskExecutorImpl) fetchAndHandleTask(ctx context.Context) error {
+	handlerReady, err := p.taskHandler.IsReadyToHandle(ctx)
+	if err != nil {
+		return err
+	}
+	if !handlerReady {
+		p.logger.Debug().Msg("handler is not ready to pick up tasks")
+		return nil
+	}
+
 	taskRequest := api.NewTaskRequest(p.nonceId)
 	task, err := p.requestHandler.GetTask(ctx, taskRequest)
 	if err != nil {

--- a/nil/services/synccommittee/proofprovider/service.go
+++ b/nil/services/synccommittee/proofprovider/service.go
@@ -20,6 +20,7 @@ type Config struct {
 	SyncCommitteeRpcEndpoint string
 	TaskListenerRpcEndpoint  string
 	SkipRate                 int
+	MaxConcurrentBatches     uint32
 	Telemetry                *telemetry.Config
 }
 
@@ -28,6 +29,7 @@ func NewDefaultConfig() *Config {
 		SyncCommitteeRpcEndpoint: "tcp://127.0.0.1:8530",
 		TaskListenerRpcEndpoint:  "tcp://127.0.0.1:8531",
 		SkipRate:                 0,
+		MaxConcurrentBatches:     1,
 		Telemetry: &telemetry.Config{
 			ServiceName: "proof_provider",
 		},
@@ -61,7 +63,7 @@ func New(config *Config, database db.DB) (*ProofProvider, error) {
 	taskExecutor, err := executor.New(
 		executor.DefaultConfig(),
 		taskRpcClient,
-		newTaskHandler(taskStorage, taskResultStorage, config.SkipRate, clock, logger),
+		newTaskHandler(taskStorage, taskResultStorage, config.SkipRate, config.MaxConcurrentBatches, clock, logger),
 		metricsHandler,
 		logger,
 	)

--- a/nil/services/synccommittee/prover/task_handler.go
+++ b/nil/services/synccommittee/prover/task_handler.go
@@ -61,6 +61,11 @@ func newTaskHandlerConfig(nilRpcEndpoint string) taskHandlerConfig {
 	}
 }
 
+func (h *taskHandler) IsReadyToHandle(ctx context.Context) (bool, error) {
+	// Prover is always ready to pick up a new task after finishing a previous one
+	return true, nil
+}
+
 func (h *taskHandler) Handle(ctx context.Context, executorId types.TaskExecutorId, task *types.Task) error {
 	var taskResult *types.TaskResult
 


### PR DESCRIPTION
Currently proof provider fetches new batch tasks regardless of number of prover tasks in the queue. This commit introduces a limit for the queue.