### PR TITLE
Sync Committee: Subgraph Fetcher Fix

### DIFF
--- a/nil/cmd/proof_provider/main.go
+++ b/nil/cmd/proof_provider/main.go
@@ -21,7 +21,7 @@ type cmdConfig struct {
 }
 
 func main() {
-	check.PanicIfErr(execute())
+	check.PanicIfNotCancelledErr(execute())
 }
 
 func execute() error {

--- a/nil/cmd/prover/main.go
+++ b/nil/cmd/prover/main.go
@@ -19,7 +19,7 @@ import (
 )
 
 func main() {
-	check.PanicIfErr(execute())
+	check.PanicIfNotCancelledErr(execute())
 }
 
 type CommonConfig = prover.Config

--- a/nil/cmd/sync_committee/main.go
+++ b/nil/cmd/sync_committee/main.go
@@ -21,7 +21,7 @@ type cmdConfig struct {
 }
 
 func main() {
-	check.PanicIfErr(execute())
+	check.PanicIfNotCancelledErr(execute())
 }
 
 func execute() error {

--- a/nil/common/check/check.go
+++ b/nil/common/check/check.go
@@ -1,6 +1,8 @@
 package check
 
 import (
+	"context"
+	"errors"
 	"fmt"
 
 	"github.com/NilFoundation/nil/nil/common/logging"
@@ -41,6 +43,15 @@ func PanicIfErr(err error) {
 	if err != nil {
 		panic(err)
 	}
+}
+
+// PanicIfNotCancelledErr panics if the provided error is non-nil and not a context.Canceled error.
+func PanicIfNotCancelledErr(err error) {
+	if err == nil || errors.Is(err, context.Canceled) {
+		return
+	}
+
+	panic(err)
 }
 
 // LogAndPanicIfErrf logs the error with the provided logger and message and panics if err is not nil.

--- a/nil/services/synccommittee/core/aggregator.go
+++ b/nil/services/synccommittee/core/aggregator.go
@@ -103,14 +103,14 @@ func (agg *aggregator) Name() string {
 }
 
 func (agg *aggregator) Run(ctx context.Context, started chan<- struct{}) error {
-	agg.logger.Info().Msg("starting blocks fetching")
+	agg.logger.Info().Msg("Starting block fetching")
 
 	err := agg.workerAction.Run(ctx, started)
 
 	if err == nil || errors.Is(err, context.Canceled) {
-		agg.logger.Info().Msg("blocks fetching stopped")
+		agg.logger.Info().Msg("Block fetching stopped")
 	} else {
-		agg.logger.Error().Err(err).Msg("error running aggregator, stopped")
+		agg.logger.Error().Err(err).Msg("Error running aggregator, stopped")
 	}
 
 	return err
@@ -122,9 +122,9 @@ func (agg *aggregator) Pause(ctx context.Context) error {
 		return err
 	}
 	if paused {
-		agg.logger.Info().Msg("blocks fetching paused")
+		agg.logger.Info().Msg("Block fetching paused")
 	} else {
-		agg.logger.Warn().Msg("blocks fetching already paused")
+		agg.logger.Warn().Msg("Block fetching already paused")
 	}
 	return nil
 }
@@ -135,9 +135,9 @@ func (agg *aggregator) Resume(ctx context.Context) error {
 		return err
 	}
 	if resumed {
-		agg.logger.Info().Msg("blocks fetching resumed")
+		agg.logger.Info().Msg("Block fetching resumed")
 	} else {
-		agg.logger.Warn().Msg("blocks fetching already running")
+		agg.logger.Warn().Msg("Block fetching already running")
 	}
 	return nil
 }
@@ -161,31 +161,27 @@ func (agg *aggregator) handleProcessingErr(ctx context.Context, err error) error
 	case err == nil:
 		return nil
 
-	case errors.Is(err, types.ErrBatchNotReady):
-		agg.logger.Warn().Err(err).Msg("received unready block batch, skipping")
-		return nil
-
 	case errors.Is(err, types.ErrBlockMismatch):
-		agg.logger.Warn().Err(err).Msg("block mismatch detected, resetting state")
+		agg.logger.Warn().Err(err).Msg("Block mismatch detected, resetting state")
 		if err := agg.resetter.ResetProgressNotProved(ctx); err != nil {
 			return fmt.Errorf("error resetting state: %w", err)
 		}
 		return nil
 
 	case errors.Is(err, storage.ErrStateRootNotInitialized):
-		agg.logger.Warn().Err(err).Msg("state root not initialized, skipping")
+		agg.logger.Warn().Err(err).Msg("State root not initialized, skipping")
 		return nil
 
 	case errors.Is(err, storage.ErrCapacityLimitReached):
-		agg.logger.Info().Err(err).Msg("storage capacity limit reached, skipping")
+		agg.logger.Info().Err(err).Msg("Storage capacity limit reached, skipping")
 		return nil
 
 	case errors.Is(err, context.Canceled):
-		agg.logger.Info().Err(err).Msg("block processing cancelled")
+		agg.logger.Info().Err(err).Msg("Block processing cancelled")
 		return err
 
 	default:
-		agg.logger.Error().Err(err).Msg("error processing blocks")
+		agg.logger.Error().Err(err).Msg("Error processing blocks")
 		return err
 	}
 }
@@ -220,7 +216,7 @@ func (agg *aggregator) processBlockRange(ctx context.Context) error {
 		agg.logger.Debug().
 			Stringer(logging.FieldShardId, coreTypes.MainShardId).
 			Stringer(logging.FieldBlockNumber, latestBlockRef.Number).
-			Msg("no new blocks to fetch")
+			Msg("No new blocks to fetch")
 		return nil
 	}
 
@@ -392,7 +388,7 @@ func (agg *aggregator) createProofTasks(ctx context.Context, batch *types.BlockB
 
 	agg.logger.Debug().
 		Stringer(logging.FieldBatchId, batch.Id).
-		Msgf("created proof task, latestMainHash=%s", batch.LatestMainBlock().Hash)
+		Msgf("Created proof task, latestMainHash=%s", batch.LatestMainBlock().Hash)
 
 	return nil
 }

--- a/nil/services/synccommittee/internal/types/block_batch.go
+++ b/nil/services/synccommittee/internal/types/block_batch.go
@@ -13,7 +13,6 @@ import (
 )
 
 var (
-	ErrBatchNotReady  = errors.New("batch is not ready for handling")
 	ErrBatchMismatch  = errors.New("batch mismatch")
 	ErrBatchNotProved = errors.New("batch is not proved")
 	ErrBlockMismatch  = errors.New("block mismatch")

--- a/nil/services/synccommittee/internal/types/block_subgraph.go
+++ b/nil/services/synccommittee/internal/types/block_subgraph.go
@@ -10,6 +10,8 @@ import (
 // ShardChainSegment represents a sequence of blocks in a shard
 type ShardChainSegment []*Block
 
+var EmptyChainSegment = make(ShardChainSegment, 0)
+
 // Earliest retrieves the first block in the segment
 func (s ShardChainSegment) Earliest() *Block {
 	if len(s) == 0 {


### PR DESCRIPTION
Sync Committee: Subgraph Fetcher Fix

Do not terminate batch construction with an error if no new blocks were produced in some execution shards

* Updated logic of `subgraphFetcher.fetchShardChainSegment()` method
* Added new test: `Test_No_Progress_In_Exec_Shard`
* Removed error `ErrBatchNotReady`, which is no longer used;
