### PR TITLE
[execution] inc seqno on errors with a balance

### DIFF
--- a/nil/contracts/solidity/tests/Test.sol
+++ b/nil/contracts/solidity/tests/Test.sol
@@ -278,4 +278,3 @@ contract Test is NilBase {
 }
 
 contract Empty {}
-

--- a/nil/internal/collate/proposer_test.go
+++ b/nil/internal/collate/proposer_test.go
@@ -199,7 +199,7 @@ func (s *ProposerTestSuite) TestCollator() {
 	})
 
 	s.Run("Execute", func() {
-		m := execution.NewExecutionTransaction(to, to, 0, contracts.NewCounterAddCallData(s.T(), 3))
+		m := execution.NewExecutionTransaction(to, to, 1, contracts.NewCounterAddCallData(s.T(), 3))
 		pool.Reset()
 		pool.Add(m)
 

--- a/nil/internal/execution/state.go
+++ b/nil/internal/execution/state.go
@@ -1101,6 +1101,17 @@ func (es *ExecutionState) HandleTransaction(
 		}
 	}()
 
+	if txn.IsExternal() {
+		addr := txn.To
+		seqno, err := es.GetExtSeqno(addr)
+		if err != nil {
+			return NewExecutionResult().SetFatal(err)
+		}
+		if err := es.SetExtSeqno(addr, seqno+1); err != nil {
+			return NewExecutionResult().SetFatal(err)
+		}
+	}
+
 	es.txnFeeCredit = txn.FeeCredit
 
 	if err := es.updateGasPrice(txn); err != nil {
@@ -1323,16 +1334,6 @@ func (es *ExecutionState) handleExecutionTransaction(
 
 	es.preTxHookCall(transaction)
 	defer func() { es.postTxHookCall(transaction, res) }()
-
-	if transaction.IsExternal() {
-		seqno, err := es.GetExtSeqno(addr)
-		if err != nil {
-			return NewExecutionResult().SetFatal(err)
-		}
-		if err := es.SetExtSeqno(addr, seqno+1); err != nil {
-			return NewExecutionResult().SetFatal(err)
-		}
-	}
 
 	es.revertId = es.Snapshot()
 

--- a/nil/tests/cli/cli_test.go
+++ b/nil/tests/cli/cli_test.go
@@ -350,6 +350,11 @@ faucet_endpoint = {{ .FaucetUrl }}
 		s.Contains(res, "New smart account address:")
 	})
 
+	s.Run("Check seqno", func() {
+		res := s.RunCli("-c", cfgPath, "smart-account", "seqno")
+		s.Contains(res, "Smart account seqno: 1")
+	})
+
 	var addr string
 	s.Run("Get contract address", func() {
 		addr = s.RunCli("-c", cfgPath, "contract", "address", s.incBinPath, "123321", "--abi", s.incAbiPath, "-q")
@@ -376,7 +381,7 @@ faucet_endpoint = {{ .FaucetUrl }}
 
 	s.Run("Check seqno", func() {
 		res := s.RunCli("-c", cfgPath, "smart-account", "seqno")
-		s.Contains(res, "Smart account seqno: 1")
+		s.Contains(res, "Smart account seqno: 2")
 
 		res = s.RunCli("-c", cfgPath, "contract", "seqno", addr)
 		s.Contains(res, "Contract seqno: 0")


### PR DESCRIPTION
We authorized such message that mean that user paid for it. However in case if we don't increment seqno it's possible to send two transactions with the same hash that will be processed and create hash collision.