### PR TITLE
[GH-#] Error handling in RunWithTimeout

### DIFF
--- a/.github/workflows/build_artifacts.yml
+++ b/.github/workflows/build_artifacts.yml
@@ -32,7 +32,7 @@ jobs:
         run: nix develop -c make generated
 
       - name: golangci-lint
-        run: nix develop -c golangci-lint run
+        run: nix develop -c make golangci-lint
 
       - name: Run checklocks
         run: nix develop -c make checklocks

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -113,3 +113,4 @@ issues:
 run:
   build-tags:
     - test
+    - goexperiment.synctest

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
-    "go.testTags": "assert,test",
-    "go.buildTags": "assert,test",
+    "go.testTags": "assert,test,goexperiment.synctest",
+    "go.buildTags": "assert,test,goexperiment.synctest",
     "gopls": {
         "formatting.gofumpt": true
     },

--- a/nil/cmd/nil_block_generator/internal/commands/client.go
+++ b/nil/cmd/nil_block_generator/internal/commands/client.go
@@ -11,6 +11,7 @@ import (
 	cliservice_common "github.com/NilFoundation/nil/nil/cmd/nil/common"
 	"github.com/NilFoundation/nil/nil/cmd/nild/nildconfig"
 	"github.com/NilFoundation/nil/nil/common"
+	"github.com/NilFoundation/nil/nil/common/concurrent"
 	"github.com/NilFoundation/nil/nil/common/logging"
 	"github.com/NilFoundation/nil/nil/common/version"
 	"github.com/NilFoundation/nil/nil/internal/db"
@@ -33,10 +34,14 @@ func backgroundNilNode(cfg *nildconfig.Config) {
 		database.Close()
 		stop()
 	}()
-	exitCode := nilservice.Run(ctx, cfg.Config, database, nil,
-		func(ctx context.Context) error {
+	exitCode := nilservice.Run(
+		ctx,
+		cfg.Config,
+		database,
+		nil,
+		concurrent.WithSource(func(ctx context.Context) error {
 			return database.LogGC(ctx, cfg.DB.DiscardRatio, cfg.DB.GcFrequency)
-		})
+		}))
 	if exitCode != 0 {
 		fmt.Printf("nilservice failed with code %d\n", exitCode)
 	}

--- a/nil/cmd/nild/main.go
+++ b/nil/cmd/nild/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/NilFoundation/nil/nil/cmd/nild/nildconfig"
 	"github.com/NilFoundation/nil/nil/common/check"
+	"github.com/NilFoundation/nil/nil/common/concurrent"
 	"github.com/NilFoundation/nil/nil/common/logging"
 	"github.com/NilFoundation/nil/nil/internal/cobrax"
 	"github.com/NilFoundation/nil/nil/internal/cobrax/cmdflags"
@@ -48,10 +49,14 @@ func main() {
 		check.PanicIfErr(err)
 	}
 
-	exitCode := nilservice.Run(context.Background(), cfg.Config, database, nil,
-		func(ctx context.Context) error {
+	exitCode := nilservice.Run(
+		context.Background(),
+		cfg.Config,
+		database,
+		nil,
+		concurrent.WithSource(func(ctx context.Context) error {
 			return database.LogGC(ctx, cfg.DB.DiscardRatio, cfg.DB.GcFrequency)
-		})
+		}))
 
 	database.Close()
 	os.Exit(exitCode)

--- a/nil/common/concurrent/synctest_import_lint_workaround.go
+++ b/nil/common/concurrent/synctest_import_lint_workaround.go
@@ -1,0 +1,13 @@
+//go:build test
+
+package concurrent
+
+// NOTE: If your IDE does not find this import, add goexperiment.synctest to the build tags.
+import "testing/synctest"
+
+// Since testing/synctest is an experimental package, linters go crazy trying to organize its import among others.
+// Therefore, we put it in a separate file and use the functions from the package through.
+var (
+	synctestRun  = synctest.Run
+	synctestWait = synctest.Wait
+)

--- a/nil/common/concurrent/utils.go
+++ b/nil/common/concurrent/utils.go
@@ -3,46 +3,83 @@ package concurrent
 import (
 	"context"
 	"fmt"
+	"runtime/debug"
 	"sync"
 	"time"
-
-	"github.com/NilFoundation/nil/nil/common/check"
 )
 
 type Func = func(context.Context) error
+
+type FuncWithSource struct {
+	Func
+	Stack string
+}
+
+func WithSource(f Func) FuncWithSource {
+	return FuncWithSource{
+		Func: f,
+		Stack: func(stack []byte) string {
+			// We could use an approach like in dd-trace-go
+			// https://github.com/DataDog/dd-trace-go/blob/ba03925427c3ecd73ce2d64af50/ddtrace/tracer/span.go#L376-L407,
+			// but it's easier to just remove unnecessary lines from the output.
+			newlineCount := 0
+			for i := range stack {
+				if stack[i] == '\n' {
+					newlineCount++
+					if newlineCount == 5 {
+						return string(stack[i+1:])
+					}
+				}
+			}
+			return ""
+		}(debug.Stack()),
+	}
+}
 
 // RunWithTimeout calls each given function in a separate goroutine and waits for them to finish.
 // It logs a fatal message if an error occurred.
 // If timeout is positive, it is added to the context. Otherwise, it is ignored.
 // Note that RunWithTimeout does not forcefully terminate the goroutines;
 // your functions should be able to handle context cancellation.
-func RunWithTimeout(ctx context.Context, timeout time.Duration, fs ...Func) error {
+func RunWithTimeout(ctx context.Context, timeout time.Duration, fs ...FuncWithSource) error {
 	var wg sync.WaitGroup
 
+	var cancel context.CancelFunc
 	if timeout > 0 {
-		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, timeout)
-		defer cancel()
+	} else {
+		ctx, cancel = context.WithCancel(ctx)
 	}
+	defer cancel()
 
+	var once sync.Once
+	var originError error
 	for _, f := range fs {
 		wg.Add(1)
 
-		go func(fn Func) {
+		go func(fn FuncWithSource) {
 			defer wg.Done()
-
-			err := fn(ctx)
-			// todo: decide on what to do with other goroutines
-			check.PanicIfErr(err)
+			if err := fn.Func(ctx); err != nil {
+				once.Do(func() {
+					var location string
+					if fn.Stack != "" {
+						location = "\n" + fn.Stack
+					} else {
+						location = "<unknown location>"
+					}
+					originError = fmt.Errorf("goroutine failed: %w. Function was created at: %s", err, location)
+					cancel()
+				})
+			}
 		}(f) // to avoid loop-variable reuse in goroutines
 	}
 
 	wg.Wait()
-	return nil
+	return originError
 }
 
 // Run calls RunWithTimeout without a timeout.
-func Run(ctx context.Context, fs ...Func) error {
+func Run(ctx context.Context, fs ...FuncWithSource) error {
 	return RunWithTimeout(ctx, 0, fs...)
 }
 

--- a/nil/common/concurrent/utils_test.go
+++ b/nil/common/concurrent/utils_test.go
@@ -25,54 +25,59 @@ func TestRunWithTimeout_AllFunctionsSucceed(t *testing.T) {
 	require.NoError(t, err)
 }
 
+var errTest = errors.New("test error")
+
 func TestRunWithTimeout_FunctionFails(t *testing.T) {
 	t.Parallel()
-
-	err := RunWithTimeout(
-		t.Context(),
-		1*time.Second,
-		WithSource(func(ctx context.Context) error {
-			return errors.New("failure")
-		}),
-		WithSource(func(ctx context.Context) error {
-			time.Sleep(50 * time.Millisecond)
-			if ctx.Err() != nil {
+	synctestRun(func() {
+		err := RunWithTimeout(
+			t.Context(),
+			1*time.Second,
+			WithSource(func(ctx context.Context) error {
+				return errTest
+			}),
+			WithSource(func(ctx context.Context) error {
+				time.Sleep(50 * time.Millisecond)
+				synctestWait()
 				return ctx.Err()
-			}
-			return nil
-		}))
-	require.Error(t, err)
-	errorLines := strings.Split(err.Error(), "\n")
-	require.Contains(t, errorLines[0], "failure")
-	require.Contains(t, errorLines[2], "nil/nil/common/concurrent/utils_test.go:34")
+			}))
+		var exectutionError *ExecutionError
+		require.ErrorAs(t, err, &exectutionError)
+		require.ErrorIs(t, exectutionError.Err, errTest)
+		errorLines := strings.Split(exectutionError.Error(), "\n")
+		require.Contains(t, errorLines[0], errTest.Error())
+		require.Contains(t, errorLines[2], "nil/common/concurrent/utils_test.go:36")
+	})
 }
 
 func TestRunWithTimeout_TimeoutExceededWithContextCheck(t *testing.T) {
 	t.Parallel()
-
-	err := RunWithTimeout(
-		t.Context(),
-		10*time.Millisecond,
-		WithSource(func(ctx context.Context) error {
-			time.Sleep(50 * time.Millisecond)
-			if ctx.Err() != nil {
+	synctestRun(func() {
+		err := RunWithTimeout(
+			t.Context(),
+			10*time.Millisecond,
+			WithSource(func(ctx context.Context) error {
+				time.Sleep(50 * time.Millisecond)
+				synctestWait()
 				return ctx.Err()
-			}
-			return nil
-		}))
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "context deadline exceeded")
+			}))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "context deadline exceeded")
+	})
 }
 
 func TestRunWithTimeout_TimeoutExceededWithoutContextCheck(t *testing.T) {
 	t.Parallel()
 
-	err := RunWithTimeout(
-		t.Context(),
-		10*time.Millisecond,
-		WithSource(func(ctx context.Context) error {
-			time.Sleep(50 * time.Millisecond)
-			return nil
-		}))
-	require.NoError(t, err)
+	synctestRun(func() {
+		err := RunWithTimeout(
+			t.Context(),
+			10*time.Millisecond,
+			WithSource(func(ctx context.Context) error {
+				time.Sleep(50 * time.Millisecond)
+				synctestWait()
+				return nil
+			}))
+		require.NoError(t, err)
+	})
 }

--- a/nil/common/concurrent/utils_test.go
+++ b/nil/common/concurrent/utils_test.go
@@ -1,0 +1,78 @@
+package concurrent
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunWithTimeout_AllFunctionsSucceed(t *testing.T) {
+	t.Parallel()
+
+	err := RunWithTimeout(
+		t.Context(),
+		1*time.Second,
+		WithSource(func(ctx context.Context) error {
+			return nil
+		}),
+		WithSource(func(ctx context.Context) error {
+			return nil
+		}))
+	require.NoError(t, err)
+}
+
+func TestRunWithTimeout_FunctionFails(t *testing.T) {
+	t.Parallel()
+
+	err := RunWithTimeout(
+		t.Context(),
+		1*time.Second,
+		WithSource(func(ctx context.Context) error {
+			return errors.New("failure")
+		}),
+		WithSource(func(ctx context.Context) error {
+			time.Sleep(50 * time.Millisecond)
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			return nil
+		}))
+	require.Error(t, err)
+	errorLines := strings.Split(err.Error(), "\n")
+	require.Contains(t, errorLines[0], "failure")
+	require.Contains(t, errorLines[2], "nil/nil/common/concurrent/utils_test.go:34")
+}
+
+func TestRunWithTimeout_TimeoutExceededWithContextCheck(t *testing.T) {
+	t.Parallel()
+
+	err := RunWithTimeout(
+		t.Context(),
+		10*time.Millisecond,
+		WithSource(func(ctx context.Context) error {
+			time.Sleep(50 * time.Millisecond)
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			return nil
+		}))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "context deadline exceeded")
+}
+
+func TestRunWithTimeout_TimeoutExceededWithoutContextCheck(t *testing.T) {
+	t.Parallel()
+
+	err := RunWithTimeout(
+		t.Context(),
+		10*time.Millisecond,
+		WithSource(func(ctx context.Context) error {
+			time.Sleep(50 * time.Millisecond)
+			return nil
+		}))
+	require.NoError(t, err)
+}

--- a/nil/services/nilservice/service.go
+++ b/nil/services/nilservice/service.go
@@ -244,7 +244,7 @@ func getSyncerConfig(name string, cfg *Config, shardId types.ShardId) *collate.S
 }
 
 type syncersResult struct {
-	funcs   []concurrent.Func
+	funcs   []concurrent.FuncWithSource
 	syncers []*collate.Syncer
 	wgInit  sync.WaitGroup
 }
@@ -262,7 +262,7 @@ func createSyncers(
 	logger logging.Logger,
 ) (*syncersResult, error) {
 	res := &syncersResult{
-		funcs:   make([]concurrent.Func, 0, cfg.NShards+2),
+		funcs:   make([]concurrent.FuncWithSource, 0, cfg.NShards+2),
 		syncers: make([]*collate.Syncer, 0, cfg.NShards),
 	}
 	res.wgInit.Add(1)
@@ -275,39 +275,40 @@ func createSyncers(
 			return nil, err
 		}
 		res.syncers = append(res.syncers, syncer)
-		res.funcs = append(res.funcs, func(ctx context.Context) error {
-			res.Wait() // Wait for syncers initialization
-			if err := syncer.Run(ctx); err != nil {
-				logger.Error().
-					Err(err).
-					Stringer(logging.FieldShardId, shardId).
-					Msg("Syncer goroutine failed")
-				return err
-			}
-			return nil
-		})
+		res.funcs = append(res.funcs, concurrent.WithSource(
+			func(ctx context.Context) error {
+				res.Wait() // Wait for syncers initialization
+				if err := syncer.Run(ctx); err != nil {
+					logger.Error().
+						Err(err).
+						Stringer(logging.FieldShardId, shardId).
+						Msg("Syncer goroutine failed")
+					return err
+				}
+				return nil
+			}))
 	}
-	res.funcs = append(res.funcs, func(ctx context.Context) error {
+	res.funcs = append(res.funcs, concurrent.WithSource(func(ctx context.Context) error {
 		defer res.wgInit.Done()
 		if err := initSyncers(ctx, res.syncers, cfg.AllowDbDrop); err != nil {
 			logger.Error().Err(err).Msg("Failed to initialize syncers")
 			return err
 		}
 		return nil
-	})
-	res.funcs = append(res.funcs, func(ctx context.Context) error {
+	}))
+	res.funcs = append(res.funcs, concurrent.WithSource(func(ctx context.Context) error {
 		for _, syncer := range res.syncers {
 			syncer.WaitComplete()
 		}
 		return res.syncers[0].SetHandlers(ctx)
-	})
+	}))
 
 	return res, nil
 }
 
 type Node struct {
 	NetworkManager *network.Manager
-	funcs          []concurrent.Func
+	funcs          []concurrent.FuncWithSource
 	logger         logging.Logger
 	ctx            context.Context
 }
@@ -330,12 +331,12 @@ func (i *Node) Close(ctx context.Context) {
 
 func runNormalOrCollatorsOnly(
 	ctx context.Context,
-	funcs []concurrent.Func,
+	funcs []concurrent.FuncWithSource,
 	cfg *Config,
 	database db.DB,
 	networkManager *network.Manager,
 	logger logging.Logger,
-) ([]concurrent.Func, map[types.ShardId]txnpool.Pool, error) {
+) ([]concurrent.FuncWithSource, map[types.ShardId]txnpool.Pool, error) {
 	if err := cfg.LoadValidatorKeys(); err != nil {
 		return nil, nil, err
 	}
@@ -382,7 +383,7 @@ func CreateNode(
 	cfg *Config,
 	database db.DB,
 	interop chan<- ServiceInterop,
-	workers ...concurrent.Func,
+	workers ...concurrent.FuncWithSource,
 ) (*Node, error) {
 	logger := logging.NewLogger(name)
 
@@ -407,7 +408,7 @@ func CreateNode(
 		cfg.L1Fetcher = rollup.NewL1BlockFetcherRpc(ctx)
 	}
 
-	funcs := make([]concurrent.Func, 0, int(cfg.NShards)+2+len(workers))
+	funcs := make([]concurrent.FuncWithSource, 0, int(cfg.NShards)+2+len(workers))
 
 	if cfg.CollatorTickPeriodMs == 0 {
 		cfg.CollatorTickPeriodMs = defaultCollatorTickPeriodMs
@@ -461,7 +462,7 @@ func CreateNode(
 			ReplayLastBlock:      cfg.Replay.BlockIdLast,
 		})
 
-		funcs = append(funcs, func(ctx context.Context) error {
+		funcs = append(funcs, concurrent.WithSource(func(ctx context.Context) error {
 			if err := replayer.Run(ctx); err != nil {
 				logger.Error().
 					Err(err).
@@ -470,17 +471,17 @@ func CreateNode(
 				return err
 			}
 			return nil
-		})
+		}))
 	case RpcRunMode:
 		if networkManager == nil {
 			err := errors.New("Failed to start rpc node without network configuration")
 			logger.Error().Err(err).Send()
 			return nil, err
 		}
-		funcs = append(funcs, func(ctx context.Context) error {
+		funcs = append(funcs, concurrent.WithSource(func(ctx context.Context) error {
 			network.ConnectToPeers(ctx, cfg.RpcNode.ArchiveNodeList, *networkManager, logger)
 			return nil
-		})
+		}))
 	default:
 		panic("unsupported run mode")
 	}
@@ -489,13 +490,13 @@ func CreateNode(
 		interop <- ServiceInterop{TxnPools: txnPools}
 	}
 
-	funcs = append(funcs, func(ctx context.Context) error {
+	funcs = append(funcs, concurrent.WithSource(func(ctx context.Context) error {
 		if err := startAdminServer(ctx, cfg); err != nil {
 			logger.Error().Err(err).Msg("Admin server goroutine failed")
 			return err
 		}
 		return nil
-	})
+	}))
 
 	rawApi, err := getRawApi(cfg, networkManager, database, txnPools)
 	if err != nil {
@@ -504,7 +505,7 @@ func CreateNode(
 	}
 
 	if (cfg.RPCPort != 0 || cfg.HttpUrl != "") && rawApi != nil {
-		funcs = append(funcs, func(ctx context.Context) error {
+		funcs = append(funcs, concurrent.WithSource(func(ctx context.Context) error {
 			if syncersResult != nil {
 				syncersResult.Wait() // Wait for syncers initialization
 			}
@@ -521,7 +522,7 @@ func CreateNode(
 				return err
 			}
 			return nil
-		})
+		}))
 	}
 
 	if cfg.RunMode != CollatorsOnlyRunMode && cfg.RunMode != RpcRunMode {
@@ -557,7 +558,7 @@ func Run(
 	cfg *Config,
 	database db.DB,
 	interop chan<- ServiceInterop,
-	workers ...concurrent.Func,
+	workers ...concurrent.FuncWithSource,
 ) int {
 	if cfg.GracefulShutdown {
 		signalCtx, cancel := signal.NotifyContext(ctx, syscall.SIGTERM, syscall.SIGINT)
@@ -640,8 +641,8 @@ func createShards(
 	validators []*collate.Validator, syncers *syncersResult,
 	database db.DB, networkManager *network.Manager,
 	logger logging.Logger,
-) ([]concurrent.Func, error) {
-	funcs := make([]concurrent.Func, 0, cfg.NShards)
+) ([]concurrent.FuncWithSource, error) {
+	funcs := make([]concurrent.FuncWithSource, 0, cfg.NShards)
 
 	validatorsNum := len(cfg.ZeroState.GetValidators())
 	if validatorsNum != int(cfg.NShards)-1 {
@@ -670,7 +671,7 @@ func createShards(
 			}
 			collator := collate.NewScheduler(validators[i], database, consensus, networkManager)
 
-			funcs = append(funcs, func(ctx context.Context) error {
+			funcs = append(funcs, concurrent.WithSource(func(ctx context.Context) error {
 				syncers.Wait() // Wait for syncers initialization
 				if err := consensus.Init(ctx); err != nil {
 					return err
@@ -683,7 +684,7 @@ func createShards(
 					return err
 				}
 				return nil
-			})
+			}))
 		} else if networkManager == nil {
 			return nil, errors.New("trying to start syncer without network configuration")
 		}

--- a/nix/nil.nix
+++ b/nix/nil.nix
@@ -82,7 +82,7 @@ buildGo124Module rec {
   packageName = "github.com/NilFoundation/nil";
 
   doCheck = enableTesting;
-  checkFlags = [ "-tags assert,test" "-timeout 15m" ]
+  checkFlags = [ "-tags assert,test,goexperiment.synctest" "-timeout 15m" ]
     ++ (if enableRaceDetector then [ "-race" ] else [ ]);
 
   preCheck = ''


### PR DESCRIPTION
In this PR, two changes related to `concurrent.RunWithTimeout`:
1. Instead of panicking, we cancel the current context that the other functions are running with and return the original error from the entire function. This is needed to be able to occasionally terminate with an error, right now we only know how to crash.
3. We keep track of where the function that ended with the error was created. This is very useful for debugging, because unlike panic (inside a function) when an error occurs, we have no way to reliably trace the source of the problem. I think that overhead is not terrible here, because we only create long-lived functions once at the start of services, and do not do it all the time.