### PR TITLE
[journald-forwarder] Stop sending logs from journald forwarder, when we fetch logs

### DIFF
--- a/nil/cmd/journald_forwarder/main.go
+++ b/nil/cmd/journald_forwarder/main.go
@@ -11,7 +11,7 @@ import (
 
 func main() {
 	cfg := &journald_forwarder.Config{}
-	logger := logging.NewLogger("journald_forwarder")
+	logger := logging.NewLoggerWithStore("journald_forwarder", false)
 	rootCmd := &cobra.Command{
 		Use:   "journald_to_click",
 		Short: "Run journald to click handler",

--- a/nil/services/journald_forwarder/main.go
+++ b/nil/services/journald_forwarder/main.go
@@ -253,7 +253,6 @@ func (s *LogServer) processLogRecord(ctx context.Context, logRecord *v12.LogReco
 func (s *LogServer) Export(
 	ctx context.Context, req *logs.ExportLogsServiceRequest,
 ) (*logs.ExportLogsServiceResponse, error) {
-	s.logger.Info().Int("log_records", len(req.ResourceLogs)).Msg("Received log records")
 	for _, resourceLog := range req.ResourceLogs {
 		if err := s.processResourceLog(ctx, resourceLog); err != nil {
 			return nil, err


### PR DESCRIPTION
Don't send logs when we fetch log. Over wise we get loop.