### PR TITLE
fix: update transaction page ui

### DIFF
--- a/explorer_frontend/src/features/transaction/components/Logs.tsx
+++ b/explorer_frontend/src/features/transaction/components/Logs.tsx
@@ -6,6 +6,7 @@ import { type StyleObject, useStyletron } from "styletron-react";
 import { addressRoute } from "../../routing";
 import { Card, Link, addHexPrefix } from "../../shared";
 import type { TransactionLog } from "../types/TransactionLog";
+import noLog from "./assets/no-log.svg";
 
 type LogsProps = {
   logs: TransactionLog[];
@@ -16,6 +17,15 @@ const styles = {
     display: "flex",
     flexDirection: "column",
     gap: "16px",
+  },
+  noLogsContainer: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: "16px",
+    height: "100%",
+    width: "100%",
   },
   contaier: {
     display: "grid",
@@ -55,7 +65,16 @@ export const Logs: FC<LogsProps> = ({ logs }) => {
   return (
     <>
       {logs.length === 0 ? (
-        <ParagraphLarge>No logs</ParagraphLarge>
+        <div className={css(styles.noLogsContainer)}>
+          <img src={noLog} alt="no-log" width={88} height={88} />
+          <ParagraphLarge color={COLORS.gray50}>
+            No logs found for this transaction
+          </ParagraphLarge>
+          <ParagraphSmall color={COLORS.gray300}>
+            It looks like this transaction didn’t generate any events
+            or interactions
+          </ParagraphSmall>
+        </div>
       ) : (
         <div className={css(styles.logsContainer)}>
           {logs.map((log) => (
@@ -66,12 +85,16 @@ export const Logs: FC<LogsProps> = ({ logs }) => {
                   <ParagraphSmall>
                     <Link
                       to={addressRoute}
-                      params={{ address: addHexPrefix(log.address.toLowerCase()) }}
+                      params={{
+                        address: addHexPrefix(log.address.toLowerCase()),
+                      }}
                     >
                       {addHexPrefix(log.address.toLowerCase())}
                     </Link>
                   </ParagraphSmall>
-                  <CopyButton textToCopy={addHexPrefix(log.address.toLowerCase())} />
+                  <CopyButton
+                    textToCopy={addHexPrefix(log.address.toLowerCase())}
+                  />
                 </div>
                 <ParagraphSmall color={COLORS.gray400}>Topics:</ParagraphSmall>
                 <div>{getTopics(log, css)}</div>
@@ -86,7 +109,10 @@ export const Logs: FC<LogsProps> = ({ logs }) => {
   );
 };
 
-const getTopics = (log: TransactionLog, css: (style: StyleObject) => string) => {
+const getTopics = (
+  log: TransactionLog,
+  css: (style: StyleObject) => string
+) => {
   const limit = log.topics_count;
 
   return Array.from({ length: limit }, (_, i) => {

--- a/explorer_frontend/src/features/transaction/components/Logs.tsx
+++ b/explorer_frontend/src/features/transaction/components/Logs.tsx
@@ -67,12 +67,9 @@ export const Logs: FC<LogsProps> = ({ logs }) => {
       {logs.length === 0 ? (
         <div className={css(styles.noLogsContainer)}>
           <img src={noLog} alt="no-log" width={88} height={88} />
-          <ParagraphLarge color={COLORS.gray50}>
-            No logs found for this transaction
-          </ParagraphLarge>
+          <ParagraphLarge color={COLORS.gray50}>No logs found for this transaction</ParagraphLarge>
           <ParagraphSmall color={COLORS.gray300}>
-            It looks like this transaction didn’t generate any events
-            or interactions
+            It looks like this transaction didn’t generate any events or interactions
           </ParagraphSmall>
         </div>
       ) : (
@@ -92,9 +89,7 @@ export const Logs: FC<LogsProps> = ({ logs }) => {
                       {addHexPrefix(log.address.toLowerCase())}
                     </Link>
                   </ParagraphSmall>
-                  <CopyButton
-                    textToCopy={addHexPrefix(log.address.toLowerCase())}
-                  />
+                  <CopyButton textToCopy={addHexPrefix(log.address.toLowerCase())} />
                 </div>
                 <ParagraphSmall color={COLORS.gray400}>Topics:</ParagraphSmall>
                 <div>{getTopics(log, css)}</div>
@@ -109,10 +104,7 @@ export const Logs: FC<LogsProps> = ({ logs }) => {
   );
 };
 
-const getTopics = (
-  log: TransactionLog,
-  css: (style: StyleObject) => string
-) => {
+const getTopics = (log: TransactionLog, css: (style: StyleObject) => string) => {
   const limit = log.topics_count;
 
   return Array.from({ length: limit }, (_, i) => {

--- a/explorer_frontend/src/features/transaction/components/Transaction.tsx
+++ b/explorer_frontend/src/features/transaction/components/Transaction.tsx
@@ -17,16 +17,28 @@ import { useStyletron } from "styletron-react";
 import { useMobile } from "../../shared";
 import { TransactionList } from "../../transaction-list";
 import { $transaction, fetchTransactionFx } from "../models/transaction";
-import { $transactionChilds, fetchTransactionChildsFx } from "../models/transactionChilds.ts";
-import { $transactionLogs, fetchTransactionLogsFx } from "../models/transactionLogs";
+import {
+  $transactionChilds,
+  fetchTransactionChildsFx,
+} from "../models/transactionChilds.ts";
+import {
+  $transactionLogs,
+  fetchTransactionLogsFx,
+} from "../models/transactionLogs";
 import { Logs } from "./Logs";
 import { Overview } from "./Overview";
 
 export const Transaction = () => {
   const [css] = useStyletron();
   const [isMobile] = useMobile();
-  const [transaction, pending] = useUnit([$transaction, fetchTransactionFx.pending]);
-  const [logs, logsPending] = useUnit([$transactionLogs, fetchTransactionLogsFx.pending]);
+  const [transaction, pending] = useUnit([
+    $transaction,
+    fetchTransactionFx.pending,
+  ]);
+  const [logs, logsPending] = useUnit([
+    $transactionLogs,
+    fetchTransactionLogsFx.pending,
+  ]);
   const [transactionChilds, childsLoading] = useUnit([
     $transactionChilds,
     fetchTransactionChildsFx.pending,
@@ -47,38 +59,74 @@ export const Transaction = () => {
   }, [transaction]);
 
   return (
-    <>
-      <HeadingXLarge className={css({ marginBottom: SPACE[32] })}>Transaction</HeadingXLarge>
+    <div
+      className={css({
+        display: "flex",
+        flexDirection: "column",
+        flexWrap: "nowrap",
+        width: "100%",
+        position: "absolute",
+        left: "0",
+        right: "0",
+        paddingLeft: "48px",
+        paddingRight: "48px",
+      })}
+    >
+      <HeadingXLarge className={css({ marginBottom: SPACE[32] })}>
+        Transaction
+      </HeadingXLarge>
       {!transaction ? (
         pending ? (
           <Skeleton animation />
         ) : (
-          <ParagraphSmall color={COLORS.gray100}>Transaction not found</ParagraphSmall>
+          <ParagraphSmall color={COLORS.gray100}>
+            Transaction not found
+          </ParagraphSmall>
         )
       ) : (
-        <Tabs activeKey={activeKey} onChange={onChangeHandler} overrides={tabsOverrides}>
+        <Tabs
+          activeKey={activeKey}
+          onChange={onChangeHandler}
+          overrides={tabsOverrides}
+        >
           <Tab title="Overview" kind={TAB_KIND.secondary}>
             <Overview transaction={transaction} />
           </Tab>
           <Tab
             title="Logs"
-            endEnhancer={<Tag size={TAG_SIZE.m}>{logs?.length ?? 0}</Tag>}
+            endEnhancer={
+              logs?.length > 0 ? (
+                <Tag size={TAG_SIZE.m}>{logs?.length ?? 0}</Tag>
+              ) : (
+                ""
+              )
+            }
             kind={TAB_KIND.secondary}
           >
             {logsPending ? <Skeleton animation /> : <Logs logs={logs} />}
           </Tab>
-          <Tab
-            title={isMobile ? "Outgoing txn" : "Outgoing transactions"}
-            endEnhancer={
-              <Tag size={TAG_SIZE.m}>{!childsLoading ? transactionChilds?.length : "..."}</Tag>
-            }
-            kind={TAB_KIND.secondary}
-          >
-            <TransactionList type="transaction" identifier={transaction.hash} view="incoming" />
-          </Tab>
+          {!childsLoading && transactionChilds?.length > 0 ? (
+            <Tab
+              title={isMobile ? "Outgoing txn" : "Outgoing transactions"}
+              endEnhancer={
+                <Tag size={TAG_SIZE.m}>
+                  {!childsLoading ? transactionChilds?.length : "..."}
+                </Tag>
+              }
+              kind={TAB_KIND.secondary}
+            >
+              <TransactionList
+                type="transaction"
+                identifier={transaction.hash}
+                view="incoming"
+              />
+            </Tab>
+          ) : (
+            <></>
+          )}
         </Tabs>
       )}
-    </>
+    </div>
   );
 };
 

--- a/explorer_frontend/src/features/transaction/components/Transaction.tsx
+++ b/explorer_frontend/src/features/transaction/components/Transaction.tsx
@@ -17,28 +17,16 @@ import { useStyletron } from "styletron-react";
 import { useMobile } from "../../shared";
 import { TransactionList } from "../../transaction-list";
 import { $transaction, fetchTransactionFx } from "../models/transaction";
-import {
-  $transactionChilds,
-  fetchTransactionChildsFx,
-} from "../models/transactionChilds.ts";
-import {
-  $transactionLogs,
-  fetchTransactionLogsFx,
-} from "../models/transactionLogs";
+import { $transactionChilds, fetchTransactionChildsFx } from "../models/transactionChilds.ts";
+import { $transactionLogs, fetchTransactionLogsFx } from "../models/transactionLogs";
 import { Logs } from "./Logs";
 import { Overview } from "./Overview";
 
 export const Transaction = () => {
   const [css] = useStyletron();
   const [isMobile] = useMobile();
-  const [transaction, pending] = useUnit([
-    $transaction,
-    fetchTransactionFx.pending,
-  ]);
-  const [logs, logsPending] = useUnit([
-    $transactionLogs,
-    fetchTransactionLogsFx.pending,
-  ]);
+  const [transaction, pending] = useUnit([$transaction, fetchTransactionFx.pending]);
+  const [logs, logsPending] = useUnit([$transactionLogs, fetchTransactionLogsFx.pending]);
   const [transactionChilds, childsLoading] = useUnit([
     $transactionChilds,
     fetchTransactionChildsFx.pending,
@@ -72,35 +60,21 @@ export const Transaction = () => {
         paddingRight: "48px",
       })}
     >
-      <HeadingXLarge className={css({ marginBottom: SPACE[32] })}>
-        Transaction
-      </HeadingXLarge>
+      <HeadingXLarge className={css({ marginBottom: SPACE[32] })}>Transaction</HeadingXLarge>
       {!transaction ? (
         pending ? (
           <Skeleton animation />
         ) : (
-          <ParagraphSmall color={COLORS.gray100}>
-            Transaction not found
-          </ParagraphSmall>
+          <ParagraphSmall color={COLORS.gray100}>Transaction not found</ParagraphSmall>
         )
       ) : (
-        <Tabs
-          activeKey={activeKey}
-          onChange={onChangeHandler}
-          overrides={tabsOverrides}
-        >
+        <Tabs activeKey={activeKey} onChange={onChangeHandler} overrides={tabsOverrides}>
           <Tab title="Overview" kind={TAB_KIND.secondary}>
             <Overview transaction={transaction} />
           </Tab>
           <Tab
             title="Logs"
-            endEnhancer={
-              logs?.length > 0 ? (
-                <Tag size={TAG_SIZE.m}>{logs?.length ?? 0}</Tag>
-              ) : (
-                ""
-              )
-            }
+            endEnhancer={logs?.length > 0 ? <Tag size={TAG_SIZE.m}>{logs?.length ?? 0}</Tag> : ""}
             kind={TAB_KIND.secondary}
           >
             {logsPending ? <Skeleton animation /> : <Logs logs={logs} />}
@@ -109,17 +83,11 @@ export const Transaction = () => {
             <Tab
               title={isMobile ? "Outgoing txn" : "Outgoing transactions"}
               endEnhancer={
-                <Tag size={TAG_SIZE.m}>
-                  {!childsLoading ? transactionChilds?.length : "..."}
-                </Tag>
+                <Tag size={TAG_SIZE.m}>{!childsLoading ? transactionChilds?.length : "..."}</Tag>
               }
               kind={TAB_KIND.secondary}
             >
-              <TransactionList
-                type="transaction"
-                identifier={transaction.hash}
-                view="incoming"
-              />
+              <TransactionList type="transaction" identifier={transaction.hash} view="incoming" />
             </Tab>
           ) : (
             <></>

--- a/explorer_frontend/src/features/transaction/components/assets/no-log.svg
+++ b/explorer_frontend/src/features/transaction/components/assets/no-log.svg
@@ -1,0 +1,7 @@
+<svg width="88" height="88" viewBox="0 0 88 88" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M69.6667 7.33333H18.3334C16.3083 7.33333 14.6667 8.97495 14.6667 11V77C14.6667 79.025 16.3083 80.6667 18.3334 80.6667H69.6667C71.6917 80.6667 73.3334 79.025 73.3334 77V11C73.3334 8.97495 71.6917 7.33333 69.6667 7.33333Z" stroke="#F1F1F1" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M31.1667 55L56.8334 55" stroke="#F1F1F1" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M31.1667 66H44" stroke="#F1F1F1" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M36.6667 38.5L51.3334 23.8333" stroke="#F1F1F1" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M51.3333 38.5L36.6666 23.8333" stroke="#F1F1F1" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/explorer_frontend/src/pages/transaction/TransactionPage.tsx
+++ b/explorer_frontend/src/pages/transaction/TransactionPage.tsx
@@ -1,18 +1,17 @@
 import { useStyletron } from "baseui";
-import { explorerRoute } from "../../features/routing/routes/explorerRoute";
 import { Meta } from "../../features/shared";
 import { Layout } from "../../features/shared/components/Layout";
-import { SidebarWithBackLink } from "../../features/shared/components/SidebarWithBackLink";
 import { Transaction } from "../../features/transaction";
 
 const TransactionPage = () => {
   const [css] = useStyletron();
   return (
-    <Layout sidebar={<SidebarWithBackLink to={explorerRoute} />}>
+    <Layout>
       <div
         className={css({
-          display: "grid",
-          gridTemplateColumns: "1fr",
+          display: "flex",
+          flexDirection: "column",
+          maxWidth: "100%",
           width: "100%",
         })}
       >


### PR DESCRIPTION
### [FIX]: enhance Transaction page UI

This PR updates the design in the transaction page

Key Changes:
- Remove the go back button and improved page padding
- Introduced a refined No Logs design when Logs = 0
- Remove Outgoing transactions tab when count = 0

to close: #599