### PR TITLE
[exporter, execution] Small improve in exporter, enable `assert` tags by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ test: generated
 %.cmd: generated
 	@# Note: $* is replaced by the command name
 	@echo "Building $*"
-	@cd ./nil/cmd/$* && $(GOBUILD) -o $(GOBIN)/$*
+	@cd ./nil/cmd/$* && $(GOBUILD) -o $(GOBIN)/$* -tags assert
 	@echo "Run \"$(GOBIN)/$*\" to launch $*."
 
 %.runcmd: %.cmd

--- a/nil/internal/execution/state.go
+++ b/nil/internal/execution/state.go
@@ -1464,16 +1464,17 @@ func (es *ExecutionState) BuildBlock(blockId types.BlockNumber) (*BlockGeneratio
 				return nil, fmt.Errorf("outbound transaction %v does not belong to any inbound transaction", outTxnHash)
 			}
 		}
+		// Check that each inbound transaction has its receipt in the same index
+		for i, txnHash := range es.InTransactionHashes {
+			if txnHash != es.Receipts[i].TxnHash {
+				return nil, fmt.Errorf("receipt hash doesn't match its transaction #%d", i)
+			}
+		}
 	}
 	if len(es.InTransactions) != len(es.Receipts) {
 		return nil, fmt.Errorf(
 			"number of transactions does not match number of receipts: %d != %d",
 			len(es.InTransactions), len(es.Receipts))
-	}
-	for i, txnHash := range es.InTransactionHashes {
-		if txnHash != es.Receipts[i].TxnHash {
-			return nil, fmt.Errorf("receipt hash doesn't match its transaction #%d", i)
-		}
 	}
 
 	// Update receipts trie

--- a/nix/nil.nix
+++ b/nix/nil.nix
@@ -38,6 +38,8 @@ buildGo124Module rec {
     esac
   '';
 
+  tags = [ "assert" ];
+
   src = lib.sourceByRegex ./.. [
     "Makefile"
     "go.mod"


### PR DESCRIPTION
- Remove unnecessary receipts map because the receipt is placed in the same index as the corresponding transaction.
- Set tag `assert` by default for all binaries. ~~Add an additional check that the transaction is always unique in the database.~~