### PR TITLE
[rpc, stresser] Introduce dev-api with `DoPanicOnShard` method

### DIFF
--- a/nil/client/client.go
+++ b/nil/client/client.go
@@ -40,6 +40,7 @@ type Client interface {
 	RawClient
 	DbClient
 	Web3Client
+	jsonrpc.DevAPI
 
 	CreateBatchRequest() BatchRequest
 	BatchCall(ctx context.Context, req BatchRequest) ([]any, error)

--- a/nil/client/direct_client.go
+++ b/nil/client/direct_client.go
@@ -23,6 +23,7 @@ type DirectClient struct {
 	debugApi jsonrpc.DebugAPI
 	dbApi    jsonrpc.DbAPI
 	web3Api  jsonrpc.Web3API
+	devApi   jsonrpc.DevAPI
 }
 
 var _ Client = (*DirectClient)(nil)
@@ -37,12 +38,14 @@ func NewEthClient(
 	debugApi := jsonrpc.NewDebugAPI(localApi, logger)
 	dbApi := jsonrpc.NewDbAPI(db, logger)
 	web3Api := jsonrpc.NewWeb3API(localApi)
+	devApi := jsonrpc.NewDevAPI(localApi)
 
 	return &DirectClient{
 		ethApi:   ethApi,
 		debugApi: debugApi,
 		dbApi:    dbApi,
 		web3Api:  web3Api,
+		devApi:   devApi,
 	}, nil
 }
 
@@ -387,4 +390,8 @@ func (c *DirectClient) GetDebugContract(
 
 func (c *DirectClient) ClientVersion(ctx context.Context) (string, error) {
 	return c.web3Api.ClientVersion(ctx)
+}
+
+func (c *DirectClient) DoPanicOnShard(ctx context.Context, shardId types.ShardId) (uint64, error) {
+	return c.devApi.DoPanicOnShard(ctx, shardId)
 }

--- a/nil/client/rpc/client.go
+++ b/nil/client/rpc/client.go
@@ -80,6 +80,7 @@ const (
 	Debug_getBlockByNumber               = "debug_getBlockByNumber"
 	Debug_getContract                    = "debug_getContract"
 	Web3_clientVersion                   = "web3_clientVersion"
+	Dev_doPanicOnShard                   = "dev_doPanicOnShard"
 )
 
 const (
@@ -1054,4 +1055,9 @@ func (c *Client) GetDebugContract(
 	}
 
 	return DebugRPCContract, err
+}
+
+func (c *Client) DoPanicOnShard(ctx context.Context, shardId types.ShardId) (uint64, error) {
+	_, err := c.call(ctx, Dev_doPanicOnShard, shardId)
+	return 0, err
 }

--- a/nil/cmd/nild/main.go
+++ b/nil/cmd/nild/main.go
@@ -158,6 +158,7 @@ func parseArgs() *nildconfig.Config {
 	runCmd.Flags().StringVar(&cfg.CometaConfig, "cometa-config", "", "path to Cometa config")
 	runCmd.Flags().StringVar(
 		&cfg.ValidatorKeysPath, "validator-keys-path", cfg.ValidatorKeysPath, "path to write validator keys")
+	runCmd.Flags().BoolVar(&cfg.EnableDevApi, "dev-api", cfg.EnableDevApi, "enable development API")
 
 	addBasicFlags(runCmd.Flags(), cfg)
 	cmdflags.AddNetwork(runCmd.Flags(), cfg.Config.Network)
@@ -193,6 +194,7 @@ func parseArgs() *nildconfig.Config {
 			cfg.RunMode = nilservice.RpcRunMode
 		},
 	}
+	rpcCmd.Flags().BoolVar(&cfg.EnableDevApi, "dev-api", cfg.EnableDevApi, "enable development API")
 
 	addRpcNodeFlags(rpcCmd.Flags(), cfg)
 	addAllowDbClearFlag(rpcCmd.Flags(), cfg)

--- a/nil/cmd/stresser/main.go
+++ b/nil/cmd/stresser/main.go
@@ -5,9 +5,13 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/NilFoundation/nil/nil/common/check"
 	"github.com/NilFoundation/nil/nil/services/stresser"
+	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
 )
+
+var logLevel *string
 
 func main() {
 	var configFile string
@@ -15,6 +19,9 @@ func main() {
 		Use:   "stresser --config <config-file>",
 		Short: "Run stresser",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			level, err := zerolog.ParseLevel(*logLevel)
+			check.PanicIfErr(err)
+			zerolog.SetGlobalLevel(level)
 			st, err := stresser.NewStresserFromFile(configFile)
 			if err != nil {
 				return fmt.Errorf("Failed to create stresser: %w", err)
@@ -27,6 +34,11 @@ func main() {
 	}
 
 	rootCmd.Flags().StringVarP(&configFile, "config", "c", "", "config file")
+	logLevel = rootCmd.Flags().StringP(
+		"log-level",
+		"l",
+		"info",
+		"log level: trace|debug|info|warn|error|fatal|panic")
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)

--- a/nil/internal/execution/state.go
+++ b/nil/internal/execution/state.go
@@ -1067,7 +1067,7 @@ func (es *ExecutionState) HandleTransaction(
 			}
 			ev = es.logger.Debug()
 		}
-
+		ev.Stringer(logging.FieldTransactionHash, es.InTransactionHash)
 		ev.Stringer("result", retError).Int(logging.FieldTransactionSeqno, int(txn.Seqno))
 		if !txn.IsRefund() && !txn.IsBounce() {
 			ev.Stringer("gasUsed", retError.GasUsed).

--- a/nil/services/nilservice/config.go
+++ b/nil/services/nilservice/config.go
@@ -41,6 +41,7 @@ type Config struct {
 	// RPC
 	RPCPort        int                   `yaml:"rpcPort,omitempty"`
 	BootstrapPeers network.AddrInfoSlice `yaml:"bootstrapPeers,omitempty"`
+	EnableDevApi   bool                  `yaml:"enableDevApi,omitempty"`
 
 	// Profiling
 	PprofPort int `yaml:"pprofPort,omitempty"`

--- a/nil/services/nilservice/service.go
+++ b/nil/services/nilservice/service.go
@@ -102,6 +102,16 @@ func startRpcServer(
 		},
 	}
 
+	if cfg.EnableDevApi {
+		devImpl := jsonrpc.NewDevAPI(rawApi)
+		apiList = append(apiList, transport.API{
+			Namespace: "dev",
+			Public:    true,
+			Service:   devImpl,
+			Version:   "1.0",
+		})
+	}
+
 	if cfg.Cometa != nil {
 		cmt, err := cometa.NewService(ctx, cfg.Cometa, client)
 		if err != nil {
@@ -172,7 +182,7 @@ func getRawApi(
 	for shardId := range types.ShardId(cfg.NShards) {
 		var err error
 		if slices.Contains(myShards, uint(shardId)) {
-			shardApis[shardId] = rawapi.NewLocalShardApi(shardId, database, txnPools[shardId])
+			shardApis[shardId] = rawapi.NewLocalShardApi(shardId, database, txnPools[shardId], cfg.EnableDevApi)
 			if assert.Enable {
 				api, ok := shardApis[shardId].(*rawapi.LocalShardApi)
 				check.PanicIfNot(ok)

--- a/nil/services/rpc/jsonrpc/debug_api_test.go
+++ b/nil/services/rpc/jsonrpc/debug_api_test.go
@@ -75,7 +75,7 @@ func TestDebugGetBlock(t *testing.T) {
 	err = tx.Commit()
 	require.NoError(t, err)
 
-	mainShardApi := rawapi.NewLocalShardApi(types.MainShardId, database, nil)
+	mainShardApi := rawapi.NewLocalShardApi(types.MainShardId, database, nil, false)
 	localShardApis := map[types.ShardId]rawapi.ShardApi{
 		types.MainShardId: mainShardApi,
 	}
@@ -156,7 +156,7 @@ func (suite *SuiteDbgContracts) SetupSuite() {
 	err = tx.Commit()
 	suite.Require().NoError(err)
 
-	shardApi := rawapi.NewLocalShardApi(shardId, suite.db, nil)
+	shardApi := rawapi.NewLocalShardApi(shardId, suite.db, nil, false)
 	localShardApis := map[types.ShardId]rawapi.ShardApi{
 		shardId: shardApi,
 	}

--- a/nil/services/rpc/jsonrpc/dev_api.go
+++ b/nil/services/rpc/jsonrpc/dev_api.go
@@ -1,0 +1,26 @@
+package jsonrpc
+
+import (
+	"context"
+
+	"github.com/NilFoundation/nil/nil/internal/types"
+	"github.com/NilFoundation/nil/nil/services/rpc/rawapi"
+)
+
+type DevAPI interface {
+	DoPanicOnShard(ctx context.Context, shardId types.ShardId) (uint64, error)
+}
+
+type DevAPIImpl struct {
+	rawApi rawapi.NodeApi
+}
+
+func NewDevAPI(rawApi rawapi.NodeApi) DevAPI {
+	return &DevAPIImpl{
+		rawApi: rawApi,
+	}
+}
+
+func (d *DevAPIImpl) DoPanicOnShard(ctx context.Context, shardId types.ShardId) (uint64, error) {
+	return d.rawApi.DoPanicOnShard(ctx, shardId)
+}

--- a/nil/services/rpc/jsonrpc/eth_api_test.go
+++ b/nil/services/rpc/jsonrpc/eth_api_test.go
@@ -32,7 +32,7 @@ func NewTestEthAPI(t *testing.T, ctx context.Context, db db.DB, nShards int) *AP
 	pools := NewPools(t, ctx, nShards)
 	for shardId := range types.ShardId(nShards) {
 		var err error
-		shardApi := rawapi.NewLocalShardApi(shardId, db, pools[shardId])
+		shardApi := rawapi.NewLocalShardApi(shardId, db, pools[shardId], false)
 		shardApis[shardId], err = rawapi.NewLocalRawApiAccessor(shardId, shardApi)
 		require.NoError(t, err)
 	}

--- a/nil/services/rpc/rawapi/api.go
+++ b/nil/services/rpc/rawapi/api.go
@@ -68,6 +68,7 @@ type NodeApiRo interface {
 type NodeApi interface {
 	NodeApiRo
 	SendTransaction(ctx context.Context, shardId types.ShardId, transaction []byte) (txnpool.DiscardReason, error)
+	DoPanicOnShard(ctx context.Context, shardId types.ShardId) (uint64, error)
 }
 
 type ShardApiRo interface {
@@ -117,6 +118,7 @@ type ShardApiRo interface {
 type ShardApi interface {
 	ShardApiRo
 	SendTransaction(ctx context.Context, transaction []byte) (txnpool.DiscardReason, error)
+	DoPanicOnShard(ctx context.Context) (uint64, error)
 }
 
 func SetShardApiAsP2pRequestHandlersIfAllowed(

--- a/nil/services/rpc/rawapi/client.go
+++ b/nil/services/rpc/rawapi/client.go
@@ -237,6 +237,10 @@ func (api *ShardApiAccessor) ClientVersion(ctx context.Context) (string, error) 
 	return sendRequestAndGetResponseWithCallerMethodName[string](ctx, api, "ClientVersion")
 }
 
+func (api *ShardApiAccessor) DoPanicOnShard(ctx context.Context) (uint64, error) {
+	return sendRequestAndGetResponseWithCallerMethodName[uint64](ctx, api, "DoPanicOnShard")
+}
+
 func (api *ShardApiAccessor) setNodeApi(nodeApi NodeApi) {
 	api.onSetNodeApi(nodeApi)
 }

--- a/nil/services/rpc/rawapi/local.go
+++ b/nil/services/rpc/rawapi/local.go
@@ -12,10 +12,11 @@ import (
 )
 
 type LocalShardApi struct {
-	db       db.ReadOnlyDB
-	accessor *execution.StateAccessor
-	ShardId  types.ShardId
-	txnpool  txnpool.Pool
+	db           db.ReadOnlyDB
+	accessor     *execution.StateAccessor
+	ShardId      types.ShardId
+	txnpool      txnpool.Pool
+	enableDevApi bool
 
 	nodeApi NodeApi
 }
@@ -25,13 +26,14 @@ var (
 	_ ShardApi   = (*LocalShardApi)(nil)
 )
 
-func NewLocalShardApi(shardId types.ShardId, db db.ReadOnlyDB, txnpool txnpool.Pool) *LocalShardApi {
+func NewLocalShardApi(shardId types.ShardId, db db.ReadOnlyDB, txnpool txnpool.Pool, enableDevApi bool) *LocalShardApi {
 	stateAccessor := execution.NewStateAccessor()
 	return &LocalShardApi{
-		db:       db,
-		accessor: stateAccessor,
-		ShardId:  shardId,
-		txnpool:  txnpool,
+		db:           db,
+		accessor:     stateAccessor,
+		ShardId:      shardId,
+		txnpool:      txnpool,
+		enableDevApi: enableDevApi,
 	}
 }
 

--- a/nil/services/rpc/rawapi/local_dev.go
+++ b/nil/services/rpc/rawapi/local_dev.go
@@ -1,0 +1,18 @@
+package rawapi
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+func (api *LocalShardApi) DoPanicOnShard(ctx context.Context) (uint64, error) {
+	if !api.enableDevApi {
+		return 0, errors.New("dev api is not enabled")
+	}
+	go func() {
+		time.Sleep(10 * time.Second)
+		panic("RPC request for panic on shard")
+	}()
+	return 0, nil
+}

--- a/nil/services/rpc/rawapi/node.go
+++ b/nil/services/rpc/rawapi/node.go
@@ -327,3 +327,12 @@ func (api *NodeApiOverShardApis) ClientVersion(ctx context.Context) (string, err
 	}
 	return result, nil
 }
+
+func (api *NodeApiOverShardApis) DoPanicOnShard(ctx context.Context, shardId types.ShardId) (uint64, error) {
+	methodName := methodNameChecked("DoPanicOnShard")
+	shardApi, ok := api.Apis[shardId]
+	if !ok {
+		return 0, makeShardNotFoundError(methodName, shardId)
+	}
+	return shardApi.DoPanicOnShard(ctx)
+}

--- a/nil/services/rpc/rawapi/server.go
+++ b/nil/services/rpc/rawapi/server.go
@@ -44,6 +44,7 @@ type NetworkTransportProtocolRo interface {
 type NetworkTransportProtocol interface {
 	NetworkTransportProtocolRo
 	SendTransaction(pb.SendTransactionRequest) pb.SendTransactionResponse
+	DoPanicOnShard() pb.Uint64Response
 }
 
 func SetRawApiRequestHandlers(

--- a/nil/services/stresser/examples/workload.yaml
+++ b/nil/services/stresser/examples/workload.yaml
@@ -24,3 +24,6 @@
   batchSize: 20
 - name: blockchain_metrics
   interval: 10s
+- name: do_panic
+  interval: 20m
+  shardId: 2

--- a/nil/services/stresser/instance.go
+++ b/nil/services/stresser/instance.go
@@ -35,7 +35,7 @@ func (n *NildInstance) Init(nildPath string, workingDir string) error {
 	if n.IsRpc {
 		cmd = "rpc"
 	}
-	n.cmd = exec.Command(nildPath, cmd, "--config", cfgFile, "-l", "debug", "--log-filter", "-consensus")
+	n.cmd = exec.Command(nildPath, cmd, "--config", cfgFile, "-l", "debug", "--log-filter", "-consensus", "--dev-api")
 	n.cmd.Dir = n.workingDir
 
 	return nil
@@ -58,7 +58,7 @@ func (n *NildInstance) InitSingle(nildPath string, rootDir string, rpcPort int, 
 	}
 
 	n.cmd = exec.Command(nildPath, "run", "--nshards", strconv.Itoa(numShards), "--http-port", //nolint:gosec
-		strconv.Itoa(rpcPort), "-l", "debug", "--log-filter", "-consensus")
+		strconv.Itoa(rpcPort), "-l", "debug", "--log-filter", "-consensus", "--dev-api")
 	n.cmd.Dir = n.workingDir
 
 	return nil

--- a/nil/services/stresser/workload/do_panic.go
+++ b/nil/services/stresser/workload/do_panic.go
@@ -1,0 +1,24 @@
+package workload
+
+import (
+	"context"
+
+	"github.com/NilFoundation/nil/nil/internal/types"
+	"github.com/NilFoundation/nil/nil/services/stresser/core"
+)
+
+type DoPanic struct {
+	WorkloadBase `yaml:",inline"`
+	ShardId      types.ShardId `yaml:"shardId"`
+}
+
+func (w *DoPanic) Init(ctx context.Context, client *core.Helper, params *WorkloadParams) error {
+	w.WorkloadBase.Init(ctx, client, params)
+	return nil
+}
+
+func (w *DoPanic) Run(ctx context.Context, args *RunParams) ([]*core.Transaction, error) {
+	_, err := w.client.Client.DoPanicOnShard(ctx, w.ShardId)
+	w.logger.Info().Err(err).Msg("do panic")
+	return nil, err
+}

--- a/nil/services/stresser/workload/runner.go
+++ b/nil/services/stresser/workload/runner.go
@@ -46,9 +46,7 @@ func (r *Runner) MainLoop(ctx context.Context) {
 			txs, err := r.Workload.Run(ctx, &p)
 			if err != nil {
 				r.logger.Error().Err(err).Msg("Error running workload")
-				return
-			}
-			if len(txs) > 0 {
+			} else if len(txs) > 0 {
 				r.newTxs <- txs
 			}
 		}

--- a/nil/services/stresser/workload/workload.go
+++ b/nil/services/stresser/workload/workload.go
@@ -92,6 +92,8 @@ func GetWorkload(name string) (Workload, error) {
 		wd = &SendRequests{}
 	case "blockchain_metrics":
 		wd = &BlockchainMetrics{}
+	case "do_panic":
+		wd = &DoPanic{}
 	default:
 		return nil, fmt.Errorf("unknown workload name: %s", name)
 	}

--- a/nil/services/txnpool/txnpool.go
+++ b/nil/services/txnpool/txnpool.go
@@ -172,6 +172,7 @@ func (p *TxnPool) add(txns ...*metaTxn) ([]DiscardReason, error) {
 			Uint64(logging.FieldShardId, uint64(txn.To.ShardId())).
 			Stringer(logging.FieldTransactionHash, txn.Hash()).
 			Stringer(logging.FieldTransactionTo, txn.To).
+			Int(logging.FieldTransactionSeqno, int(txn.Seqno)).
 			Int("total", p.all.tree.Len()).
 			Msg("Added new transaction.")
 	}

--- a/nil/tests/rpc_suite.go
+++ b/nil/tests/rpc_suite.go
@@ -117,7 +117,7 @@ func (s *RpcSuite) Start(cfg *nilservice.Config) {
 			var err error
 			localShardApis[shardId], err = rawapi.NewLocalRawApiAccessor(
 				shardId,
-				rawapi.NewLocalShardApi(shardId, s.Db, service.TxnPools[shardId]))
+				rawapi.NewLocalShardApi(shardId, s.Db, service.TxnPools[shardId], false))
 			s.Require().NoError(err)
 		}
 		localApi := rawapi.NewNodeApiOverShardApis(localShardApis)


### PR DESCRIPTION
`DEVAPI` is an api for utilities useful for developers. Currently, it contains only one method `DoPanicOnShard` which forces validator, which is currently being used for the given shard, to crash.

Also, there are some improvements in Stresser:
- Add `do_panic` workload.
- Add retries for top-up via Faucet. It is necessary because of a known issue with data race of Faucet contract's seqno.
- Improve the procedure of waiting for cluster readiness.