### PR TITLE
[GH-#] GetSockPath* fixed for tests with long names

### DIFF
--- a/nil/services/rpc/unix_socket.go
+++ b/nil/services/rpc/unix_socket.go
@@ -12,28 +12,49 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func getSockDir(t *testing.T) string {
+const tmpDir = "/tmp"
+
+func makeSockPathImpl(name string, filename string, postprocess func(dir string, err error)) string {
+	dirName := strings.ReplaceAll(name, "/", "_")
+	maxDirNameLen := 108 - 1 - // https://github.com/golang/go/blob/go1.24.0/src/syscall/ztypes_linux_amd64.go#L172
+		len(tmpDir) - //
+		1 - // "/"
+		1 - // "_"
+		10 - // max random 32bit number digits
+		1 - // "/"
+		len(filename)
+
+	if len(dirName) >= maxDirNameLen {
+		dirName = dirName[:maxDirNameLen]
+	}
+	dir, err := os.MkdirTemp(tmpDir, dirName+"_*")
+	postprocess(dir, err)
+	return filepath.Join(dir, filename)
+}
+
+func makeSockPath(t *testing.T, filename string) string {
 	t.Helper()
 
-	// Use os.MkdirTemp instead of t.TempDir() to avoid issues with
-	// max unix socket name length on MacOS
-	dir, err := os.MkdirTemp("/tmp", strings.ReplaceAll(t.Name(), "/", "_")+"_*") //nolint: usetesting
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = os.RemoveAll(dir) })
-	return dir
+	return makeSockPathImpl(
+		t.Name(),
+		filename,
+		func(dir string, err error) {
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = os.RemoveAll(dir) })
+		})
 }
 
 func GetSockPath(t *testing.T) string {
 	t.Helper()
-	return "unix://" + filepath.Join(getSockDir(t), "httpd.sock")
+	return "unix://" + makeSockPath(t, "httpd.sock")
 }
 
 func GetSockPathIdx(t *testing.T, idx int) string {
 	t.Helper()
-	return fmt.Sprintf("unix://%s/httpd%d.sock", getSockDir(t), idx)
+	return "unix://" + makeSockPath(t, fmt.Sprintf("httpd%d.sock", idx))
 }
 
 func GetSockPathService(t *testing.T, service string) string {
 	t.Helper()
-	return fmt.Sprintf("unix://%s/httpd_%s.sock", getSockDir(t), service)
+	return "unix://" + makeSockPath(t, fmt.Sprintf("httpd_%s.sock", service))
 }

--- a/nil/services/rpc/unix_socket_test.go
+++ b/nil/services/rpc/unix_socket_test.go
@@ -1,0 +1,43 @@
+package rpc
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeSockPathImpl(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		filename    string
+		shouldBeCut bool
+	}{
+		{"ShortNameZ", "short.sock", false},
+		{"LongName80characters-----------------------------------------------------------Z", "short.sock", false},
+		{"LongName80characters-----------------------------------------------------------Z", "loooooong.sock", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := makeSockPathImpl(
+				tt.name,
+				tt.filename,
+				func(dir string, err error) {
+					require.NoError(t, err)
+				})
+			require.Lessf(t, len(path), 108, "Generated path should be less than 108 characters: %s", path)
+
+			lastDirPrefixSymbol := path[strings.LastIndex(path, "_")-1]
+			if !tt.shouldBeCut {
+				require.EqualValues(t, 'Z', lastDirPrefixSymbol)
+			} else {
+				require.NotEqualValues(t, 'Z', lastDirPrefixSymbol)
+			}
+		})
+	}
+}


### PR DESCRIPTION
We trim the paths so that we don't run into the socket path length limitation. Since `MkdirTemp` adds a random number to the suffix anyway, this is safe.