### PR TITLE
📄 [docs] Fix broken LICENSE links in README files

### DIFF
--- a/create-nil-hardhat-project/README.MD
+++ b/create-nil-hardhat-project/README.MD
@@ -14,7 +14,7 @@
 * [Usage](#-usage)
 * [Contributing](#-contributing)
 * [Work in progress](#-work-in-progress)
-* [License](#license)
+* [Licence](#licence)
 
 ## 🚀 Overview
 
@@ -110,4 +110,4 @@ This project is currently under active development. Not all features are fully i
 
 ## License
 
-[MIT](./LICENSE)
+[MIT](./LICENCE)

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@
 * [Installation](#installation)
 * [Usage](#usage)
 * [Tests](#tests)
-* [License](#license)
+* [Licence](#licence)
 
 ## Overview
 
@@ -74,4 +74,4 @@ npm run test path/to/test
 
 ## License
 
-[MIT](./LICENSE)
+[MIT](./LICENCE)

--- a/smart-contracts/README.md
+++ b/smart-contracts/README.md
@@ -12,7 +12,7 @@
 - [Overview](#overview)
 - [Installation](#installation)
 - [Usage](#usage)
-- [License](#license)
+- [Licence](#licence)
 
 ## Overview
 
@@ -52,6 +52,6 @@ import "@nilfoundation/smart-contracts/contracts/SmartAccount.sol";
 
 ## License
 
-[MIT](./LICENSE)
+[MIT](./LICENCE)
 
 


### PR DESCRIPTION
Updated incorrect links to the LICENCE file across multiple README.md files to consistently point to the correct LICENSE file.
