### PR TITLE
[collate] workaround doubled tx

### DIFF
--- a/nil/internal/collate/proposer.go
+++ b/nil/internal/collate/proposer.go
@@ -439,9 +439,6 @@ func (p *proposer) handleTransactionsFromNeighbors(tx db.RoTx) error {
 
 				if txn.To.ShardId() == p.params.ShardId {
 					// TODO: Temporary workaround to prevent transaction duplication
-					// This check also breaks refunds from not initialized logic
-					//nolint: lll
-					// See https://github.com/NilFoundation/nil/blob/06885370c1efc4c5990f52869f2b03d14d102d85/nil/internal/execution/state.go#L901-L905
 					isProcessed, err := p.isTxProcessed(tx, txn.Hash())
 					if err != nil {
 						return err

--- a/nil/internal/collate/proposer.go
+++ b/nil/internal/collate/proposer.go
@@ -351,6 +351,10 @@ func (p *proposer) handleTransactionsFromPool() error {
 	return nil
 }
 
+func (p *proposer) isTxProcessed(dbTx db.RoTx, txHash common.Hash) (bool, error) {
+	return dbTx.ExistsInShard(p.params.ShardId, db.BlockHashAndInTransactionIndexByTransactionHash, txHash.Bytes())
+}
+
 func (p *proposer) handleTransactionsFromNeighbors(tx db.RoTx) error {
 	state, err := db.ReadCollatorState(tx, p.params.ShardId)
 	if err != nil && !errors.Is(err, db.ErrKeyNotFound) {
@@ -434,6 +438,18 @@ func (p *proposer) handleTransactionsFromNeighbors(tx db.RoTx) error {
 				}
 
 				if txn.To.ShardId() == p.params.ShardId {
+					// TODO: Temporary workaround to prevent transaction duplication
+					// This check also breaks refunds from not initialized logic
+					//nolint: lll
+					// See https://github.com/NilFoundation/nil/blob/06885370c1efc4c5990f52869f2b03d14d102d85/nil/internal/execution/state.go#L901-L905
+					isProcessed, err := p.isTxProcessed(tx, txn.Hash())
+					if err != nil {
+						return err
+					}
+					if isProcessed {
+						continue
+					}
+
 					txnHash := txn.Hash()
 					if err := execution.ValidateInternalTransaction(txn); err != nil {
 						p.logger.Warn().Err(err).

--- a/nil/internal/collate/proposer_test.go
+++ b/nil/internal/collate/proposer_test.go
@@ -172,8 +172,7 @@ func (s *ProposerTestSuite) TestCollator() {
 		balance = balance.Add(feeCredit).Add(feeCredit)
 		s.Equal(balance, s.getMainBalance())
 
-		// TODO: Enable when fixed uninitialized refunds
-		// s.checkSeqno(shardId)
+		s.checkSeqno(shardId)
 	})
 
 	s.Run("DoNotProcessDuplicates", func() {

--- a/nil/internal/collate/replay_scheduler.go
+++ b/nil/internal/collate/replay_scheduler.go
@@ -32,7 +32,7 @@ type ReplayScheduler struct {
 }
 
 func NewReplayScheduler(txFabric db.DB, params ReplayParams) *ReplayScheduler {
-	params.ExecutionMode = execution.ModeReplay
+	params.ExecutionMode = execution.ModeManualReplay
 	return &ReplayScheduler{
 		txFabric: txFabric,
 		params:   params,

--- a/nil/internal/collate/validator.go
+++ b/nil/internal/collate/validator.go
@@ -420,7 +420,7 @@ func (s *Validator) replayBlockUnlocked(ctx context.Context, block *types.BlockW
 	}
 
 	params := s.params.BlockGeneratorParams
-	params.ExecutionMode = execution.ModeReplay
+	params.ExecutionMode = execution.ModeSyncReplay
 	gen, err := execution.NewBlockGenerator(ctx, params, s.txFabric, prevBlock)
 	if err != nil {
 		return err

--- a/nil/internal/collate/validator.go
+++ b/nil/internal/collate/validator.go
@@ -135,24 +135,20 @@ func (s *Validator) BuildProposal(ctx context.Context) (*execution.ProposalSSZ, 
 	return proposal, nil
 }
 
-func (s *Validator) VerifyProposal(ctx context.Context, proposal *execution.ProposalSSZ) (*types.Block, error) {
+func (s *Validator) BuildBlockByProposal(ctx context.Context, proposal *execution.ProposalSSZ) (*types.Block, error) {
 	p, err := execution.ConvertProposal(proposal)
 	if err != nil {
 		return nil, err
 	}
 
-	// No lock since below we use only locked functions and only in read mode
-	if err := s.validateProposal(ctx, p); err != nil {
-		return nil, err
-	}
-
-	prevBlock, _, err := s.GetLastBlock(ctx)
+	prevBlock, err := s.getBlock(ctx, proposal.PrevBlockHash)
 	if err != nil {
 		return nil, err
 	}
 
-	s.params.ExecutionMode = execution.ModeVerify
-	gen, err := execution.NewBlockGenerator(ctx, s.params.BlockGeneratorParams, s.txFabric, prevBlock)
+	params := s.params.BlockGeneratorParams
+	params.ExecutionMode = execution.ModeVerify
+	gen, err := execution.NewBlockGenerator(ctx, params, s.txFabric, prevBlock)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create block generator: %w", err)
 	}
@@ -164,6 +160,16 @@ func (s *Validator) VerifyProposal(ctx context.Context, proposal *execution.Prop
 		return nil, fmt.Errorf("failed to generate block: %w", err)
 	}
 	return res.Block, nil
+}
+
+func (s *Validator) IsValidProposal(ctx context.Context, proposal *execution.ProposalSSZ) error {
+	p, err := execution.ConvertProposal(proposal)
+	if err != nil {
+		return err
+	}
+
+	// No lock since below we use only locked functions and only in read mode
+	return s.validateProposal(ctx, p)
 }
 
 func (s *Validator) InsertProposal(
@@ -180,7 +186,7 @@ func (s *Validator) InsertProposal(
 func (s *Validator) insertProposalUnlocked(
 	ctx context.Context,
 	proposal *execution.ProposalSSZ,
-	params *types.ConsensusParams,
+	consensusParams *types.ConsensusParams,
 ) error {
 	p, err := execution.ConvertProposal(proposal)
 	if err != nil {
@@ -195,14 +201,15 @@ func (s *Validator) insertProposalUnlocked(
 		return err
 	}
 
-	s.params.ExecutionMode = execution.ModeProposal
-	gen, err := execution.NewBlockGenerator(ctx, s.params.BlockGeneratorParams, s.txFabric, prevBlock)
+	params := s.params.BlockGeneratorParams
+	params.ExecutionMode = execution.ModeProposal
+	gen, err := execution.NewBlockGenerator(ctx, params, s.txFabric, prevBlock)
 	if err != nil {
 		return fmt.Errorf("failed to create block generator: %w", err)
 	}
 	defer gen.Rollback()
 
-	res, err := gen.GenerateBlock(p, params)
+	res, err := gen.GenerateBlock(p, consensusParams)
 	if err != nil {
 		return fmt.Errorf("failed to generate block: %w", err)
 	}
@@ -410,8 +417,9 @@ func (s *Validator) replayBlockUnlocked(ctx context.Context, block *types.BlockW
 		}
 	}
 
-	s.params.ExecutionMode = execution.ModeReplay
-	gen, err := execution.NewBlockGenerator(ctx, s.params.BlockGeneratorParams, s.txFabric, prevBlock)
+	params := s.params.BlockGeneratorParams
+	params.ExecutionMode = execution.ModeReplay
+	gen, err := execution.NewBlockGenerator(ctx, params, s.txFabric, prevBlock)
 	if err != nil {
 		return err
 	}

--- a/nil/internal/consensus/ibft/ibft.go
+++ b/nil/internal/consensus/ibft/ibft.go
@@ -33,7 +33,7 @@ type ConsensusParams struct {
 
 type validator interface {
 	BuildProposal(ctx context.Context) (*execution.ProposalSSZ, error)
-	BuildBlockByProposal(ctx context.Context, proposal *execution.ProposalSSZ) (*types.Block, error)
+	BuildBlockByProposal(ctx context.Context, proposal *execution.ProposalSSZ) (*types.Block, common.Hash, error)
 	IsValidProposal(ctx context.Context, proposal *execution.ProposalSSZ) error
 	InsertProposal(ctx context.Context, proposal *execution.ProposalSSZ, params *types.ConsensusParams) error
 	GetLastBlock(ctx context.Context) (*types.Block, common.Hash, error)

--- a/nil/internal/consensus/ibft/ibft.go
+++ b/nil/internal/consensus/ibft/ibft.go
@@ -33,7 +33,8 @@ type ConsensusParams struct {
 
 type validator interface {
 	BuildProposal(ctx context.Context) (*execution.ProposalSSZ, error)
-	VerifyProposal(ctx context.Context, proposal *execution.ProposalSSZ) (*types.Block, error)
+	BuildBlockByProposal(ctx context.Context, proposal *execution.ProposalSSZ) (*types.Block, error)
+	IsValidProposal(ctx context.Context, proposal *execution.ProposalSSZ) error
 	InsertProposal(ctx context.Context, proposal *execution.ProposalSSZ, params *types.ConsensusParams) error
 	GetLastBlock(ctx context.Context) (*types.Block, common.Hash, error)
 }

--- a/nil/internal/consensus/ibft/messages.go
+++ b/nil/internal/consensus/ibft/messages.go
@@ -42,7 +42,7 @@ func (i *backendIBFT) BuildPrePrepareMessage(
 		return nil
 	}
 
-	block, err := i.validator.VerifyProposal(i.ctx, proposal)
+	block, err := i.validator.BuildBlockByProposal(i.ctx, proposal)
 	if err != nil {
 		i.logger.Error().Err(err).Msg("failed to verify proposal")
 		return nil

--- a/nil/internal/consensus/ibft/messages.go
+++ b/nil/internal/consensus/ibft/messages.go
@@ -42,13 +42,12 @@ func (i *backendIBFT) BuildPrePrepareMessage(
 		return nil
 	}
 
-	block, err := i.validator.BuildBlockByProposal(i.ctx, proposal)
+	_, proposalHash, err := i.validator.BuildBlockByProposal(i.ctx, proposal)
 	if err != nil {
 		i.logger.Error().Err(err).Msg("failed to verify proposal")
 		return nil
 	}
 
-	proposalHash := block.Hash(i.shardId)
 	msg := &protoIBFT.IbftMessage{
 		View: view,
 		From: i.ID(),

--- a/nil/internal/consensus/ibft/verifier.go
+++ b/nil/internal/consensus/ibft/verifier.go
@@ -126,7 +126,7 @@ func (i *backendIBFT) IsValidProposalHash(proposal *protoIBFT.Proposal, hash []b
 		return false
 	}
 
-	block, err := i.validator.BuildBlockByProposal(i.ctx, prop)
+	_, blockHash, err := i.validator.BuildBlockByProposal(i.ctx, prop)
 	if err != nil {
 		event := i.logger.Error()
 		if errors.Is(err, cerrors.ErrOldBlock) {
@@ -140,7 +140,6 @@ func (i *backendIBFT) IsValidProposalHash(proposal *protoIBFT.Proposal, hash []b
 		return false
 	}
 
-	blockHash := block.Hash(i.shardId)
 	isValid := bytes.Equal(blockHash.Bytes(), hash)
 	if !isValid {
 		i.logger.Error().

--- a/nil/internal/consensus/ibft/verifier.go
+++ b/nil/internal/consensus/ibft/verifier.go
@@ -21,8 +21,7 @@ func (i *backendIBFT) IsValidProposal(rawProposal []byte) bool {
 		return false
 	}
 
-	_, err = i.validator.VerifyProposal(i.ctx, proposal)
-	if err != nil {
+	if err = i.validator.IsValidProposal(i.ctx, proposal); err != nil {
 		event := i.logger.Error()
 		if errors.Is(err, cerrors.ErrOldBlock) {
 			event = i.logger.Debug()
@@ -127,7 +126,7 @@ func (i *backendIBFT) IsValidProposalHash(proposal *protoIBFT.Proposal, hash []b
 		return false
 	}
 
-	block, err := i.validator.VerifyProposal(i.ctx, prop)
+	block, err := i.validator.BuildBlockByProposal(i.ctx, prop)
 	if err != nil {
 		event := i.logger.Error()
 		if errors.Is(err, cerrors.ErrOldBlock) {

--- a/nil/internal/execution/block_generator.go
+++ b/nil/internal/execution/block_generator.go
@@ -397,7 +397,7 @@ func (g *BlockGenerator) Finalize(blockRes *BlockGenerationResult, params *types
 		return err
 	}
 
-	if err := PostprocessBlock(g.rwTx, g.params.ShardId, blockRes); err != nil {
+	if err := PostprocessBlock(g.rwTx, g.params.ShardId, blockRes, g.params.ExecutionMode); err != nil {
 		return err
 	}
 

--- a/nil/internal/execution/execution_state_test.go
+++ b/nil/internal/execution/execution_state_test.go
@@ -160,7 +160,7 @@ func (s *SuiteExecutionState) TestDeployAndCall() {
 	s.Run("Execute", func() {
 		txn := NewExecutionTransaction(addrSmartAccount, addrSmartAccount, 1,
 			contracts.NewCounterAddCallData(s.T(), 47))
-		res := es.HandleTransaction(s.ctx, txn, dummyPayer{})
+		res := es.AddAndHandleTransaction(s.ctx, txn, dummyPayer{})
 		s.Require().False(res.Failed())
 
 		seqno, err := es.GetSeqno(addrSmartAccount)
@@ -174,16 +174,21 @@ func (s *SuiteExecutionState) TestDeployAndCall() {
 }
 
 func (s *SuiteExecutionState) TestExecStateMultipleBlocks() {
-	txn1 := types.NewEmptyTransaction()
-	txn1.Data = []byte{1}
-	txn1.Seqno = 1
-	txn2 := types.NewEmptyTransaction()
-	txn2.Data = []byte{2}
-	txn2.Seqno = 2
+	createTx := func(index int) *types.Transaction {
+		txn := types.NewEmptyTransaction()
+		txn.Data = []byte{byte(index)}
+		txn.Seqno = types.Seqno(index)
+		return txn
+	}
+
+	txn1 := createTx(1)
+	txn2 := createTx(2)
 	blockHash1 := GenerateBlockFromTransactionsWithoutExecution(s.T(), context.Background(),
 		types.BaseShardId, 0, common.EmptyHash, s.db, txn1, txn2)
+
+	txn3 := createTx(3)
 	blockHash2 := GenerateBlockFromTransactionsWithoutExecution(s.T(), context.Background(),
-		types.BaseShardId, 1, blockHash1, s.db, txn2)
+		types.BaseShardId, 1, blockHash1, s.db, txn3)
 
 	tx, err := s.db.CreateRoTx(s.ctx)
 	s.Require().NoError(err)
@@ -204,7 +209,7 @@ func (s *SuiteExecutionState) TestExecStateMultipleBlocks() {
 
 	check(blockHash1, 0, txn1)
 	check(blockHash1, 1, txn2)
-	check(blockHash2, 0, txn2)
+	check(blockHash2, 0, txn3)
 }
 
 func TestSuiteExecutionState(t *testing.T) {
@@ -412,7 +417,7 @@ func (s *SuiteExecutionState) TestTransactionStatus() {
 		txn.FeeCredit = toGasCredit(0)
 		txn.MaxFeePerGas = types.MaxFeePerGasDefault
 		txn.From = counterAddr
-		res := es.HandleTransaction(s.ctx, txn, dummyPayer{})
+		res := es.AddAndHandleTransaction(s.ctx, txn, dummyPayer{})
 		s.Equal(types.ErrorOutOfGas, res.Error.Code())
 		s.Require().ErrorAs(res.Error, &vmErrStub)
 	})
@@ -425,7 +430,7 @@ func (s *SuiteExecutionState) TestTransactionStatus() {
 		txn.FeeCredit = toGasCredit(1_000_000)
 		txn.MaxFeePerGas = types.MaxFeePerGasDefault
 		txn.From = counterAddr
-		res := es.HandleTransaction(s.ctx, txn, dummyPayer{})
+		res := es.AddAndHandleTransaction(s.ctx, txn, dummyPayer{})
 		fmt.Println(res.Error.Error())
 		s.Equal(types.ErrorExecutionReverted, res.Error.Code())
 		s.Require().ErrorAs(res.Error, &vmErrStub)
@@ -440,7 +445,7 @@ func (s *SuiteExecutionState) TestTransactionStatus() {
 		txn.FeeCredit = toGasCredit(100_000)
 		txn.MaxFeePerGas = types.MaxFeePerGasDefault
 		txn.From = faucetAddr
-		res := es.HandleTransaction(s.ctx, txn, dummyPayer{})
+		res := es.AddAndHandleTransaction(s.ctx, txn, dummyPayer{})
 		s.Equal(types.ErrorTransactionToMainShard, res.Error.Code())
 		s.Require().ErrorAs(res.Error, &vmErrStub)
 	})
@@ -505,7 +510,7 @@ func (s *SuiteExecutionState) TestPrecompiles() {
 			big.NewInt(0),
 			[]byte{})
 		s.Require().NoError(err)
-		res := es.HandleTransaction(s.ctx, txn, dummyPayer{})
+		res := es.AddAndHandleTransaction(s.ctx, txn, dummyPayer{})
 		s.False(res.Failed())
 	})
 
@@ -521,7 +526,7 @@ func (s *SuiteExecutionState) TestPrecompiles() {
 			[]byte{1, 2, 3, 4})
 		s.Require().NoError(err)
 
-		res := es.HandleTransaction(s.ctx, txn, dummyPayer{})
+		res := es.AddAndHandleTransaction(s.ctx, txn, dummyPayer{})
 		s.True(res.Failed())
 		s.Equal(types.ErrorTransactionToMainShard, res.Error.Code())
 	})
@@ -530,7 +535,7 @@ func (s *SuiteExecutionState) TestPrecompiles() {
 		txn.Data, err = abi.Pack("testAsyncCall", testAddr, types.EmptyAddress, types.EmptyAddress, big.NewInt(0),
 			uint8(types.ForwardKindNone), big.NewInt(1_000_000_000_000_000), []byte{1, 2, 3, 4})
 		s.Require().NoError(err)
-		res := es.HandleTransaction(s.ctx, txn, dummyPayer{})
+		res := es.AddAndHandleTransaction(s.ctx, txn, dummyPayer{})
 		s.True(res.Failed())
 		s.Equal(types.ErrorInsufficientBalance, res.Error.Code())
 	})
@@ -542,7 +547,7 @@ func (s *SuiteExecutionState) TestPrecompiles() {
 	s.Run("testSendRawTxn: invalid transaction", func() {
 		txn.Data, err = abi.Pack("testSendRawTxn", []byte{1, 2})
 		s.Require().NoError(err)
-		res := es.HandleTransaction(s.ctx, txn, dummyPayer{})
+		res := es.AddAndHandleTransaction(s.ctx, txn, dummyPayer{})
 		s.True(res.Failed())
 		s.Equal(types.ErrorInvalidTransactionInputUnmarshalFailed, res.Error.Code())
 	})
@@ -553,7 +558,7 @@ func (s *SuiteExecutionState) TestPrecompiles() {
 		s.Require().NoError(err)
 		txn.Data, err = abi.Pack("testSendRawTxn", data)
 		s.Require().NoError(err)
-		res := es.HandleTransaction(s.ctx, txn, dummyPayer{})
+		res := es.AddAndHandleTransaction(s.ctx, txn, dummyPayer{})
 		s.True(res.Failed())
 		s.Equal(types.ErrorTransactionToMainShard, res.Error.Code())
 		payload.To = testAddr
@@ -565,7 +570,7 @@ func (s *SuiteExecutionState) TestPrecompiles() {
 		s.Require().NoError(err)
 		txn.Data, err = abi.Pack("testSendRawTxn", data)
 		s.Require().NoError(err)
-		res := es.HandleTransaction(s.ctx, txn, dummyPayer{})
+		res := es.AddAndHandleTransaction(s.ctx, txn, dummyPayer{})
 		s.True(res.Failed())
 		s.Equal(types.ErrorInsufficientBalance, res.Error.Code())
 	})
@@ -578,7 +583,7 @@ func (s *SuiteExecutionState) TestPrecompiles() {
 		s.Require().NoError(err)
 		txn.Data, err = abi.Pack("testSendRawTxn", data)
 		s.Require().NoError(err)
-		res := es.HandleTransaction(s.ctx, txn, dummyPayer{})
+		res := es.AddAndHandleTransaction(s.ctx, txn, dummyPayer{})
 		s.True(res.Failed())
 		s.Equal(types.ErrorInsufficientBalance, res.Error.Code())
 	})
@@ -587,7 +592,7 @@ func (s *SuiteExecutionState) TestPrecompiles() {
 		txn.Data, err = abi.Pack("testTokenBalance", types.GenerateRandomAddress(0),
 			types.TokenId(types.HexToAddress("0x0a")))
 		s.Require().NoError(err)
-		res := es.HandleTransaction(s.ctx, txn, dummyPayer{})
+		res := es.AddAndHandleTransaction(s.ctx, txn, dummyPayer{})
 		s.True(res.Failed())
 		s.Equal(types.ErrorCrossShardTransaction, res.Error.Code())
 	})
@@ -635,7 +640,7 @@ func (s *SuiteExecutionState) TestPanic() {
 	txn := NewExecutionTransaction(types.MainSmartAccountAddress, types.MainSmartAccountAddress, 1,
 		contracts.NewSmartAccountSendCallData(s.T(), []byte(""), types.Gas(500_000), types.Value0, nil,
 			types.MainSmartAccountAddress, types.ExecutionTransactionKind))
-	execResult := es.HandleTransaction(s.ctx, txn, dummyPayer{})
+	execResult := es.AddAndHandleTransaction(s.ctx, txn, dummyPayer{})
 	s.False(execResult.Failed())
 
 	// Check panic is handled correctly

--- a/nil/internal/execution/state.go
+++ b/nil/internal/execution/state.go
@@ -1279,13 +1279,17 @@ func (es *ExecutionState) handleExecutionTransaction(
 	_ context.Context,
 	transaction *types.Transaction,
 ) *ExecutionResult {
+	if assert.Enable {
+		check.PanicIfNot(transaction.Hash() == es.InTransactionHash)
+	}
+
 	check.PanicIfNot(transaction.IsExecution())
 	addr := transaction.To
 	es.logger.Debug().
 		Stringer(logging.FieldTransactionFrom, transaction.From).
 		Stringer(logging.FieldTransactionTo, addr).
 		Stringer(logging.FieldTransactionFlags, transaction.Flags).
-		Stringer(logging.FieldTransactionHash, transaction.Hash()).
+		Stringer(logging.FieldTransactionHash, es.InTransactionHash).
 		Stringer("value", transaction.Value).
 		Stringer("feeCredit", transaction.FeeCredit).
 		Msg("Handling execution transaction...")

--- a/nil/internal/execution/state.go
+++ b/nil/internal/execution/state.go
@@ -32,10 +32,11 @@ const (
 	TraceBlocksEnabled                    = false
 	ExternalTransactionVerificationMaxGas = types.Gas(100_000)
 
-	ModeReadOnly = "read-only"
-	ModeProposal = "proposal"
-	ModeReplay   = "replay"
-	ModeVerify   = "verify"
+	ModeReadOnly     = "read-only"
+	ModeProposal     = "proposal"
+	ModeSyncReplay   = "syncer-replay"
+	ModeManualReplay = "manual-replay"
+	ModeVerify       = "verify"
 )
 
 var blocksTracer *BlocksTracer
@@ -898,18 +899,11 @@ func (es *ExecutionState) AddOutTransaction(
 		return nil, err
 	}
 
-	// TODO:	This happens when we send refunds from uninitialized accounts when transferring money to them.
-	//			For now we will write all such refunds with identical zero seqno, because we can't change seqno
-	//			of uninitialized accounts.
-	//			In future we should add transfer that is free on the reciepient's side, so that these transfers
-	//			won't require refunds.
-	if seqno != 0 {
-		if seqno+1 < seqno {
-			return nil, vm.ErrNonceUintOverflow
-		}
-		if err := es.SetSeqno(caller, seqno+1); err != nil {
-			return nil, err
-		}
+	if seqno+1 < seqno {
+		return nil, vm.ErrNonceUintOverflow
+	}
+	if err := es.SetSeqno(caller, seqno+1); err != nil {
+		return nil, err
 	}
 
 	txn := payload.ToTransaction(caller, seqno)

--- a/nil/internal/execution/testaide.go
+++ b/nil/internal/execution/testaide.go
@@ -180,10 +180,16 @@ func Deploy(t *testing.T, ctx context.Context, es *ExecutionState,
 	t.Helper()
 
 	txn := NewDeployTransaction(payload, shardId, from, seqno, types.Value{})
-	es.AddInTransaction(txn)
-	execResult := es.HandleTransaction(ctx, txn, dummyPayer{})
+	execResult := es.AddAndHandleTransaction(ctx, txn, dummyPayer{})
 	require.False(t, execResult.Failed())
 	es.AddReceipt(execResult)
 
 	return txn.To
+}
+
+func (es *ExecutionState) AddAndHandleTransaction(
+	ctx context.Context, txn *types.Transaction, payer Payer,
+) *ExecutionResult {
+	es.AddInTransaction(txn)
+	return es.HandleTransaction(ctx, txn, payer)
 }

--- a/nil/internal/execution/testaide.go
+++ b/nil/internal/execution/testaide.go
@@ -121,7 +121,7 @@ func generateBlockFromTransactions(t *testing.T, ctx context.Context, execute bo
 	blockRes, err := es.Commit(blockId, nil)
 	require.NoError(t, err)
 
-	err = PostprocessBlock(tx, shardId, blockRes)
+	err = PostprocessBlock(tx, shardId, blockRes, ModeVerify)
 	require.NoError(t, err)
 	require.NotNil(t, blockRes.Block)
 

--- a/nil/internal/vm/precompiled.go
+++ b/nil/internal/vm/precompiled.go
@@ -700,17 +700,20 @@ func (a *verifySignature) Run(input []byte) ([]byte, error) {
 	return common.EmptyHash[:], nil
 }
 
-func VerifySignatureArgs() abi.Arguments {
-	// arguments: bytes pubkey, uint256 hash, bytes signature
-	// returns: bool signatureValid
-	uint256Ty, _ := abi.NewType("uint256", "", nil)
-	bytesTy, _ := abi.NewType("bytes", "", nil)
-	args := abi.Arguments{
+// arguments: bytes pubkey, uint256 hash, bytes signature
+// returns: bool signatureValid
+var (
+	uint256Ty, _        = abi.NewType("uint256", "", nil)
+	bytesTy, _          = abi.NewType("bytes", "", nil)
+	verifySignatureArgs = abi.Arguments{
 		abi.Argument{Name: "pubkey", Type: bytesTy},
 		abi.Argument{Name: "hash", Type: uint256Ty},
 		abi.Argument{Name: "signature", Type: bytesTy},
 	}
-	return args
+)
+
+func VerifySignatureArgs() abi.Arguments {
+	return verifySignatureArgs
 }
 
 type checkIsInternal struct{}

--- a/nil/services/rpc/filters/filters_test.go
+++ b/nil/services/rpc/filters/filters_test.go
@@ -291,7 +291,7 @@ func (s *SuiteFilters) TestBlocksRange() {
 	blockHash := block.Hash(types.MainShardId)
 	s.Require().NoError(db.WriteBlock(tx, types.MainShardId, blockHash, &block))
 	blockResult := &execution.BlockGenerationResult{BlockHash: blockHash, Block: &block}
-	err = execution.PostprocessBlock(tx, types.MainShardId, blockResult)
+	err = execution.PostprocessBlock(tx, types.MainShardId, blockResult, execution.ModeVerify)
 	s.Require().NoError(err)
 
 	block = types.Block{
@@ -303,7 +303,7 @@ func (s *SuiteFilters) TestBlocksRange() {
 	blockHash = block.Hash(types.MainShardId)
 	s.Require().NoError(db.WriteBlock(tx, types.MainShardId, blockHash, &block))
 	blockResult = &execution.BlockGenerationResult{BlockHash: blockHash, Block: &block}
-	err = execution.PostprocessBlock(tx, types.MainShardId, blockResult)
+	err = execution.PostprocessBlock(tx, types.MainShardId, blockResult, execution.ModeVerify)
 	s.Require().NoError(err)
 
 	block = types.Block{
@@ -315,7 +315,7 @@ func (s *SuiteFilters) TestBlocksRange() {
 	blockHash = block.Hash(types.MainShardId)
 	s.Require().NoError(db.WriteBlock(tx, types.MainShardId, blockHash, &block))
 	blockResult = &execution.BlockGenerationResult{BlockHash: blockHash, Block: &block}
-	err = execution.PostprocessBlock(tx, types.MainShardId, blockResult)
+	err = execution.PostprocessBlock(tx, types.MainShardId, blockResult, execution.ModeVerify)
 	s.Require().NoError(err)
 
 	block = types.Block{
@@ -327,7 +327,7 @@ func (s *SuiteFilters) TestBlocksRange() {
 	blockHash = block.Hash(types.MainShardId)
 	s.Require().NoError(db.WriteBlock(tx, types.MainShardId, blockHash, &block))
 	blockResult = &execution.BlockGenerationResult{BlockHash: blockHash, Block: &block}
-	err = execution.PostprocessBlock(tx, types.MainShardId, blockResult)
+	err = execution.PostprocessBlock(tx, types.MainShardId, blockResult, execution.ModeVerify)
 	s.Require().NoError(err)
 	s.Require().NoError(tx.Commit())
 
@@ -391,7 +391,7 @@ func (s *SuiteFilters) TestBlocksRange() {
 	blockHash = block.Hash(types.MainShardId)
 	s.Require().NoError(db.WriteBlock(tx, types.MainShardId, blockHash, &block))
 	blockResult = &execution.BlockGenerationResult{BlockHash: blockHash, Block: &block}
-	err = execution.PostprocessBlock(tx, types.MainShardId, blockResult)
+	err = execution.PostprocessBlock(tx, types.MainShardId, blockResult, execution.ModeVerify)
 	s.Require().NoError(err)
 	s.Require().NoError(tx.Commit())
 

--- a/nil/services/rpc/jsonrpc/debug_api_test.go
+++ b/nil/services/rpc/jsonrpc/debug_api_test.go
@@ -68,7 +68,7 @@ func TestDebugGetBlock(t *testing.T) {
 		err = db.WriteBlock(tx, types.MainShardId, b.BlockHash, b.Block)
 		require.NoError(t, err)
 
-		err = execution.PostprocessBlock(tx, types.MainShardId, b)
+		err = execution.PostprocessBlock(tx, types.MainShardId, b, execution.ModeVerify)
 		require.NoError(t, err)
 	}
 
@@ -149,7 +149,7 @@ func (suite *SuiteDbgContracts) SetupSuite() {
 	suite.Require().NoError(err)
 	suite.blockHash = blockRes.BlockHash
 
-	err = execution.PostprocessBlock(tx, shardId, blockRes)
+	err = execution.PostprocessBlock(tx, shardId, blockRes, execution.ModeVerify)
 	suite.Require().NotNil(blockRes.Block)
 	suite.Require().NoError(err)
 

--- a/nil/services/rpc/jsonrpc/eth_accounts_test.go
+++ b/nil/services/rpc/jsonrpc/eth_accounts_test.go
@@ -67,7 +67,7 @@ func (suite *SuiteEthAccounts) SetupSuite() {
 	suite.Require().NoError(err)
 	suite.blockHash = blockRes.BlockHash
 
-	err = execution.PostprocessBlock(tx, shardId, blockRes)
+	err = execution.PostprocessBlock(tx, shardId, blockRes, execution.ModeVerify)
 	suite.Require().NotNil(blockRes.Block)
 	suite.Require().NoError(err)
 

--- a/nil/services/rpc/jsonrpc/eth_receipt_test.go
+++ b/nil/services/rpc/jsonrpc/eth_receipt_test.go
@@ -51,7 +51,7 @@ func (s *SuiteEthReceipt) SetupSuite() {
 
 	blockRes := writeTestBlock(s.T(), tx, types.BaseShardId, types.BlockNumber(0), []*types.Transaction{s.transaction},
 		[]*types.Receipt{&s.receipt}, s.outTransactions)
-	err = execution.PostprocessBlock(tx, types.BaseShardId, blockRes)
+	err = execution.PostprocessBlock(tx, types.BaseShardId, blockRes, execution.ModeVerify)
 	s.Require().NoError(err)
 
 	err = tx.Commit()

--- a/nil/services/rpc/jsonrpc/eth_transaction_test.go
+++ b/nil/services/rpc/jsonrpc/eth_transaction_test.go
@@ -52,7 +52,7 @@ func (s *SuiteEthTransaction) SetupSuite() {
 		[]*types.Transaction{s.transaction},
 		[]*types.Receipt{&receipt},
 		[]*types.Transaction{})
-	err = execution.PostprocessBlock(tx, types.BaseShardId, blockRes)
+	err = execution.PostprocessBlock(tx, types.BaseShardId, blockRes, execution.ModeVerify)
 	s.Require().NoError(err)
 	s.lastBlockHash = blockRes.BlockHash
 


### PR DESCRIPTION
During the replay block, we do not update the collator state, which may cause the proposer to include transactions that have already been executed.

This patch adds a check to detect already executed transactions — such messages will now be skipped.