### PR TITLE
Sync Committee: ProofBatch Task Result Handling

### DIFF
--- a/nil/services/synccommittee/core/reset/resetter.go
+++ b/nil/services/synccommittee/core/reset/resetter.go
@@ -12,7 +12,8 @@ type BatchResetter interface {
 	// ResetBatchesRange resets Sync Committee's block processing progress
 	// to a point preceding batch with the specified ID.
 	ResetBatchesRange(
-		ctx context.Context, firstBatchToPurge scTypes.BatchId) (purgedBatches []scTypes.BatchId, err error)
+		ctx context.Context, firstBatchToPurge scTypes.BatchId,
+	) (purgedBatches []scTypes.BatchId, err error)
 
 	// ResetBatchesNotProved resets Sync Committee's progress for all not yet proved batches.
 	ResetBatchesNotProved(ctx context.Context) error

--- a/nil/services/synccommittee/internal/storage/block_storage.go
+++ b/nil/services/synccommittee/internal/storage/block_storage.go
@@ -115,6 +115,24 @@ func (bs *BlockStorage) TryGetLatestBatchId(ctx context.Context) (*scTypes.Batch
 	return bs.ops.getLatestBatchId(tx)
 }
 
+func (bs *BlockStorage) BatchExists(ctx context.Context, batchId scTypes.BatchId) (bool, error) {
+	tx, err := bs.database.CreateRoTx(ctx)
+	if err != nil {
+		return false, err
+	}
+	defer tx.Rollback()
+
+	_, err = bs.ops.getBatch(tx, batchId)
+	switch {
+	case err == nil:
+		return true, nil
+	case errors.Is(err, scTypes.ErrBatchNotFound):
+		return false, nil
+	default:
+		return false, err
+	}
+}
+
 func (bs *BlockStorage) GetLatestFetched(ctx context.Context) (scTypes.BlockRefs, error) {
 	tx, err := bs.database.CreateRoTx(ctx)
 	if err != nil {

--- a/nil/services/synccommittee/internal/storage/block_storage_test.go
+++ b/nil/services/synccommittee/internal/storage/block_storage_test.go
@@ -136,7 +136,7 @@ func (s *BlockStorageTestSuite) Test_SetBlockBatch_Free_Capacity_On_SetBatchAsPr
 	s.Require().NoError(err)
 }
 
-func (s *BlockStorageTestSuite) Test_LatestBatchId() {
+func (s *BlockStorageTestSuite) Test_TryGetLatestBatchId() {
 	const batchesCount = 5
 	batches := testaide.NewBatchesSequence(batchesCount)
 
@@ -154,6 +154,26 @@ func (s *BlockStorageTestSuite) Test_LatestBatchId() {
 	}
 }
 
+func (s *BlockStorageTestSuite) Test_BatchExists_True() {
+	batch := testaide.NewBlockBatch(3)
+	err := s.bs.SetBlockBatch(s.ctx, batch)
+	s.Require().NoError(err)
+
+	exists, err := s.bs.BatchExists(s.ctx, batch.Id)
+	s.Require().NoError(err)
+	s.Require().True(exists)
+}
+
+func (s *BlockStorageTestSuite) Test_BatchExists_False() {
+	batch := testaide.NewBlockBatch(3)
+	err := s.bs.SetBlockBatch(s.ctx, batch)
+	s.Require().NoError(err)
+
+	exists, err := s.bs.BatchExists(s.ctx, scTypes.NewBatchId())
+	s.Require().NoError(err)
+	s.Require().False(exists)
+}
+
 func (s *BlockStorageTestSuite) Test_LatestBatchId_Mismatch() {
 	const batchesCount = 2
 	batches := testaide.NewBatchesSequence(batchesCount)
@@ -167,7 +187,7 @@ func (s *BlockStorageTestSuite) Test_LatestBatchId_Mismatch() {
 	s.Require().ErrorIs(err, scTypes.ErrBatchMismatch)
 }
 
-func (s *BlockStorageTestSuite) TestGetLastFetchedBlock() {
+func (s *BlockStorageTestSuite) Test_GetLatestFetched() {
 	// initially latestFetched should be empty
 	latestFetched, err := s.bs.GetLatestFetched(s.ctx)
 	s.Require().NoError(err)
@@ -177,7 +197,7 @@ func (s *BlockStorageTestSuite) TestGetLastFetchedBlock() {
 	err = s.bs.SetBlockBatch(s.ctx, batch)
 	s.Require().NoError(err)
 
-	// latestFetched is updated after the main shard block is saved
+	// latestFetched is updated after batch is saved
 	latestFetched, err = s.bs.GetLatestFetched(s.ctx)
 	s.Require().NoError(err)
 	s.Require().NotEmpty(latestFetched)


### PR DESCRIPTION
### Sync Committee: ProofBatch Task Result Handling

Follow-up #697:

* Do not trigger state reset if batch associated with the task does not exist;
* Extended `TaskStateChangeHandlerTestSuite` with more tests;
