### PR TITLE
[docs] added description and links to interactive tutorials from docs

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -170,12 +170,16 @@ const config = {
                 href: "https://explore.nil.foundation/",
               },
               {
-                label: "Solidity extension",
-                href: "https://www.npmjs.com/package/@nilfoundation/smart-contracts",
+                label: "Playground",
+                href: "https://explore.nil.foundation/playground"
               },
               {
-                label: "=nil; CLI",
-                href: "https://github.com/NilFoundation/nil/tree/main/nil/cmd/nil",
+                label: "Interactive tutorials",
+                href: "https://explore.nil.foundation/tutorial/async-call"
+              },
+              {
+                label: "Solidity extension",
+                href: "https://www.npmjs.com/package/@nilfoundation/smart-contracts",
               },
               {
                 label: "Client library",

--- a/docs/nil/guides/cometa-and-debugging.mdx
+++ b/docs/nil/guides/cometa-and-debugging.mdx
@@ -11,7 +11,9 @@ Working with the Cometa service involves these steps:
 
 :::tip[Playground integration]
 
-Whenever a contract is deployed via [**the =nil; Playground**](https://explore.nil.foundation/playground), it is automatically registered inside the Cometa service.
+Whenever a contract is deployed via [**the =nil; Playground**](https://explore.nil.foundation/playground), it is automatically registered inside the Cometa service. 
+
+This means that transactions that are sent by these contracts can be immediately debugged with Cometa without any additional setup.
 
 :::
 

--- a/docs/nil/intro.mdx
+++ b/docs/nil/intro.mdx
@@ -29,7 +29,14 @@ Access the block explorer and interact with the cluster in the browser.
 <CardSection>
     <Card id='blockexplorer' title='Block explorer ↪' description='' to='https://explore.nil.foundation/'/>
     <Card id='playground' title='Playground ↪' description='' to='https://explore.nil.foundation/playground'/>
+    <Card id='playground' title='Interactive tutorials ↪' description='' to='https://explore.nil.foundation/tutorial/async-call'/>
 </CardSection>
+
+:::tip[Interactive tutorials]
+
+Interactive tutorials provide a structured hands-on experience for learning the key features of Solidity programming on =nil;.
+
+:::
 
 ## Spec and guides
 


### PR DESCRIPTION
## Short Summary

This diff adds links to interactive tutorials from docs and adds a brief description of interactive tutorials to incentivize their usage.

## What Changes Were Made

- Added links to Playground and interactive tutorials in the 'Dev tools' dropdown
- Added a short description of interactive tutorials on the index page of docs

## Checklist

_Please mark each item with an `x` inside the brackets (e.g., [x]) once completed._

- [x] I have read and followed the [Contributing Guide](https://github.com/NilFoundation/nil/blob/main/CONTRIBUTION-GUIDE.md)
- [x] I have tested the changes locally
- [x] I have added relevant tests (if applicable)
- [x] I have updated documentation/comments (if applicable)
