### PR TITLE
[cli] fix crash on requesting non-existing block 

### DIFF
--- a/nil/cmd/nil/internal/block/block.go
+++ b/nil/cmd/nil/internal/block/block.go
@@ -47,6 +47,11 @@ func runCommand(cmd *cobra.Command, args []string) error {
 		logger.Error().Err(err).Msg("Failed to fetch the block by number")
 		return err
 	}
-	fmt.Println(string(blockData))
+	if blockData != nil {
+		fmt.Println(string(blockData))
+	} else {
+		fmt.Println("null")
+	}
+
 	return nil
 }

--- a/nil/internal/execution/postprocess.go
+++ b/nil/internal/execution/postprocess.go
@@ -66,7 +66,7 @@ func (pp *blockPostprocessor) fillBlockHashAndTransactionIndexByTransactionHash(
 					return fmt.Errorf("fail to check transaction existence in DB: %w", err)
 				}
 				if ok {
-					return fmt.Errorf("fatal: duplicate transaction %x", hash)
+					return fmt.Errorf("fatal: duplicate transaction in %s: %x", table, hash)
 				}
 			}
 

--- a/nil/services/cliservice/block_format_test.go
+++ b/nil/services/cliservice/block_format_test.go
@@ -124,6 +124,7 @@ func TestDebugBlockToText(t *testing.T) {
 				ChildBlocksRootHash: common.HexToHash("0xDEADBABE"),
 				MainShardHash:       common.HexToHash("0xB16B055"),
 				Timestamp:           0x12345678,
+				GasUsed:             1234,
 			},
 			LogsBloom: types.Bloom{},
 		},
@@ -147,8 +148,10 @@ func TestDebugBlockToText(t *testing.T) {
 		text, err := s.debugBlockToText(types.ShardId(13), block, false, false)
 		require.NoError(t, err)
 
-		expectedText := `Block #100500 [0x000dad995dc84952f5631bfba6237a9a77520053aa6f282a6471dd1ea1af6a89] @ 13 shard
+		expectedText := `Block #100500 [0x000dba05b595d9709214a9f31c34785e40733b6a01d90f295a44e7ab9a861088] @ 13 shard
   PrevBlock: 0x00000000000000000000000000000000000000000000000000000000deadbeef
+  BaseFee: 0
+  GasUsed: 1234
   ChildBlocksRootHash: 0x00000000000000000000000000000000000000000000000000000000deadbabe
   ChildBlocks:
     - 1: 0x0000000000000000000000000000000000000000000000000000000000000111

--- a/nil/tests/cli/cli_test.go
+++ b/nil/tests/cli/cli_test.go
@@ -81,13 +81,20 @@ func (s *SuiteCliService) TestCliBlock() {
 	block, err := s.DefaultClient.GetBlock(s.Context, types.BaseShardId, 0, false)
 	s.Require().NoError(err)
 
-	res, err := s.cli.FetchBlock(types.BaseShardId, block.Hash.Hex())
+	res, err := s.cli.FetchDebugBlock(types.BaseShardId, block.Hash.Hex(), true, false, true)
 	s.Require().NoError(err)
-	s.JSONEq(s.toJSON(block), string(res))
+	var blockRes map[string]any
+	s.Require().NoError(json.Unmarshal(res, &blockRes))
+	s.EqualValues(block.Number, blockRes["id"])
 
-	res, err = s.cli.FetchBlock(types.BaseShardId, "0")
+	res, err = s.cli.FetchDebugBlock(types.BaseShardId, "0", true, false, true)
 	s.Require().NoError(err)
-	s.JSONEq(s.toJSON(block), string(res))
+	s.Require().NoError(json.Unmarshal(res, &blockRes))
+	s.EqualValues(block.Number, blockRes["id"])
+
+	res, err = s.cli.FetchDebugBlock(types.BaseShardId, "10000000000", true, false, true)
+	s.Require().NoError(err)
+	s.Require().Empty(res)
 }
 
 func (s *SuiteCliService) TestCliTransaction() {
@@ -310,6 +317,9 @@ func (s *SuiteCliExec) TestCallCliBasic() {
 	res := s.RunCli("-c", cfgPath, "block", "--json", block.Number.String())
 	s.Contains(res, block.Number.String())
 	s.Contains(res, block.Hash.String())
+
+	res = s.RunCli("-c", cfgPath, "block", "--json", "10000000000000")
+	s.Equal("null", res)
 }
 
 func (s *SuiteCliExec) TestCliSmartAccount() {


### PR DESCRIPTION
Before this patch simple request could crash CLI:
```
nil block 0x0004c3c56fde2450c25c9f0501588655be1483e083014f0e6ad4fa617c68432b
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x125a4be]

goroutine 1 [running]:
github.com/NilFoundation/nil/nil/services/rpc/jsonrpc.(*DebugRPCBlock).Decode(0x0)
	github.com/NilFoundation/nil/nil/services/rpc/jsonrpc/types.go:182 +0x3e
github.com/NilFoundation/nil/nil/services/rpc/jsonrpc.(*DebugRPCBlock).DecodeSSZ(0xc000312000?)
	github.com/NilFoundation/nil/nil/services/rpc/jsonrpc/types.go:199 +0x13
github.com/NilFoundation/nil/nil/services/cliservice.(*Service).FetchDebugBlock(0xc00048c460, 0x1, {0x16cada0?, 0xc0004742e0?}, 0x0, 0x0, 0x0)
	github.com/NilFoundation/nil/nil/services/cliservice/block.go:46 +0x7d
github.com/NilFoundation/nil/nil/cmd/nil/internal/block.runCommand(0xc000506300?, {0xc000474f30, 0x1, 0x1a3e358?})
	github.com/NilFoundation/nil/nil/cmd/nil/internal/block/block.go:44 +0xaa
github.com/spf13/cobra.(*Command).execute(0xc00044d508, {0xc000474f00, 0x1, 0x1})
	github.com/spf13/cobra@v1.9.1/command.go:1015 +0xa94
github.com/spf13/cobra.(*Command).ExecuteC(0xc00044c908)
	github.com/spf13/cobra@v1.9.1/command.go:1148 +0x40c
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.9.1/command.go:1071
main.(*RootCommand).Execute(0xc000482400?)
	github.com/NilFoundation/nil/nil/cmd/nil/main.go:144 +0x16
main.main()
	github.com/NilFoundation/nil/nil/cmd/nil/main.go:120 +0x254
```

Closes #675