### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/nil/internal/vm/memory_table.go
+++ b/nil/internal/vm/memory_table.go
@@ -73,10 +73,7 @@ func memoryCall(stack *Stack) (uint64, bool) {
 	if overflow {
 		return 0, true
 	}
-	if x > y {
-		return x, false
-	}
-	return y, false
+	return max(x, y), false
 }
 
 func memoryDelegateCall(stack *Stack) (uint64, bool) {
@@ -88,10 +85,7 @@ func memoryDelegateCall(stack *Stack) (uint64, bool) {
 	if overflow {
 		return 0, true
 	}
-	if x > y {
-		return x, false
-	}
-	return y, false
+	return max(x, y), false
 }
 
 func memoryStaticCall(stack *Stack) (uint64, bool) {
@@ -103,10 +97,7 @@ func memoryStaticCall(stack *Stack) (uint64, bool) {
 	if overflow {
 		return 0, true
 	}
-	if x > y {
-		return x, false
-	}
-	return y, false
+	return max(x, y), false
 }
 
 func memoryReturn(stack *Stack) (uint64, bool) {


### PR DESCRIPTION
Use the built-in max/min from the standard library in Go 1.21 to simplify the code.