### PR TITLE
[playground] add Playground version to playground logo

### DIFF
--- a/explorer_frontend/.env
+++ b/explorer_frontend/.env
@@ -1,2 +1,3 @@
 VITE_APP_TITLE="=nil; zkSharding"
 VITE_APP_DESCRIPTION="zkSharding for Ethereum"
+VITE_PLAYGROUND_VERSION=""

--- a/explorer_frontend/src/features/shared/components/Layout/Logo.tsx
+++ b/explorer_frontend/src/features/shared/components/Layout/Logo.tsx
@@ -1,20 +1,21 @@
 import { Link } from "atomic-router-react";
-import { useStore } from "effector-react";
+import type { ReactNode } from "react";
 import { useStyletron } from "styletron-react";
 import { explorerRoute } from "../../../routing/routes/explorerRoute";
-import { tutorialWithUrlStringRoute } from "../../../routing/routes/tutorialRoute";
 import logo from "./assets/Logo.svg";
 import { styles } from "./styles";
 
-export const Logo = () => {
-  const [css] = useStyletron();
+type LogoProps = {
+  subText?: ReactNode;
+};
 
-  const isTutorial = useStore(tutorialWithUrlStringRoute.$isOpened);
+export const Logo = ({ subText }: LogoProps) => {
+  const [css] = useStyletron();
 
   return (
     <Link className={css(styles.logo)} to={explorerRoute}>
       <img src={logo} alt="logo" />
-      {isTutorial && <span className={css(styles.tutorialText)}>Tutorials v1.0</span>}
+      {subText}
     </Link>
   );
 };

--- a/explorer_frontend/src/features/shared/components/Layout/Navbar.tsx
+++ b/explorer_frontend/src/features/shared/components/Layout/Navbar.tsx
@@ -2,14 +2,14 @@ import type { ReactNode } from "react";
 import { useStyletron } from "styletron-react";
 import { Search } from "../../../search";
 import { useMobile } from "../../hooks/useMobile";
-import { Logo } from "./Logo";
 import { styles } from "./styles";
 
 type NavbarProps = {
   children?: ReactNode;
+  logo?: ReactNode;
 };
 
-export const Navbar = ({ children }: NavbarProps) => {
+export const Navbar = ({ children, logo = null }: NavbarProps) => {
   const [isMobile] = useMobile();
   const [css] = useStyletron();
   return (
@@ -20,7 +20,7 @@ export const Navbar = ({ children }: NavbarProps) => {
           display: "flex",
         })}
       >
-        <Logo />
+        {logo}
         {!isMobile && <Search />}
       </div>
       <div

--- a/explorer_frontend/src/features/shared/components/Layout/index.tsx
+++ b/explorer_frontend/src/features/shared/components/Layout/index.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { useStyletron } from "styletron-react";
 import { useMobile } from "../../hooks/useMobile";
+import { Logo } from "./Logo";
 import { Navbar } from "./Navbar";
 import { mobileContainerStyle, mobileContentStyle, styles } from "./styles";
 
@@ -16,7 +17,7 @@ export const Layout = ({ children, sidebar, navbar }: LayoutProps) => {
 
   return (
     <div className={css(isMobile ? mobileContainerStyle : styles.container)}>
-      <Navbar>{navbar}</Navbar>
+      <Navbar logo={<Logo />}>{navbar}</Navbar>
       <div className={css(isMobile ? mobileContentStyle : styles.content)}>
         {sidebar}
         {children}

--- a/explorer_frontend/src/features/shared/components/Layout/styles.ts
+++ b/explorer_frontend/src/features/shared/components/Layout/styles.ts
@@ -57,13 +57,6 @@ const navigation = {
   justifyContent: "flex-end",
 };
 
-const tutorialText = {
-  marginTop: "4px",
-  fontSize: "12px",
-  color: COLORS.blue400,
-  fontFamily: "Inter, sans-serif",
-};
-
 const navItem = {
   display: "flex",
   alignItems: "center",
@@ -87,7 +80,6 @@ export const styles = {
   navItem,
   content,
   navLink,
-  tutorialText,
 };
 
 export const mobileContainerStyle: StyleObject = {

--- a/explorer_frontend/src/features/shared/index.ts
+++ b/explorer_frontend/src/features/shared/index.ts
@@ -21,6 +21,7 @@ export { HyperlinkIcon } from "./components/HyperlinkIcon";
 export { QuestionIcon } from "./components/QuestionIcon";
 export { ArrowUpRightIcon } from "./components/ArrowUpRightIcon";
 export { InternalPageContainer } from "./components/InternalPageContainer";
+export { Logo } from "./components/Layout/Logo";
 export * from "./components/Popover";
 export * from "./utils/age";
 export * from "./utils/convert";

--- a/explorer_frontend/src/pages/playground/PlaygroundPage.tsx
+++ b/explorer_frontend/src/pages/playground/PlaygroundPage.tsx
@@ -1,4 +1,4 @@
-import { PROGRESS_BAR_SIZE, ProgressBar } from "@nilfoundation/ui-kit";
+import { COLORS, PROGRESS_BAR_SIZE, ProgressBar } from "@nilfoundation/ui-kit";
 import { useStyletron } from "baseui";
 import { useUnit } from "effector-react";
 import { expandProperty } from "inline-style-expand-shorthand";
@@ -11,7 +11,7 @@ import { ContractsContainer, closeApp } from "../../features/contracts";
 import { NetworkErrorNotification } from "../../features/healthcheck";
 import { $rpcIsHealthy } from "../../features/healthcheck/model";
 import { Logs } from "../../features/logs/components/Logs";
-import { useMobile } from "../../features/shared";
+import { Logo, useMobile } from "../../features/shared";
 import { Navbar } from "../../features/shared/components/Layout/Navbar";
 import { mobileContainerStyle, styles } from "../../features/shared/components/Layout/styles";
 import { fetchSolidityCompiler } from "../../services/compiler";
@@ -21,6 +21,7 @@ export const PlaygroundPage = () => {
   const [isDownloading, isRPCHealthy] = useUnit([fetchSolidityCompiler.pending, $rpcIsHealthy]);
   const [css] = useStyletron();
   const [isMobile] = useMobile();
+  const playgroundVersion = import.meta.env.VITE_PLAYGROUND_VERSION;
 
   useEffect(() => {
     loadedPlaygroundPage();
@@ -33,7 +34,26 @@ export const PlaygroundPage = () => {
   return (
     <div className={css(isMobile ? mobileContainerStyle : styles.container)}>
       {!isRPCHealthy && <NetworkErrorNotification />}
-      <Navbar>
+      <Navbar
+        logo={
+          <Logo
+            subText={
+              playgroundVersion ? (
+                <span
+                  className={css({
+                    marginTop: "4px",
+                    fontSize: "12px",
+                    color: COLORS.gray400,
+                    fontFamily: "Inter, sans-serif",
+                  })}
+                >
+                  {`Playground v${playgroundVersion}`}
+                </span>
+              ) : null
+            }
+          />
+        }
+      >
         <AccountPane />
       </Navbar>
       <div

--- a/explorer_frontend/src/pages/tutorials/TutorialPage.tsx
+++ b/explorer_frontend/src/pages/tutorials/TutorialPage.tsx
@@ -21,7 +21,7 @@ import { ContractsContainer } from "../../features/contracts/components/Contract
 import { NetworkErrorNotification } from "../../features/healthcheck";
 import { $rpcIsHealthy } from "../../features/healthcheck/model";
 import { Logs } from "../../features/logs/components/Logs";
-import { useMobile } from "../../features/shared";
+import { Logo, useMobile } from "../../features/shared";
 import { Navbar } from "../../features/shared/components/Layout/Navbar";
 import { mobileContainerStyle, styles } from "../../features/shared/components/Layout/styles";
 import { TutorialText } from "../../features/tutorial/TutorialText";
@@ -98,7 +98,24 @@ export const TutorialPage = () => {
   return (
     <div className={css(isMobile ? mobileContainerStyle : styles.container)}>
       {!isRPCHealthy && <NetworkErrorNotification />}
-      <Navbar>
+      <Navbar
+        logo={
+          <Logo
+            subText={
+              <span
+                className={css({
+                  marginTop: "4px",
+                  fontSize: "12px",
+                  color: COLORS.blue400,
+                  fontFamily: "Inter, sans-serif",
+                })}
+              >
+                Tutorials v1.0
+              </span>
+            }
+          />
+        }
+      >
         <AccountPane />
       </Navbar>
       <div

--- a/flake.nix
+++ b/flake.nix
@@ -122,6 +122,8 @@
                 mkdir -p ./usr/share/${packages.docsaibackend.name}
                 mkdir -p ./usr/share/${packages.rollup-bridge-contracts.name}
 
+                echo "${version}" > ./VERSION
+
                 cp -r ${pkg}/bin ./usr/
                 cp -r ${pkg}/share ./usr/
                 cp -r ${packages.nildocs.outPath}/* ./usr/share/${packages.nildocs.pname}

--- a/nix/nilexplorer.nix
+++ b/nix/nilexplorer.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation rec {
     "biome.json"
     "^explorer_frontend(/.*)?$"
     "^explorer_backend(/.*)?$"
+    "VERSION"
   ];
 
   pnpmDeps = (callPackage ./npmdeps.nix { });
@@ -43,7 +44,10 @@ stdenv.mkDerivation rec {
     (cd smart-contracts; pnpm run build)
     (cd niljs; pnpm run build)
 
-    (cd explorer_frontend; pnpm run build)
+    export VITE_PLAYGROUND_VERSION=$( [ -f VERSION ] && cat VERSION || echo "" )
+    cd explorer_frontend
+    pnpm run build
+    cd -
 
     (cd explorer_backend; pnpm run build)
   '';


### PR DESCRIPTION
This diff adds `Playground v123` text to playground logo if version is specified.
The version is injected as `env` during the build because it is not a subject to be changed after the app is built.