### PR TITLE
Added PR template for external contributors

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,36 @@
+## Short Summary
+
+<!-- Briefly describe what this PR does -->
+
+## What Changes Were Made
+
+<!-- List the changes introduced in this PR -->
+
+-
+-
+-
+
+## Related Issue
+
+<!-- If this PR addresses an existing issue, please link it here -->
+
+Fixes #[Issue Number]  
+or  
+Related to #[Issue Number]
+
+## Breaking Changes (if any)
+
+<!-- OPTIONAL: Describe any breaking changes this PR introduces -->
+
+## Screenshots / Visual Changes
+
+<!-- OPTIONAL: Add screenshots, recordings, or visual references if relevant -->
+
+## Checklist
+
+_Please mark each item with an `x` inside the brackets (e.g., [x]) once completed._
+
+- [ ] I have read and followed the [Contributing Guide](https://github.com/NilFoundation/nil/blob/main/CONTRIBUTION-GUIDE.md)
+- [ ] I have tested the changes locally
+- [ ] I have added relevant tests (if applicable)
+- [ ] I have updated documentation/comments (if applicable)


### PR DESCRIPTION
This PR introduces a template for pull requests which should help external contributors for opening a PR. It includes a short format for what the PR can contain and also some checklists which are essential for following our guidelines. 