### PR TITLE
relayer metrics

### DIFF
--- a/nil/services/relayer/internal/l1/metrics.go
+++ b/nil/services/relayer/internal/l1/metrics.go
@@ -1,0 +1,156 @@
+package l1
+
+import (
+	"context"
+
+	"github.com/NilFoundation/nil/nil/internal/telemetry"
+	"github.com/NilFoundation/nil/nil/internal/telemetry/telattr"
+	"github.com/NilFoundation/nil/nil/services/relayer/internal/metrics"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+type EventListenerMetrics interface {
+	SetFetcherActive(ctx context.Context)
+	SetFetcherIdle(ctx context.Context)
+	AddEventFromFetcher(ctx context.Context)
+	AddEventFromSubscriber(ctx context.Context)
+	AddSubscriptionError(ctx context.Context)
+}
+
+const (
+	eventSourceLabel      = "event_source"
+	eventSourceFetcher    = "fetcher"
+	eventSourceSubscriber = "subscriber"
+
+	eventStatusLabel     = "event_status"
+	eventStatusFinalized = "finalized"
+	eventStatusOrphaned  = "orphaned"
+)
+
+type eventListenerMetrics struct {
+	attrs metric.MeasurementOption
+
+	fetcherRunStatus telemetry.Gauge // 0 if fetcher is inactive
+	subsciptionError telemetry.Counter
+	eventsProcessed  telemetry.Counter
+}
+
+func NewEventListenerMetrics() (EventListenerMetrics, error) {
+	elm := &eventListenerMetrics{}
+	if err := metrics.InitMetrics(elm, "relayer", "event_listener"); err != nil {
+		return nil, err
+	}
+	return elm, nil
+}
+
+func (elm *eventListenerMetrics) Init(name string, meter telemetry.Meter, attrs metric.MeasurementOption) error {
+	var err error
+
+	elm.fetcherRunStatus, err = meter.Int64Gauge(name + ".fetcher_active")
+	if err != nil {
+		return err
+	}
+
+	elm.subsciptionError, err = meter.Int64Counter(name + ".subscription_failure")
+	if err != nil {
+		return err
+	}
+
+	elm.eventsProcessed, err = meter.Int64Counter(name + ".events_processed")
+	if err != nil {
+		return err
+	}
+
+	elm.attrs = attrs
+	return nil
+}
+
+func (elm *eventListenerMetrics) SetFetcherActive(ctx context.Context) {
+	elm.fetcherRunStatus.Record(ctx, 1, elm.attrs)
+}
+
+func (elm *eventListenerMetrics) SetFetcherIdle(ctx context.Context) {
+	elm.fetcherRunStatus.Record(ctx, 0, elm.attrs)
+}
+
+func (elm *eventListenerMetrics) AddEventFromFetcher(ctx context.Context) {
+	sourceAttr := telattr.With(attribute.String(eventSourceLabel, eventSourceFetcher))
+	elm.eventsProcessed.Add(ctx, 1, elm.attrs, sourceAttr)
+}
+
+func (elm *eventListenerMetrics) AddEventFromSubscriber(ctx context.Context) {
+	sourceAttr := telattr.With(attribute.String(eventSourceLabel, eventSourceSubscriber))
+	elm.eventsProcessed.Add(ctx, 1, elm.attrs, sourceAttr)
+}
+
+func (elm *eventListenerMetrics) AddSubscriptionError(ctx context.Context) {
+	elm.subsciptionError.Add(ctx, 1, elm.attrs)
+}
+
+type FinalityEnsurerMetrics interface {
+	SetTimeSinceFinalizedBlockNumberUpdate(ctx context.Context, sec uint64)
+	AddRelayError(ctx context.Context)
+	AddFinalizedEvents(ctx context.Context, count uint64)
+	AddOrphanedEvents(ctx context.Context, count uint64)
+}
+
+type finalityEnsurerMetrics struct {
+	attrs metric.MeasurementOption
+
+	finalizedBlockUpdateLag telemetry.Gauge
+	relayErrors             telemetry.Counter
+	processedEvents         telemetry.Counter
+}
+
+func NewFinalityEnsurerMetrics() (FinalityEnsurerMetrics, error) {
+	fem := &finalityEnsurerMetrics{}
+	if err := metrics.InitMetrics(fem, "relayer", "finality_ensurer"); err != nil {
+		return nil, err
+	}
+	return fem, nil
+}
+
+func (fem *finalityEnsurerMetrics) Init(name string, meter telemetry.Meter, attrs metric.MeasurementOption) error {
+	var err error
+
+	fem.finalizedBlockUpdateLag, err = meter.Int64Gauge(name + ".finalized_block_update_lag_sec")
+	if err != nil {
+		return err
+	}
+
+	fem.relayErrors, err = meter.Int64Counter(name + ".relay_error")
+	if err != nil {
+		return err
+	}
+
+	fem.processedEvents, err = meter.Int64Counter(name + ".processed_events")
+	if err != nil {
+		return err
+	}
+
+	fem.attrs = attrs
+	return nil
+}
+
+func (fem *finalityEnsurerMetrics) SetTimeSinceFinalizedBlockNumberUpdate(ctx context.Context, sec uint64) {
+	fem.finalizedBlockUpdateLag.Record(ctx, int64(sec), fem.attrs)
+}
+
+func (fem *finalityEnsurerMetrics) AddRelayError(ctx context.Context) {
+	fem.relayErrors.Add(ctx, 1, fem.attrs)
+}
+
+func (fem *finalityEnsurerMetrics) AddFinalizedEvents(ctx context.Context, count uint64) {
+	fem.processedEvents.Add(ctx, int64(count),
+		telattr.With(attribute.String(eventStatusLabel, eventStatusFinalized)),
+		fem.attrs,
+	)
+}
+
+func (fem *finalityEnsurerMetrics) AddOrphanedEvents(ctx context.Context, count uint64) {
+	fem.processedEvents.Add(ctx, int64(count),
+		telattr.With(attribute.String(eventStatusLabel, eventStatusOrphaned)),
+		fem.attrs,
+	)
+}

--- a/nil/services/relayer/internal/l2/metrics.go
+++ b/nil/services/relayer/internal/l2/metrics.go
@@ -1,0 +1,54 @@
+package l2
+
+import (
+	"context"
+
+	"github.com/NilFoundation/nil/nil/internal/telemetry"
+	"github.com/NilFoundation/nil/nil/services/relayer/internal/metrics"
+	"go.opentelemetry.io/otel/metric"
+)
+
+type TransactionSenderMetrics interface {
+	AddRelayedEvents(ctx context.Context, count uint64)
+	AddRelayError(ctx context.Context)
+}
+
+type transactionSenderMetrics struct {
+	attrs metric.MeasurementOption
+
+	relayErrors   telemetry.Counter
+	relayedEvents telemetry.Counter
+}
+
+func NewTransactionSenderMetrics() (TransactionSenderMetrics, error) {
+	tsm := &transactionSenderMetrics{}
+	if err := metrics.InitMetrics(tsm, "relayer", "transaction_sender"); err != nil {
+		return nil, err
+	}
+	return tsm, nil
+}
+
+func (tsm *transactionSenderMetrics) Init(name string, meter telemetry.Meter, attrs metric.MeasurementOption) error {
+	var err error
+
+	tsm.relayedEvents, err = meter.Int64Counter(name + ".relayed_events")
+	if err != nil {
+		return err
+	}
+
+	tsm.relayErrors, err = meter.Int64Counter(name + ".relay_error")
+	if err != nil {
+		return err
+	}
+
+	tsm.attrs = attrs
+	return nil
+}
+
+func (tsm *transactionSenderMetrics) AddRelayError(ctx context.Context) {
+	tsm.relayErrors.Add(ctx, 1, tsm.attrs)
+}
+
+func (tsm *transactionSenderMetrics) AddRelayedEvents(ctx context.Context, count uint64) {
+	tsm.relayedEvents.Add(ctx, int64(count), tsm.attrs)
+}

--- a/nil/services/relayer/internal/metrics/init.go
+++ b/nil/services/relayer/internal/metrics/init.go
@@ -1,0 +1,33 @@
+package metrics
+
+import (
+	"os"
+
+	"github.com/NilFoundation/nil/nil/internal/telemetry"
+	"github.com/NilFoundation/nil/nil/internal/telemetry/telattr"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+type Metrics interface {
+	Init(name string, meter telemetry.Meter, attrs metric.MeasurementOption) error
+}
+
+func InitMetrics(mt Metrics, namespace, component string) error {
+	meter := telemetry.NewMeter(namespace)
+
+	hostName, err := os.Hostname()
+	if err != nil {
+		return err
+	}
+
+	attr := telattr.With(
+		attribute.String("host.name", hostName),
+	)
+
+	return mt.Init(
+		namespace+"."+component,
+		meter,
+		attr,
+	)
+}

--- a/nil/services/relayer/internal/storage/metrics.go
+++ b/nil/services/relayer/internal/storage/metrics.go
@@ -1,0 +1,92 @@
+package storage
+
+import (
+	"context"
+
+	"github.com/NilFoundation/nil/nil/internal/db"
+	"github.com/NilFoundation/nil/nil/internal/telemetry"
+	"github.com/NilFoundation/nil/nil/internal/telemetry/telattr"
+	"github.com/NilFoundation/nil/nil/services/relayer/internal/metrics"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+type TableMetrics interface {
+	RecordInserts(context.Context, db.TableName, int)
+	RecordDeletes(context.Context, db.TableName, int)
+	SetTableSize(context.Context, db.TableName, int)
+}
+
+const (
+	opLabel = "operation"
+
+	rwOpDel    = "delete"
+	rwOpInsert = "insert"
+)
+
+type tableMetrics struct {
+	attrs     metric.MeasurementOption
+	sizeGauge telemetry.Gauge
+	opCounter telemetry.Counter
+}
+
+func NewTableMetrics() (TableMetrics, error) {
+	tm := &tableMetrics{}
+	if err := metrics.InitMetrics(tm, "relayer", "storage"); err != nil {
+		return nil, err
+	}
+	return tm, nil
+}
+
+func (tm *tableMetrics) Init(name string, meter telemetry.Meter, attrs metric.MeasurementOption) error {
+	var err error
+
+	tm.sizeGauge, err = meter.Int64Gauge(name + ".table_size")
+	if err != nil {
+		return err
+	}
+
+	tm.opCounter, err = meter.Int64Counter(name + ".table_operations")
+	if err != nil {
+		return err
+	}
+
+	tm.attrs = attrs
+
+	return nil
+}
+
+func (tm *tableMetrics) RecordInserts(ctx context.Context, table db.TableName, val int) {
+	tm.opCounter.Add(
+		ctx,
+		int64(val),
+		tm.attrs,
+		telattr.With(
+			attribute.String(opLabel, rwOpInsert),
+			attribute.String("table_name", string(table)),
+		),
+	)
+}
+
+func (tm *tableMetrics) RecordDeletes(ctx context.Context, table db.TableName, val int) {
+	tm.opCounter.Add(
+		ctx,
+		int64(val),
+		tm.attrs,
+		telattr.With(
+			attribute.String(opLabel, rwOpDel),
+			attribute.String("table_name", string(table)),
+		),
+	)
+}
+
+func (tm *tableMetrics) SetTableSize(ctx context.Context, table db.TableName, size int) {
+	tm.sizeGauge.Record(
+		ctx,
+		int64(size),
+		tm.attrs,
+		telattr.With(
+			attribute.String("table_name", string(table)),
+		),
+	)
+}


### PR DESCRIPTION
This PR adds metrics needed for monitoring state of the nil relayer service components

Added the following metrics:
- Common DB metrics (collection size, inserts, deletes)
- Event listener metrics (fetcher status, amount of incoming events, errors)
- Finality ensurer metrics (lag of updating finalized block value, amount of finalized & orphaned events)
- Transaction sender (relay/error count)