### PR TITLE
Sync Committee: Batch Metrics + Lag Tracker

### DIFF
--- a/nil/services/synccommittee/core/config.go
+++ b/nil/services/synccommittee/core/config.go
@@ -2,8 +2,8 @@ package core
 
 import (
 	"github.com/NilFoundation/nil/nil/internal/telemetry"
-	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/rollupcontract"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/core/fetching"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/rollupcontract"
 )
 
 const (

--- a/nil/services/synccommittee/core/config.go
+++ b/nil/services/synccommittee/core/config.go
@@ -3,6 +3,7 @@ package core
 import (
 	"github.com/NilFoundation/nil/nil/internal/telemetry"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/rollupcontract"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/core/fetching"
 )
 
 const (
@@ -12,7 +13,7 @@ const (
 type Config struct {
 	RpcEndpoint             string                       `yaml:"endpoint,omitempty"`
 	TaskListenerRpcEndpoint string                       `yaml:"ownEndpoint,omitempty"`
-	AggregatorConfig        AggregatorConfig             `yaml:",inline"`
+	AggregatorConfig        fetching.AggregatorConfig    `yaml:",inline"`
 	ProposerParams          ProposerConfig               `yaml:"-"`
 	ContractWrapperConfig   rollupcontract.WrapperConfig `yaml:",inline"`
 	Telemetry               *telemetry.Config            `yaml:",inline"`
@@ -22,7 +23,7 @@ func NewDefaultConfig() *Config {
 	return &Config{
 		RpcEndpoint:             "tcp://127.0.0.1:8529",
 		TaskListenerRpcEndpoint: DefaultTaskRpcEndpoint,
-		AggregatorConfig:        NewDefaultAggregatorConfig(),
+		AggregatorConfig:        fetching.NewDefaultAggregatorConfig(),
 		ProposerParams:          NewDefaultProposerConfig(),
 		ContractWrapperConfig:   rollupcontract.NewDefaultWrapperConfig(),
 		Telemetry: &telemetry.Config{

--- a/nil/services/synccommittee/core/fetching/aggregator.go
+++ b/nil/services/synccommittee/core/fetching/aggregator.go
@@ -1,4 +1,4 @@
-package core
+package fetching
 
 import (
 	"bytes"
@@ -26,8 +26,7 @@ import (
 
 type AggregatorMetrics interface {
 	metrics.BasicMetrics
-	RecordMainBlockFetched(ctx context.Context)
-	RecordBlockBatchSize(ctx context.Context, batchSize int64)
+	RecordBatchCreated(ctx context.Context, batch *types.BlockBatch)
 }
 
 type AggregatorTaskStorage interface {
@@ -325,7 +324,6 @@ func (agg *aggregator) fetchAndProcessBlocks(ctx context.Context, blocksRange ty
 		Int64("blkCount", fetchedLen).
 		Stringer(logging.FieldShardId, shardId).
 		Msg("fetched main shard blocks")
-	agg.metrics.RecordBlockBatchSize(ctx, fetchedLen)
 	return nil
 }
 
@@ -381,7 +379,7 @@ func (agg *aggregator) handleBlockBatch(ctx context.Context, batch *types.BlockB
 		return fmt.Errorf("error creating proof tasks, latestMainHash=%s: %w", batch.LatestMainBlock().Hash, err)
 	}
 
-	agg.metrics.RecordMainBlockFetched(ctx)
+	agg.metrics.RecordBatchCreated(ctx, batch)
 	return nil
 }
 

--- a/nil/services/synccommittee/core/fetching/aggregator_test.go
+++ b/nil/services/synccommittee/core/fetching/aggregator_test.go
@@ -1,4 +1,4 @@
-package core
+package fetching
 
 import (
 	"context"

--- a/nil/services/synccommittee/core/fetching/block_fetcher.go
+++ b/nil/services/synccommittee/core/fetching/block_fetcher.go
@@ -1,4 +1,4 @@
-package core
+package fetching
 
 import (
 	"context"
@@ -16,4 +16,5 @@ type RpcBlockFetcher interface {
 		fullTx bool,
 		batchSize int,
 	) ([]*jsonrpc.RPCBlock, error)
+	GetShardIdList(ctx context.Context) ([]types.ShardId, error)
 }

--- a/nil/services/synccommittee/core/fetching/lag_tracker.go
+++ b/nil/services/synccommittee/core/fetching/lag_tracker.go
@@ -1,0 +1,135 @@
+package fetching
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/NilFoundation/nil/nil/common/logging"
+	coreTypes "github.com/NilFoundation/nil/nil/internal/types"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/metrics"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/srv"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
+)
+
+type LagTrackerMetrics interface {
+	metrics.BasicMetrics
+	RecordFetchingLag(ctx context.Context, shardId coreTypes.ShardId, blocksCount int64)
+}
+
+type LagTrackerStorage interface {
+	GetLatestFetched(ctx context.Context) (types.BlockRefs, error)
+}
+
+type LagTrackerConfig struct {
+	CheckInterval time.Duration
+}
+
+func NewDefaultLagTrackerConfig() LagTrackerConfig {
+	return LagTrackerConfig{
+		CheckInterval: 5 * time.Minute,
+	}
+}
+
+type lagTracker struct {
+	srv.WorkerLoop
+
+	fetcher RpcBlockFetcher
+	storage LagTrackerStorage
+	metrics LagTrackerMetrics
+	logger  logging.Logger
+	config  LagTrackerConfig
+}
+
+func NewLagTracker(
+	fetcher RpcBlockFetcher,
+	storage LagTrackerStorage,
+	metrics LagTrackerMetrics,
+	config LagTrackerConfig,
+	logger logging.Logger,
+) *lagTracker {
+	tracker := &lagTracker{
+		fetcher: fetcher,
+		storage: storage,
+		metrics: metrics,
+		config:  config,
+	}
+
+	tracker.WorkerLoop = srv.NewWorkerLoop("lag_tracker", tracker.config.CheckInterval, tracker.runIteration)
+	tracker.logger = srv.WorkerLogger(logger, tracker)
+	return tracker
+}
+
+func (t *lagTracker) runIteration(ctx context.Context) {
+	t.logger.Debug().Msg("running lag tracker iteration")
+
+	lagPerShard, err := t.getLagForAllShards(ctx)
+	if err != nil {
+		t.logger.Error().Err(err).Msg("failed to fetch lag per shard")
+		t.metrics.RecordError(ctx, t.Name())
+		return
+	}
+
+	for shardId, blocksCount := range lagPerShard {
+		t.metrics.RecordFetchingLag(ctx, shardId, blocksCount)
+		t.logger.Trace().Stringer(logging.FieldShardId, shardId).Msgf("lag in shard %s: %d", shardId, blocksCount)
+	}
+
+	t.logger.Debug().Msg("lag tracker iteration completed")
+}
+
+func (t *lagTracker) getLagForAllShards(ctx context.Context) (map[coreTypes.ShardId]int64, error) {
+	shardIds, err := t.fetcher.GetShardIdList(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch shard ids: %w", err)
+	}
+
+	latestFetched, err := t.storage.GetLatestFetched(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get latest fetched from storage: %w", err)
+	}
+
+	lagPerShard := make(map[coreTypes.ShardId]int64)
+
+	for _, shardId := range shardIds {
+		blocksCount, err := t.getShardLag(ctx, latestFetched, shardId)
+		if err != nil {
+			return nil, err
+		}
+		lagPerShard[shardId] = blocksCount
+	}
+
+	return lagPerShard, nil
+}
+
+func (t *lagTracker) getShardLag(
+	ctx context.Context,
+	latestFetched types.BlockRefs,
+	shardId coreTypes.ShardId,
+) (blocksCount int64, err error) {
+	actualLatestInShard, err := t.getLatestInShard(ctx, shardId)
+	if err != nil {
+		return 0, fmt.Errorf("failed to fetch latestBlockNumber for shard %d: %w", shardId, err)
+	}
+
+	latestFetchedInShard := latestFetched.TryGet(shardId)
+
+	if latestFetchedInShard == nil {
+		return int64(*actualLatestInShard), nil
+	}
+
+	lag := int64(*actualLatestInShard - latestFetchedInShard.Number)
+	return lag, nil
+}
+
+func (t *lagTracker) getLatestInShard(ctx context.Context, shardId coreTypes.ShardId) (*coreTypes.BlockNumber, error) {
+	block, err := t.fetcher.GetBlock(ctx, shardId, "latest", false)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching latest block from shard %d: %w", shardId, err)
+	}
+	if block == nil {
+		return nil, fmt.Errorf("latest main block not found in shard %d", shardId)
+	}
+
+	return &block.Number, nil
+}

--- a/nil/services/synccommittee/core/fetching/lag_tracker_test.go
+++ b/nil/services/synccommittee/core/fetching/lag_tracker_test.go
@@ -1,0 +1,153 @@
+package fetching
+
+import (
+	"context"
+	"testing"
+
+	"github.com/NilFoundation/nil/nil/client"
+	"github.com/NilFoundation/nil/nil/common/logging"
+	"github.com/NilFoundation/nil/nil/internal/db"
+	"github.com/NilFoundation/nil/nil/internal/types"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/metrics"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/storage"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/testaide"
+	scTypes "github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/suite"
+)
+
+type LagTrackerTestSuite struct {
+	suite.Suite
+
+	ctx          context.Context
+	cancellation context.CancelFunc
+
+	metrics      *metrics.SyncCommitteeMetricsHandler
+	db           db.DB
+	blockStorage *storage.BlockStorage
+
+	rpcClientMock *client.ClientMock
+	lagTracker    *lagTracker
+}
+
+func TestLagTrackerTestSuite(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(LagTrackerTestSuite))
+}
+
+func (s *LagTrackerTestSuite) SetupSuite() {
+	s.ctx, s.cancellation = context.WithCancel(context.Background())
+
+	logger := logging.NewLogger("lag_fetcher_test")
+	metricsHandler, err := metrics.NewSyncCommitteeMetrics()
+	s.Require().NoError(err)
+	s.metrics = metricsHandler
+
+	s.db, err = db.NewBadgerDbInMemory()
+	s.Require().NoError(err)
+	clock := clockwork.NewRealClock()
+	s.blockStorage = storage.NewBlockStorage(s.db, storage.DefaultBlockStorageConfig(), clock, s.metrics, logger)
+	s.rpcClientMock = &client.ClientMock{}
+
+	s.lagTracker = NewLagTracker(
+		s.rpcClientMock, s.blockStorage, s.metrics, NewDefaultLagTrackerConfig(), logger,
+	)
+}
+
+func (s *LagTrackerTestSuite) SetupTest() {
+	s.rpcClientMock.ResetCalls()
+	err := s.db.DropAll()
+	s.Require().NoError(err, "failed to clear database in SetUpTest")
+}
+
+func (s *LagTrackerTestSuite) TearDownSuite() {
+	s.cancellation()
+}
+
+func (s *LagTrackerTestSuite) Test_GetLagForAllShards_Nothing_Fetched_Yet() {
+	batches := testaide.NewBatchesSequence(3)
+	testaide.ClientMockSetBatches(s.rpcClientMock, batches)
+
+	shardLagExpected := s.countBlocks(batches)
+
+	shardLagActual, err := s.lagTracker.getLagForAllShards(s.ctx)
+	s.Require().NoError(err)
+	s.Require().Equal(shardLagExpected, shardLagActual)
+}
+
+func (s *LagTrackerTestSuite) Test_GetLagForAllShards_No_Lag() {
+	batches := testaide.NewBatchesSequence(3)
+	testaide.ClientMockSetBatches(s.rpcClientMock, batches)
+
+	for _, batch := range batches {
+		err := s.blockStorage.SetBlockBatch(s.ctx, batch)
+		s.Require().NoError(err)
+	}
+
+	currentLag, err := s.lagTracker.getLagForAllShards(s.ctx)
+	s.Require().NoError(err)
+
+	latestRefs := batches[len(batches)-1].LatestRefs()
+
+	for shardId := range latestRefs {
+		shardLag, ok := currentLag[shardId]
+		s.True(ok)
+		s.Equal(int64(0), shardLag)
+	}
+}
+
+func (s *LagTrackerTestSuite) Test_GetLagForAllShards_Lagging_Behind() {
+	batches := testaide.NewBatchesSequence(5)
+	testaide.ClientMockSetBatches(s.rpcClientMock, batches)
+	alreadyFetched := batches[:3]
+	pending := batches[3:]
+
+	for _, batch := range alreadyFetched {
+		err := s.blockStorage.SetBlockBatch(s.ctx, batch)
+		s.Require().NoError(err)
+	}
+
+	currentLagActual, err := s.lagTracker.getLagForAllShards(s.ctx)
+	s.Require().NoError(err)
+
+	currentLagExpected := s.countBlocks(pending)
+	s.Require().Equal(currentLagExpected, currentLagActual)
+}
+
+func (s *LagTrackerTestSuite) Test_GetLagForAllShards_Being_Ahead() {
+	batches := testaide.NewBatchesSequence(5)
+	stateOnL2 := batches[:3]
+	testaide.ClientMockSetBatches(s.rpcClientMock, stateOnL2)
+
+	for _, batch := range batches {
+		err := s.blockStorage.SetBlockBatch(s.ctx, batch)
+		s.Require().NoError(err)
+	}
+
+	currentLagActual, err := s.lagTracker.getLagForAllShards(s.ctx)
+	s.Require().NoError(err)
+
+	diff := batches[3:]
+	currentLagExpected := s.countBlocks(diff)
+
+	s.Require().Len(currentLagActual, len(currentLagExpected))
+	for shardId, blocksCount := range currentLagExpected {
+		shardLagActual, ok := currentLagActual[shardId]
+		s.True(ok)
+		// Expecting shard lag to be negative (Sync Committee is ahead of L2)
+		shardLagExpected := -blocksCount
+		s.Equal(shardLagExpected, shardLagActual)
+	}
+}
+
+func (s *LagTrackerTestSuite) countBlocks(batches []*scTypes.BlockBatch) map[types.ShardId]int64 {
+	s.T().Helper()
+
+	countPerShard := make(map[types.ShardId]int64)
+	for _, batch := range batches {
+		for block := range batch.BlocksIter() {
+			countPerShard[block.ShardId]++
+		}
+	}
+	return countPerShard
+}

--- a/nil/services/synccommittee/core/fetching/subgraph_fetcher.go
+++ b/nil/services/synccommittee/core/fetching/subgraph_fetcher.go
@@ -1,4 +1,4 @@
-package core
+package fetching
 
 import (
 	"context"

--- a/nil/services/synccommittee/core/fetching/subgraph_fetcher_test.go
+++ b/nil/services/synccommittee/core/fetching/subgraph_fetcher_test.go
@@ -1,4 +1,4 @@
-package core
+package fetching
 
 import (
 	"context"

--- a/nil/services/synccommittee/core/proposer.go
+++ b/nil/services/synccommittee/core/proposer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/NilFoundation/nil/nil/common/concurrent"
 	"github.com/NilFoundation/nil/nil/common/logging"
 	"github.com/NilFoundation/nil/nil/internal/types"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/core/fetching"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/metrics"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/rollupcontract"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/srv"
@@ -27,12 +28,12 @@ type ProposerStorage interface {
 
 type ProposerMetrics interface {
 	metrics.BasicMetrics
-	RecordProposerTxSent(ctx context.Context, proposalData *scTypes.ProposalData)
+	RecordStateUpdated(ctx context.Context, proposalData *scTypes.ProposalData)
 }
 
 type proposer struct {
 	storage   ProposerStorage
-	rpcClient RpcBlockFetcher
+	rpcClient fetching.RpcBlockFetcher
 
 	rollupContractWrapper rollupcontract.Wrapper
 	config                ProposerConfig
@@ -56,7 +57,7 @@ func NewProposer(
 	config ProposerConfig,
 	storage ProposerStorage,
 	contractWrapper rollupcontract.Wrapper,
-	rpcClient RpcBlockFetcher,
+	rpcClient fetching.RpcBlockFetcher,
 	metrics ProposerMetrics,
 	logger logging.Logger,
 ) (*proposer, error) {
@@ -199,7 +200,7 @@ func (p *proposer) updateState(
 		return fmt.Errorf("failed to update state: %w", err)
 	}
 
-	p.metrics.RecordProposerTxSent(ctx, proposalData)
+	p.metrics.RecordStateUpdated(ctx, proposalData)
 
 	return nil
 }

--- a/nil/services/synccommittee/internal/metrics/sync_committee_metrics.go
+++ b/nil/services/synccommittee/internal/metrics/sync_committee_metrics.go
@@ -17,16 +17,16 @@ type SyncCommitteeMetricsHandler struct {
 	attributes metric.MeasurementOption
 
 	// AggregatorMetrics
-	totalMainBlocksFetched telemetry.Counter
-	blockBatchSize         telemetry.Histogram
+	totalBatchesCreated telemetry.Counter
+	batchSizeBlocks     telemetry.Histogram
+	batchSizeTxs        telemetry.Histogram
 
 	// BlockStorageMetrics
 	totalBatchesProved telemetry.Counter
 
 	// ProposerMetrics
-	totalL1TxSent          telemetry.Counter
-	blockTotalTimeMs       telemetry.Histogram
-	blobsPerSingleProposal telemetry.Histogram
+	totalL1StateUpdates telemetry.Counter
+	batchTotalProofTime telemetry.Histogram
 }
 
 func NewSyncCommitteeMetrics() (*SyncCommitteeMetricsHandler, error) {
@@ -76,52 +76,56 @@ func (h *SyncCommitteeMetricsHandler) initBlockStorageMetrics(meter telemetry.Me
 func (h *SyncCommitteeMetricsHandler) initProposerMetrics(meter telemetry.Meter) error {
 	var err error
 
-	if h.totalL1TxSent, err = meter.Int64Counter(namespace + "total_l1_tx_sent"); err != nil {
+	if h.totalL1StateUpdates, err = meter.Int64Counter(namespace + "total_l1_state_updates"); err != nil {
 		return err
 	}
 
-	if h.blockTotalTimeMs, err = meter.Int64Histogram(namespace + "block_total_time_ms"); err != nil {
+	if h.batchTotalProofTime, err = meter.Int64Histogram(namespace + "batch_total_proof_time_ms"); err != nil {
 		return err
 	}
 
-	if h.blobsPerSingleProposal, err = meter.Int64Histogram(namespace + "blobs_per_proposal"); err != nil {
-		return err
-	}
 	return nil
 }
 
 func (h *SyncCommitteeMetricsHandler) initAggregatorMetrics(meter telemetry.Meter) error {
 	var err error
 
-	if h.totalMainBlocksFetched, err = meter.Int64Counter(namespace + "total_main_blocks_fetched"); err != nil {
+	if h.totalBatchesCreated, err = meter.Int64Counter(namespace + "total_batches_created"); err != nil {
 		return err
 	}
 
-	if h.blockBatchSize, err = meter.Int64Histogram(namespace + "block_batch_size"); err != nil {
+	if h.batchSizeBlocks, err = meter.Int64Histogram(namespace + "batch_size_blocks"); err != nil {
+		return err
+	}
+
+	if h.batchSizeTxs, err = meter.Int64Histogram(namespace + "batch_size_txs"); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (h *SyncCommitteeMetricsHandler) RecordMainBlockFetched(ctx context.Context) {
-	h.totalMainBlocksFetched.Add(ctx, 1, h.attributes)
-}
+func (h *SyncCommitteeMetricsHandler) RecordBatchCreated(ctx context.Context, batch *types.BlockBatch) {
+	h.totalBatchesCreated.Add(ctx, 1, h.attributes)
 
-func (h *SyncCommitteeMetricsHandler) RecordBlockBatchSize(ctx context.Context, batchSize int64) {
-	h.blockBatchSize.Record(ctx, batchSize, h.attributes)
+	var batchSizeBlocks int64
+	var batchSizeTxs int64
+	for block := range batch.BlocksIter() {
+		batchSizeBlocks++
+		batchSizeTxs += int64(len(block.Transactions))
+	}
+
+	h.batchSizeBlocks.Record(ctx, batchSizeBlocks, h.attributes)
+	h.batchSizeTxs.Record(ctx, batchSizeTxs, h.attributes)
 }
 
 func (h *SyncCommitteeMetricsHandler) RecordBatchProved(ctx context.Context) {
 	h.totalBatchesProved.Add(ctx, 1, h.attributes)
 }
 
-func (h *SyncCommitteeMetricsHandler) RecordProposerTxSent(ctx context.Context, proposalData *types.ProposalData) {
-	h.totalL1TxSent.Add(ctx, 1, h.attributes)
+func (h *SyncCommitteeMetricsHandler) RecordStateUpdated(ctx context.Context, proposalData *types.ProposalData) {
+	h.totalL1StateUpdates.Add(ctx, 1, h.attributes)
 
 	totalTimeMs := time.Since(proposalData.FirstBlockFetchedAt).Milliseconds()
-	h.blockTotalTimeMs.Record(ctx, totalTimeMs, h.attributes)
-
-	blobsCount := int64(len(proposalData.DataProofs))
-	h.blobsPerSingleProposal.Record(ctx, blobsCount, h.attributes)
+	h.batchTotalProofTime.Record(ctx, totalTimeMs, h.attributes)
 }

--- a/nil/services/synccommittee/internal/testaide/client_mock_block_setter.go
+++ b/nil/services/synccommittee/internal/testaide/client_mock_block_setter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"iter"
 	"log"
+	"maps"
 	"slices"
 
 	"github.com/NilFoundation/nil/nil/client"
@@ -79,5 +80,10 @@ func ClientMockSetBlocks(client *client.ClientMock, blocks iter.Seq[*scTypes.Blo
 			}
 		}
 		return blockRange, nil
+	}
+
+	shardIds := slices.Collect(maps.Keys(shardsToBlocks))
+	client.GetShardIdListFunc = func(ctx context.Context) ([]types.ShardId, error) {
+		return shardIds, nil
 	}
 }


### PR DESCRIPTION
### Block Metrics Adjustments

Changed block-related metrics published by `Sync Committee` to match the new batching model:

* Replaced `totalMainBlocksFetched` metric with `totalBatchesCreated` (counter);
* Fixed the way `batchSizeBlocks` metric is collected (moved it to `RecordBatchCreated` method);
* Replaced `txPerSingleProposal` metric published by `Proposer` with `batchSizeTxs` updated by `Aggregator`;
* Renaming: `total_l1_tx_sent` -> `total_l1_state_updates`; `block_total_time_ms` -> `batch_total_proof_time_ms`;

### Block Fetching Lag Tracker

Implemented new background worker to track per-shard block fetching lag and publish corresponding metrics to `SigNoz`. By default, lag metrics are collected every 5 minutes

* Defined `LagTracker` - new `Sync Committee` worker, responsible for fetching lag tracking;
* Extended `SyncCommitteeMetricsHandler` with new `blockFetchingLag` metric;