### PR TITLE
update golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,8 @@
+version: "2"
+run:
+  build-tags:
+    - test
+    - goexperiment.synctest
 linters:
   enable:
     - asasalint
@@ -17,14 +22,10 @@ linters:
     - exhaustive
     - fatcontext
     - forcetypeassert
-    - gci
     - gocheckcompilerdirectives
     - gochecksumtype
     - goconst
     - gocritic
-    - gofmt
-    - gofumpt
-    - goimports
     - goprintffuncname
     - gosec
     - gosmopolitan
@@ -61,56 +62,68 @@ linters:
     - wastedassign
     - whitespace
     - zerologlint
-
-linters-settings:
-  testifylint:
-    enable-all: true
-
-  lll:
-    # max line length, lines longer will be reported. Default is 120.
-    # '\t' is counted as 1 character by default, and can be changed with the tab-width option
-    line-length: 120
-    # tab width in spaces. Default to 1.
-    tab-width: 4
-
-  gosec:
-    excludes:
-      - G115
-
-  govet:
-    enable-all: true
-    disable:
-      - fieldalignment
-      - shadow
-
+  settings:
+    gosec:
+      excludes:
+        - G115
+    govet:
+      disable:
+        - fieldalignment
+        - shadow
+      enable-all: true
+    lll:
+      # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
+      line-length: 120
+      # tab width in spaces. Default to 1.
+      tab-width: 4
+    testifylint:
+      enable-all: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - lll
+        source: ^// @(component|componentprop)
+      - linters:
+          - lll
+        path: (nil/services/cliservice/block_format_test.go|nil/services/cliservice/block.go)
+      - linters:
+          - lll
+        path: nil/internal/abi/abi_test.go
+        source: "^//\treceipt{status=1 cgas=23949"
+      - linters:
+          - lll
+        path: nil/services/synccommittee/prover/internal/constants/proof_producer_codes.go
+        source: ^// https://github.com/NilFoundation/placeholder/
+      - linters:
+          - lll
+        path: nil/services/synccommittee/core/reset/resetter.go
+        source: "^\t\t// https://www.notion.so/nilfoundation/"
+    paths:
+      - clickhouse
+      - third_party$
+      - builtin$
+      - examples$
 issues:
   # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
   max-issues-per-linter: 0
   # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
   max-same-issues: 0
-  exclude-dirs:
-    - clickhouse
-  exclude-rules:
-    - linters:
-        - lll
-      source: "^// @(component|componentprop)"
-    - linters:
-        - lll
-      path: "(nil/services/cliservice/block_format_test.go|nil/services/cliservice/block.go)"
-    - linters:
-        - lll
-      path: "nil/internal/abi/abi_test.go"
-      source: "^//	receipt{status=1 cgas=23949"
-    - linters:
-        - lll
-      path: "nil/services/synccommittee/prover/internal/constants/proof_producer_codes.go"
-      source: "^// https://github.com/NilFoundation/placeholder/"
-    - linters:
-        - lll
-      path: "nil/services/synccommittee/core/reset/resetter.go"
-      source: "^		// https://www.notion.so/nilfoundation/"
-
-run:
-  build-tags:
-    - test
-    - goexperiment.synctest
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - clickhouse
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -69,8 +69,7 @@ golangci-lint:
 format: generated
 	GOPROXY= go mod tidy
 	GOPROXY= go mod vendor
-	gofumpt -l -w .
-	gci write . --skip-generated --skip-vendor
+	golangci-lint fmt
 
 lint: format golangci-lint
 

--- a/flake.lock
+++ b/flake.lock
@@ -44,11 +44,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741246872,
-        "narHash": "sha256-Q6pMP4a9ed636qilcYX8XUguvKl/0/LGXhHcRI91p0U=",
+        "narHash": "sha256-PvtyjsSWtzf4/qdeDY+q2Qmge1+x6CJVjTixTNQi3G0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "10069ef4cf863633f57238f179a0297de84bd8d3",
+        "rev": "cbf38285a40d70b13612ae5ca5fe3206341dc692",
         "type": "github"
       },
       "original": {

--- a/nil/client/rpc/client.go
+++ b/nil/client/rpc/client.go
@@ -192,7 +192,7 @@ func RunContractBatch(ctx context.Context, client *Client, smartAccount types.Ad
 	// get hash of the latest message
 	rawTxn, ok := resp[len(resp)-1].(json.RawMessage)
 	if !ok {
-		return common.EmptyHash, errors.New("Result is not bytes")
+		return common.EmptyHash, errors.New("result is not bytes")
 	}
 
 	var txHash common.Hash

--- a/nil/cmd/exporter/internal/clickhouse/clickhouse.go
+++ b/nil/cmd/exporter/internal/clickhouse/clickhouse.go
@@ -69,7 +69,7 @@ func NewTransactionWithBinary(
 		Transaction:      *transaction,
 		Binary:           transactionBinary,
 		BlockId:          block.Id,
-		BlockHash:        block.Block.Hash(shardId),
+		BlockHash:        block.Hash(shardId),
 		Hash:             hash,
 		ShardId:          shardId,
 		TransactionIndex: idx,
@@ -266,7 +266,7 @@ func (d *ClickhouseDriver) ExportBlocks(ctx context.Context, blocksToExport []*i
 			Block:    *block.decoded.Block,
 			Binary:   binary,
 			ShardId:  block.decoded.ShardId,
-			Hash:     block.decoded.Block.Hash(block.decoded.ShardId),
+			Hash:     block.decoded.Hash(block.decoded.ShardId),
 			InTxnNum: uint64(len(block.decoded.InTransactions)),
 		}
 		blockErr = blockBatch.AppendStruct(binaryBlockExtended)

--- a/nil/cmd/exporter/internal/fetch_block_test.go
+++ b/nil/cmd/exporter/internal/fetch_block_test.go
@@ -28,7 +28,7 @@ func (s *SuiteFetchBlock) TestFetchBlock() {
 	s.Require().NoError(err)
 	s.Require().NotNil(fetchedBlock)
 
-	blocks, err := s.exporter.FetchBlocks(s.context, types.MainShardId, fetchedBlock.Block.Id, fetchedBlock.Block.Id+10)
+	blocks, err := s.exporter.FetchBlocks(s.context, types.MainShardId, fetchedBlock.Id, fetchedBlock.Id+10)
 	s.Require().NoError(err)
 	s.Require().NotEmpty(blocks)
 	s.Require().Equal(fetchedBlock, blocks[0])

--- a/nil/cmd/nil/common/top-up.go
+++ b/nil/cmd/nil/common/top-up.go
@@ -57,7 +57,7 @@ func RunTopUp(
 		var ok bool
 		balance, ok = tokens[types.TokenId(faucetAddress)]
 		if !ok {
-			return fmt.Errorf("Token %s for %s %s is not found", faucetAddress, name, address)
+			return fmt.Errorf("token %s for %s %s is not found", faucetAddress, name, address)
 		}
 	}
 

--- a/nil/cmd/nil/internal/debug/debug.go
+++ b/nil/cmd/nil/internal/debug/debug.go
@@ -156,7 +156,7 @@ func (d *DebugHandler) SelectFailedReceipts() []*ReceiptInfo {
 func (d *DebugHandler) PrintSourceLocation(receipt *ReceiptInfo, loc *cometa.Location) error {
 	lines, err := receipt.Contract.GetSourceLines(loc.FileName)
 	if err != nil {
-		return fmt.Errorf("Failed to fetch the source lines: %w\n", err)
+		return fmt.Errorf("failed to fetch the source lines: %w", err)
 	}
 	startLine := int(loc.Line) - 3
 	if startLine < 1 {

--- a/nil/cmd/nil/internal/smartaccount/deploy.go
+++ b/nil/cmd/nil/internal/smartaccount/deploy.go
@@ -139,7 +139,7 @@ func runDeploy(cmd *cobra.Command, cmdArgs []string, cfg *common.Config) error {
 	if err != nil {
 		if errors.Is(err, rpc.ErrTxnDataTooLong) {
 			return fmt.Errorf(
-				`Failed to marshal transaction: %w.
+				`failed to marshal transaction: %w.
 It appears that your code exceeds the maximum supported size.
 Try compiling your contract with the usage of solc --optimize flag,
 providing small values to --optimize-runs.

--- a/nil/cmd/nil/internal/transaction/internal_transaction.go
+++ b/nil/cmd/nil/internal/transaction/internal_transaction.go
@@ -13,9 +13,9 @@ import (
 
 func GetInternalTransactionCommand() *cobra.Command {
 	var (
-		kind                   types.TransactionKind = types.ExecutionTransactionKind
+		kind                   = types.ExecutionTransactionKind
+		feeCredit              = types.NewValueFromUint64(100_000)
 		bounce                 bool
-		feeCredit              types.Value       = types.NewValueFromUint64(100_000)
 		forwardKind            types.ForwardKind = types.ForwardKindNone
 		to, refundTo, bounceTo types.Address
 		value                  types.Value

--- a/nil/cmd/nil_block_generator/internal/commands/client_test.go
+++ b/nil/cmd/nil_block_generator/internal/commands/client_test.go
@@ -99,18 +99,18 @@ func (s *NilBlockGeneratorTestSuite) TearDownTest() {
 func (s *NilBlockGeneratorTestSuite) TestGetBlock() {
 	smartAccountAdr, hexKey, err := CreateNewSmartAccount(s.url, s.logger)
 	s.Require().NoError(err)
-	s.Require().NotEqual("", smartAccountAdr)
-	s.Require().NotEqual("", hexKey)
+	s.Require().NotEmpty(smartAccountAdr)
+	s.Require().NotEmpty(hexKey)
 
 	contractAddress, err := DeployContract(s.url, smartAccountAdr, s.contractBasePath, hexKey, s.deployArgs, s.logger)
 	s.Require().NoError(err)
-	s.Require().NotEqual("", contractAddress)
+	s.Require().NotEmpty(contractAddress)
 
 	var calls []Call
 	calls = append(calls, *NewCall(s.contractName, s.method, s.contractBasePath+".abi", contractAddress, s.callArgs, 1))
 	blockHash, err := CallContract(s.url, smartAccountAdr, hexKey, calls, s.logger)
 	s.Require().NoError(err)
-	s.Require().NotEqual("", blockHash)
+	s.Require().NotEmpty(blockHash)
 }
 
 func TestNilBlockGeneratorTestSuite(t *testing.T) {

--- a/nil/cmd/nil_block_generator/internal/commands/config.go
+++ b/nil/cmd/nil_block_generator/internal/commands/config.go
@@ -179,7 +179,7 @@ func GetSockPath() (string, error) {
 func (cfg *Config) GetContract(contractName string) (*Contract, error) {
 	contract, ok := cfg.Contracts[contractName]
 	if !ok {
-		return nil, fmt.Errorf("Contract %s not deployed", contractName)
+		return nil, fmt.Errorf("contract %s not deployed", contractName)
 	}
 	return &contract, nil
 }

--- a/nil/cmd/nild/main.go
+++ b/nil/cmd/nild/main.go
@@ -161,7 +161,7 @@ func parseArgs() *nildconfig.Config {
 	runCmd.Flags().BoolVar(&cfg.EnableDevApi, "dev-api", cfg.EnableDevApi, "enable development API")
 
 	addBasicFlags(runCmd.Flags(), cfg)
-	cmdflags.AddNetwork(runCmd.Flags(), cfg.Config.Network)
+	cmdflags.AddNetwork(runCmd.Flags(), cfg.Network)
 	cmdflags.AddTelemetry(runCmd.Flags(), cfg.Telemetry)
 
 	replayCmd := &cobra.Command{
@@ -184,7 +184,7 @@ func parseArgs() *nildconfig.Config {
 	}
 
 	addBasicFlags(archiveCmd.Flags(), cfg)
-	cmdflags.AddNetwork(archiveCmd.Flags(), cfg.Config.Network)
+	cmdflags.AddNetwork(archiveCmd.Flags(), cfg.Network)
 	cmdflags.AddTelemetry(archiveCmd.Flags(), cfg.Telemetry)
 
 	rpcCmd := &cobra.Command{
@@ -198,7 +198,7 @@ func parseArgs() *nildconfig.Config {
 
 	addRpcNodeFlags(rpcCmd.Flags(), cfg)
 	addAllowDbClearFlag(rpcCmd.Flags(), cfg)
-	cmdflags.AddNetwork(rpcCmd.Flags(), cfg.Config.Network)
+	cmdflags.AddNetwork(rpcCmd.Flags(), cfg.Network)
 	cmdflags.AddTelemetry(rpcCmd.Flags(), cfg.Telemetry)
 
 	versionCmd := cobrax.VersionCmd(appTitle)

--- a/nil/cmd/relayer/main.go
+++ b/nil/cmd/relayer/main.go
@@ -72,7 +72,7 @@ func addRunCommandFlags(runCmd *cobra.Command, cfg *Config) {
 		"l1-endpoint", "", "URL for ETH L1 client",
 	)
 	runCmd.Flags().StringVar(
-		&cfg.RelayerConfig.EventListenerConfig.BridgeMessengerContractAddress,
+		&cfg.EventListenerConfig.BridgeMessengerContractAddress,
 		"l1-contract-addr",
 		"",
 		"Address of L1BridgeMessenger contract to fetch events from",
@@ -81,16 +81,16 @@ func addRunCommandFlags(runCmd *cobra.Command, cfg *Config) {
 		"l1-timeout", time.Second, "Max timeout for ETH client to timeout",
 	)
 	runCmd.Flags().IntVar(
-		&cfg.RelayerConfig.EventListenerConfig.BatchSize,
+		&cfg.EventListenerConfig.BatchSize,
 		"l1-fetcher-batch-size",
-		cfg.RelayerConfig.EventListenerConfig.BatchSize,
+		cfg.EventListenerConfig.BatchSize,
 		"Block range len used in event listener to fetch historical data",
 	)
 
 	runCmd.Flags().DurationVar(
-		&cfg.RelayerConfig.EventListenerConfig.PollInterval,
+		&cfg.EventListenerConfig.PollInterval,
 		"l1-fetcher-poll-interval",
-		cfg.RelayerConfig.EventListenerConfig.PollInterval,
+		cfg.EventListenerConfig.PollInterval,
 		"Pause which l1 fetcher takes between fetching historical data batches",
 	)
 

--- a/nil/cmd/stresser/main.go
+++ b/nil/cmd/stresser/main.go
@@ -24,10 +24,10 @@ func main() {
 			zerolog.SetGlobalLevel(level)
 			st, err := stresser.NewStresserFromFile(configFile)
 			if err != nil {
-				return fmt.Errorf("Failed to create stresser: %w", err)
+				return fmt.Errorf("failed to create stresser: %w", err)
 			}
 			if err = st.Run(context.Background()); err != nil {
-				return fmt.Errorf("Failed to run stresser: %w", err)
+				return fmt.Errorf("failed to run stresser: %w", err)
 			}
 			return nil
 		},

--- a/nil/common/concurrent/suspendable.go
+++ b/nil/common/concurrent/suspendable.go
@@ -69,16 +69,16 @@ func (s *Suspendable) Run(ctx context.Context, started chan<- struct{}) error {
 func (s *Suspendable) onStateChange(ticker *time.Ticker, currentState *workerState, req stateChangeRequest) {
 	defer close(req.response)
 
-	switch {
-	case req.newState == *currentState:
+	switch req.newState {
+	case *currentState:
 		// state remains unchanged, push false to the caller of Pause() / Resume()
 		req.response <- false
 		return
 
-	case req.newState == workerStatePaused:
+	case workerStatePaused:
 		ticker.Stop()
 
-	case req.newState == workerStateRunning:
+	case workerStateRunning:
 		ticker.Reset(s.interval)
 
 	default:

--- a/nil/common/hexutil/hexutil_test.go
+++ b/nil/common/hexutil/hexutil_test.go
@@ -72,7 +72,7 @@ func TestEncodeBig(t *testing.T) {
 
 			in, ok := test.input.(*big.Int)
 			require.True(t, ok)
-			require.EqualValues(t, test.want, EncodeBig(in))
+			require.Equal(t, test.want, EncodeBig(in))
 		})
 	}
 }
@@ -86,7 +86,7 @@ func TestEncodeUint64(t *testing.T) {
 
 			in, ok := test.input.(uint64)
 			require.True(t, ok)
-			require.EqualValues(t, test.want, EncodeUint64(in))
+			require.Equal(t, test.want, EncodeUint64(in))
 		})
 	}
 }
@@ -101,7 +101,7 @@ func TestDecodeUint64(t *testing.T) {
 			dec, err := DecodeUint64(test.input)
 			checkError(t, test.input, err, test.wantErr)
 			if test.want != nil {
-				require.EqualValues(t, test.want, dec)
+				require.Equal(t, test.want, dec)
 			}
 		})
 	}

--- a/nil/common/hexutil/json_test.go
+++ b/nil/common/hexutil/json_test.go
@@ -21,7 +21,7 @@ func checkError(t *testing.T, input string, got, want error) {
 		require.NoError(t, want, "input %s", input)
 		return
 	}
-	require.EqualValues(t, want.Error(), got.Error(), "input %s", input)
+	require.Equal(t, want.Error(), got.Error(), "input %s", input)
 }
 
 func bigFromString(s string) *big.Int {
@@ -110,8 +110,8 @@ func TestMarshalBig(t *testing.T) {
 			out, err := json.Marshal((*Big)(in))
 			require.NoError(t, err)
 			want := `"` + test.want + `"`
-			require.EqualValues(t, want, string(out))
-			require.EqualValues(t, test.want, (*Big)(in).String())
+			require.Equal(t, want, string(out))
+			require.Equal(t, test.want, (*Big)(in).String())
 		})
 	}
 }
@@ -176,8 +176,8 @@ func TestMarshalUint64(t *testing.T) {
 			out, err := json.Marshal(Uint64(in))
 			require.NoError(t, err)
 			want := `"` + test.want + `"`
-			require.EqualValues(t, want, string(out))
-			require.EqualValues(t, test.want, (Uint64)(in).String())
+			require.Equal(t, want, string(out))
+			require.Equal(t, test.want, (Uint64)(in).String())
 		})
 	}
 }
@@ -194,8 +194,8 @@ func TestMarshalUint(t *testing.T) {
 			out, err := json.Marshal(Uint(in))
 			require.NoError(t, err)
 			want := `"` + test.want + `"`
-			require.EqualValues(t, want, string(out))
-			require.EqualValues(t, test.want, (Uint)(in).String())
+			require.Equal(t, want, string(out))
+			require.Equal(t, test.want, (Uint)(in).String())
 		})
 	}
 }

--- a/nil/internal/abi/abi.go
+++ b/nil/internal/abi/abi.go
@@ -264,7 +264,6 @@ func (abi *ABI) MethodById(sigdata []byte) (*Method, error) {
 func (abi *ABI) EventByID(topic common.Hash) (*Event, error) {
 	for _, event := range abi.Events {
 		if bytes.Equal(event.ID.Bytes(), topic.Bytes()) {
-			//nolint:scopelint
 			return &event, nil
 		}
 	}

--- a/nil/internal/abi/abi_test.go
+++ b/nil/internal/abi/abi_test.go
@@ -16,8 +16,6 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with Erigon. If not, see <http://www.gnu.org/licenses/>.
-//
-//nolint:scopelint
 package abi
 
 import (
@@ -369,7 +367,7 @@ func TestInvalidABI(t *testing.T) {
 	if err == nil {
 		t.Fatal("invalid json should produce error")
 	}
-	json2 := `[{ 
+	json2 := `[{
 		"type" : "function",
 		"name" : "send",
 		"constant" : false,
@@ -1496,12 +1494,12 @@ func TestABI_EventById(t *testing.T) {
 		}, {
 			name: "",
 			json: `[{
-				"constant": true, 
-				"inputs": [], 
-				"name": "name", 
-				"outputs": [ { "name": "", "type": "string" } ], 
-				"payable": false, 
-				"stateMutability": "view", 
+				"constant": true,
+				"inputs": [],
+				"name": "name",
+				"outputs": [ { "name": "", "type": "string" } ],
+				"payable": false,
+				"stateMutability": "view",
 				"type": "function"
 			}, {
 				"constant": false,
@@ -1515,15 +1513,15 @@ func TestABI_EventById(t *testing.T) {
 				"stateMutability": "nonpayable",
 				"type": "function"
 			}, {
-				"constant": true, 
-				"inputs": [], 
-				"name": "totalSupply", 
-				"outputs": [ { "name": "", "type": "uint256" } ], 
-				"payable": false, 
-				"stateMutability": "view", 
+				"constant": true,
+				"inputs": [],
+				"name": "totalSupply",
+				"outputs": [ { "name": "", "type": "uint256" } ],
+				"payable": false,
+				"stateMutability": "view",
 				"type": "function"
 			}, {
-				"constant": false, 
+				"constant": false,
 				"inputs": [
 					{ "name": "_from", "type": "address" },
 					{ "name": "_to", "type": "address" },
@@ -1535,31 +1533,31 @@ func TestABI_EventById(t *testing.T) {
 				"stateMutability": "nonpayable",
 				"type": "function"
 			}, {
-				"constant": true, 
-				"inputs": [], 
-				"name": "decimals", 
-				"outputs": [ { "name": "", "type": "uint8" } ], 
-				"payable": false, 
-				"stateMutability": "view", 
+				"constant": true,
+				"inputs": [],
+				"name": "decimals",
+				"outputs": [ { "name": "", "type": "uint8" } ],
+				"payable": false,
+				"stateMutability": "view",
 				"type": "function"
 			}, {
-				"constant": true, 
-				"inputs": [ { "name": "_owner", "type": "address" } ], 
-				"name": "balanceOf", 
+				"constant": true,
+				"inputs": [ { "name": "_owner", "type": "address" } ],
+				"name": "balanceOf",
 				"outputs": [ { "name": "balance", "type": "uint256" } ],
 				"payable": false,
 				"stateMutability": "view",
 				"type": "function"
 			}, {
 				"constant": true,
-				"inputs": [], 
-				"name": "symbol", 
-				"outputs": [ { "name": "", "type": "string" } ], 
-				"payable": false, 
-				"stateMutability": "view", 
+				"inputs": [],
+				"name": "symbol",
+				"outputs": [ { "name": "", "type": "string" } ],
+				"payable": false,
+				"stateMutability": "view",
 				"type": "function"
 			}, {
-				"constant": false, 
+				"constant": false,
 				"inputs": [
 					{ "name": "_to", "type": "address" },
 					{ "name": "_value", "type": "uint256" }

--- a/nil/internal/abi/method.go
+++ b/nil/internal/abi/method.go
@@ -139,11 +139,12 @@ func NewMethod(
 		state += " "
 	}
 	identity := fmt.Sprintf("function %v", rawName)
-	if funType == Fallback { //nolint:gocritic
+	switch funType { //nolint:exhaustive
+	case Fallback:
 		identity = "fallback"
-	} else if funType == Receive {
+	case Receive:
 		identity = "receive"
-	} else if funType == Constructor {
+	case Constructor:
 		identity = "constructor"
 	}
 	str := fmt.Sprintf(

--- a/nil/internal/abi/method_test.go
+++ b/nil/internal/abi/method_test.go
@@ -138,11 +138,12 @@ func TestMethodString(t *testing.T) {
 
 	for _, test := range table {
 		var got string
-		if test.method == "fallback" { //nolint:gocritic
+		switch test.method {
+		case "fallback":
 			got = abi.Fallback.String()
-		} else if test.method == "receive" {
+		case "receive":
 			got = abi.Receive.String()
-		} else {
+		default:
 			got = abi.Methods[test.method].String()
 		}
 		if got != test.expectation {

--- a/nil/internal/abi/pack_test.go
+++ b/nil/internal/abi/pack_test.go
@@ -16,8 +16,6 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with Erigon. If not, see <http://www.gnu.org/licenses/>.
-//
-//nolint:scopelint
 package abi
 
 import (

--- a/nil/internal/abi/topics_test.go
+++ b/nil/internal/abi/topics_test.go
@@ -17,7 +17,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with Erigon. If not, see <http://www.gnu.org/licenses/>.
 
-//nolint:scopelint
 package abi
 
 import (

--- a/nil/internal/abi/unpack.go
+++ b/nil/internal/abi/unpack.go
@@ -136,13 +136,14 @@ func forEachUnpack(t Type, output []byte, start, size int) (interface{}, error) 
 	// this value will become our slice or our array, depending on the type
 	var refSlice reflect.Value
 
-	if t.T == SliceTy { //nolint:gocritic
+	switch t.T {
+	case SliceTy:
 		// declare our slice
 		refSlice = reflect.MakeSlice(t.GetType(), size, size)
-	} else if t.T == ArrayTy {
+	case ArrayTy:
 		// declare our array
 		refSlice = reflect.New(t.GetType()).Elem()
-	} else {
+	default:
 		return nil, errors.New("abi: invalid type in array/slice unpacking stage")
 	}
 

--- a/nil/internal/abi/unpack_test.go
+++ b/nil/internal/abi/unpack_test.go
@@ -16,8 +16,6 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with Erigon. If not, see <http://www.gnu.org/licenses/>.
-//
-//nolint:scopelint
 package abi
 
 import (
@@ -234,7 +232,6 @@ func TestLocalUnpackTests(t *testing.T) { //nolint:tparallel
 	for i, test := range unpackTests { //nolint:paralleltest
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			// Unpack
-			//nolint:scopelint
 			def := fmt.Sprintf(`[{ "name" : "method", "type": "function", "outputs": %s}]`, test.def)
 			abi, err := JSON(strings.NewReader(def))
 			if err != nil {
@@ -242,7 +239,7 @@ func TestLocalUnpackTests(t *testing.T) { //nolint:tparallel
 			}
 			encb, err := hex.DecodeString(test.enc)
 			if err != nil {
-				t.Fatalf("invalid hex %s: %v", test.enc, err) //nolint:scopelint
+				t.Fatalf("invalid hex %s: %v", test.enc, err)
 			}
 			outptr := reflect.New(reflect.TypeOf(test.want))
 			err = abi.UnpackIntoInterface(outptr.Interface(), "method", encb)

--- a/nil/internal/collate/syncer.go
+++ b/nil/internal/collate/syncer.go
@@ -332,7 +332,7 @@ func (s *Syncer) saveBlock(ctx context.Context, block *types.BlockWithExtractedD
 	}
 
 	s.logger.Trace().
-		Stringer(logging.FieldBlockNumber, block.Block.Id).
+		Stringer(logging.FieldBlockNumber, block.Id).
 		Msg("Block written")
 
 	return nil

--- a/nil/internal/collate/validator.go
+++ b/nil/internal/collate/validator.go
@@ -335,9 +335,9 @@ func (s *Validator) validateRepliedBlock(
 // +checklocksread:s.mutex
 func (s *Validator) validateBlockForProposalUnlocked(ctx context.Context, block *types.BlockWithExtractedData) error {
 	proposal := &execution.Proposal{
-		PrevBlockId:   block.Block.Id - 1,
-		PrevBlockHash: block.Block.PrevBlock,
-		MainShardHash: block.Block.MainShardHash,
+		PrevBlockId:   block.Id - 1,
+		PrevBlockHash: block.PrevBlock,
+		MainShardHash: block.MainShardHash,
 		ShardHashes:   block.ChildBlocks,
 	}
 	return s.validateProposalUnlocked(ctx, proposal)
@@ -395,9 +395,9 @@ func (s *Validator) ReplayBlock(ctx context.Context, block *types.BlockWithExtra
 
 // +checklocks:s.mutex
 func (s *Validator) replayBlockUnlocked(ctx context.Context, block *types.BlockWithExtractedData) error {
-	blockHash := block.Block.Hash(s.params.ShardId)
+	blockHash := block.Hash(s.params.ShardId)
 	s.logger.Trace().
-		Stringer(logging.FieldBlockNumber, block.Block.Id).
+		Stringer(logging.FieldBlockNumber, block.Id).
 		Stringer(logging.FieldBlockHash, blockHash).
 		Msg("Replaying block")
 
@@ -409,9 +409,9 @@ func (s *Validator) replayBlockUnlocked(ctx context.Context, block *types.BlockW
 	}
 
 	proposal := &execution.Proposal{
-		PrevBlockId:   block.Block.Id - 1,
-		PrevBlockHash: block.Block.PrevBlock,
-		MainShardHash: block.Block.MainShardHash,
+		PrevBlockId:   block.Id - 1,
+		PrevBlockHash: block.PrevBlock,
+		MainShardHash: block.MainShardHash,
 		ShardHashes:   block.ChildBlocks,
 	}
 	proposal.InternalTxns, proposal.ExternalTxns = execution.SplitInTransactions(block.InTransactions)

--- a/nil/internal/execution/contract_test.go
+++ b/nil/internal/execution/contract_test.go
@@ -131,7 +131,7 @@ func TestCall(t *testing.T) {
 
 	res := state.AddAndHandleTransaction(ctx, callTransaction, dummyPayer{})
 	require.False(t, res.Failed())
-	require.EqualValues(t, common.LeftPadBytes(hexutil.FromHex("0x2A"), 32), res.ReturnData)
+	require.Equal(t, common.LeftPadBytes(hexutil.FromHex("0x2A"), 32), res.ReturnData)
 
 	// deploy and call Caller
 	caller := contracts["Caller"]
@@ -152,7 +152,7 @@ func TestCall(t *testing.T) {
 	// check that it changed the state of SimpleContract
 	res = state.AddAndHandleTransaction(ctx, callTransaction, dummyPayer{})
 	require.False(t, res.Failed())
-	require.EqualValues(t, common.LeftPadBytes(hexutil.FromHex("0x2b"), 32), res.ReturnData)
+	require.Equal(t, common.LeftPadBytes(hexutil.FromHex("0x2b"), 32), res.ReturnData)
 
 	// check that callSetAndRevert does not change anything
 	calldata2, err = solc.ExtractABI(caller).Pack("callSetAndRevert", addr, big.NewInt(45))
@@ -168,7 +168,7 @@ func TestCall(t *testing.T) {
 	// check that did not change the state of SimpleContract
 	res = state.AddAndHandleTransaction(ctx, callTransaction, dummyPayer{})
 	require.False(t, res.Failed())
-	require.EqualValues(t, common.LeftPadBytes(hexutil.FromHex("0x2b"), 32), res.ReturnData)
+	require.Equal(t, common.LeftPadBytes(hexutil.FromHex("0x2b"), 32), res.ReturnData)
 }
 
 func TestDelegate(t *testing.T) {
@@ -211,7 +211,7 @@ func TestDelegate(t *testing.T) {
 	res = state.AddAndHandleTransaction(ctx, callTransaction, dummyPayer{})
 	require.False(t, res.Failed())
 	// check that it returned 42
-	require.EqualValues(t, common.LeftPadBytes(hexutil.FromHex("0x2a"), 32), res.ReturnData)
+	require.Equal(t, common.LeftPadBytes(hexutil.FromHex("0x2a"), 32), res.ReturnData)
 
 	// call ProxyContract.setValueStatic(delegateAddr, 42)
 	calldata, err = solc.ExtractABI(proxyContract).Pack("setValueStatic", delegateAddr, big.NewInt(42))

--- a/nil/internal/execution/execution_state_test.go
+++ b/nil/internal/execution/execution_state_test.go
@@ -204,7 +204,7 @@ func (s *SuiteExecutionState) TestExecStateMultipleBlocks() {
 		txnRead, err := transactionsRoot.Fetch(idx)
 		s.Require().NoError(err)
 
-		s.EqualValues(txn, txnRead)
+		s.Equal(txn, txnRead)
 	}
 
 	check(blockHash1, 0, txn1)
@@ -615,11 +615,11 @@ func (s *SuiteExecutionState) TestPrecompiles() {
 
 		gasPrice = types.DefaultGasPrice.Add(gasScale.Mul(types.Value10))
 		gas = vm.GetExtraGasForOutboundTransaction(state, types.ShardId(2))
-		s.EqualValues(vm.ExtraForwardFeeStep*10, gas)
+		s.Equal(vm.ExtraForwardFeeStep*10, gas)
 
 		gasPrice = types.DefaultGasPrice.Add(gasScale.Mul(types.NewValueFromUint64(101)))
 		gas = vm.GetExtraGasForOutboundTransaction(state, types.ShardId(2))
-		s.EqualValues(vm.ExtraForwardFeeStep*101, gas)
+		s.Equal(vm.ExtraForwardFeeStep*101, gas)
 	})
 }
 

--- a/nil/internal/execution/state.go
+++ b/nil/internal/execution/state.go
@@ -753,7 +753,7 @@ func (es *ExecutionState) CreateAccount(addr types.Address) error {
 func (es *ExecutionState) createAccount(addr types.Address) (*AccountState, error) {
 	if addr.ShardId() != es.ShardId {
 		return nil, fmt.Errorf(
-			"Attempt to create account %v from %v shard on %v shard", addr, addr.ShardId(), es.ShardId)
+			"attempt to create account %v from %v shard on %v shard", addr, addr.ShardId(), es.ShardId)
 	}
 	acc, err := es.GetAccount(addr)
 	if err != nil {
@@ -1143,7 +1143,7 @@ func (es *ExecutionState) HandleTransaction(
 	if txn.IsRequest() {
 		if !es.wasAwaitCall {
 			if err := es.SendResponseTransaction(txn, res); err != nil {
-				return NewExecutionResult().SetFatal(fmt.Errorf("SendResponseTransaction failed: %w\n", err))
+				return NewExecutionResult().SetFatal(fmt.Errorf("SendResponseTransaction failed: %w", err))
 			}
 			bounced = true
 			responseWasSent = true
@@ -1152,7 +1152,7 @@ func (es *ExecutionState) HandleTransaction(
 		// There is pending requests in the chain, so we need to send response to them.
 		// But we don't send response if a new request was sent during the execution.
 		if err := es.SendResponseTransaction(txn, res); err != nil {
-			return NewExecutionResult().SetFatal(fmt.Errorf("SendResponseTransaction failed: %w\n", err))
+			return NewExecutionResult().SetFatal(fmt.Errorf("SendResponseTransaction failed: %w", err))
 		}
 		responseWasSent = true
 	}

--- a/nil/internal/execution/state_accessor.go
+++ b/nil/internal/execution/state_accessor.go
@@ -510,7 +510,7 @@ func (b blockAccessor) WithConfig() blockAccessor {
 }
 
 func (b blockAccessor) ByHash(hash common.Hash) (blockAccessorResult, error) {
-	sa := b.rawBlockAccessor.rawShardAccessor
+	sa := b.rawShardAccessor
 
 	raw, err := b.rawBlockAccessor.ByHash(hash)
 	if err != nil {
@@ -578,7 +578,7 @@ func (b blockAccessor) ByHash(hash common.Hash) (blockAccessorResult, error) {
 }
 
 func (b blockAccessor) ByNumber(num types.BlockNumber) (blockAccessorResult, error) {
-	sa := b.rawBlockAccessor.rawShardAccessor
+	sa := b.rawShardAccessor
 	hash, err := db.ReadBlockHashByNumber(sa.tx, sa.shardId, num)
 	if err != nil {
 		return blockAccessorResult{}, err

--- a/nil/internal/execution/zerostate.go
+++ b/nil/internal/execution/zerostate.go
@@ -186,10 +186,9 @@ func (es *ExecutionState) GenerateZeroState(stateConfig *ZeroStateConfig) error 
 		for _, arg := range contract.CtorArgs {
 			switch arg := arg.(type) {
 			case string:
-				switch {
-				case arg[:2] == "0x":
+				if arg[:2] == "0x" {
 					args = append(args, hexutil.FromHex(arg))
-				default:
+				} else {
 					return fmt.Errorf("unknown constructor argument string pattern: %s", arg)
 				}
 			default:

--- a/nil/internal/execution/zerostate_test.go
+++ b/nil/internal/execution/zerostate_test.go
@@ -112,7 +112,7 @@ func (s *SuiteZeroState) TestWithdrawFromFaucet() {
 	faucetBalance = faucetBalance.Sub64(100)
 	newFaucetBalance := s.getBalance(s.faucetAddr)
 	s.Require().Negative(newFaucetBalance.Cmp(faucetBalance))
-	s.Require().EqualValues(types.NewValueFromUint64(100), s.getBalance(receiverAddr))
+	s.Require().Equal(types.NewValueFromUint64(100), s.getBalance(receiverAddr))
 }
 
 func TestZerostateFromConfig(t *testing.T) {

--- a/nil/internal/keys/keys.go
+++ b/nil/internal/keys/keys.go
@@ -96,17 +96,17 @@ func (v *ValidatorKeysManager) InitKey() error {
 	}
 	if _, err := os.Stat(v.validatorKeyPath); err != nil {
 		if !os.IsNotExist(err) {
-			return fmt.Errorf("Error checking key file: %w", err)
+			return fmt.Errorf("error checking key file: %w", err)
 		}
 		Logger.Warn().Msgf("Key file not found, generating new key at path: %s", v.validatorKeyPath)
 		v.generateKey()
 		if err := v.dumpKey(); err != nil {
-			return fmt.Errorf("Error saving key: %w", err)
+			return fmt.Errorf("error saving key: %w", err)
 		}
 		return nil
 	}
 	if err := v.loadKey(); err != nil {
-		return fmt.Errorf("Error loading key: %w", err)
+		return fmt.Errorf("error loading key: %w", err)
 	}
 	return nil
 }

--- a/nil/internal/readthroughdb/read_through.go
+++ b/nil/internal/readthroughdb/read_through.go
@@ -229,7 +229,7 @@ func NewReadThroughDbWithMainShard(
 	defer tx.Rollback()
 
 	if block.DbTimestamp == types.InvalidDbTimestamp {
-		return nil, errors.New("The chosen block is too old and doesn't support read-through mode")
+		return nil, errors.New("the chosen block is too old and doesn't support read-through mode")
 	}
 	if err := client.DbInitTimestamp(ctx, block.DbTimestamp); err != nil {
 		return nil, err

--- a/nil/internal/types/block.go
+++ b/nil/internal/types/block.go
@@ -142,7 +142,7 @@ func (b *RawBlockWithExtractedData) DecodeSSZ() (*BlockWithExtractedData, error)
 }
 
 func (b *BlockWithExtractedData) EncodeSSZ() (*RawBlockWithExtractedData, error) {
-	block, err := b.Block.MarshalSSZ()
+	block, err := b.MarshalSSZ()
 	if err != nil {
 		return nil, err
 	}

--- a/nil/internal/types/gas.go
+++ b/nil/internal/types/gas.go
@@ -44,7 +44,7 @@ func (g Gas) ToValue(price Value) Value {
 }
 
 func (g Gas) ToValueOverflow(price Value) (Value, bool) {
-	res, overflow := price.Uint256.mulOverflow64(g.Uint64())
+	res, overflow := price.mulOverflow64(g.Uint64())
 	return Value{res}, overflow
 }
 

--- a/nil/internal/types/receipt_test.go
+++ b/nil/internal/types/receipt_test.go
@@ -43,13 +43,13 @@ func TestReceiptEncoding(t *testing.T) {
 
 	require.Equal(t, receiptDecoded.Success, receipt.Success)
 	require.Equal(t, receiptDecoded.GasUsed, receipt.GasUsed)
-	require.Equal(t, len(receiptDecoded.Logs), len(receipt.Logs))
+	require.Len(t, receipt.Logs, len(receiptDecoded.Logs))
 	for i := range receipt.Logs {
 		log1 := receipt.Logs[i]
 		log2 := receiptDecoded.Logs[i]
 		require.Equal(t, log1.Address, log2.Address)
 		require.Equal(t, log1.Data, log2.Data)
-		require.Equal(t, len(log1.Topics), len(log2.Topics))
+		require.Len(t, log2.Topics, len(log1.Topics))
 		for j := range log1.Topics {
 			t1 := log1.Topics[j]
 			t2 := log2.Topics[j]

--- a/nil/internal/types/value.go
+++ b/nil/internal/types/value.go
@@ -90,7 +90,7 @@ func (v Value) Div64(other uint64) Value {
 }
 
 func (v Value) AddOverflow(other Value) (Value, bool) {
-	res, overflow := v.Uint256.addOverflow(other.Uint256)
+	res, overflow := v.addOverflow(other.Uint256)
 	return Value{res}, overflow
 }
 
@@ -105,28 +105,28 @@ func (v Value) Eq(other Value) bool {
 }
 
 func (v Value) SubOverflow(other Value) (Value, bool) {
-	res, overflow := v.Uint256.subOverflow(other.Uint256)
+	res, overflow := v.subOverflow(other.Uint256)
 	return Value{res}, overflow
 }
 
 func (v Value) Add64(other uint64) Value {
-	res, overflow := v.Uint256.addOverflow(NewUint256(other))
+	res, overflow := v.addOverflow(NewUint256(other))
 	check.PanicIfNot(!overflow)
 	return Value{res}
 }
 
 func (v Value) Sub64(other uint64) Value {
-	res, overflow := v.Uint256.subOverflow(NewUint256(other))
+	res, overflow := v.subOverflow(NewUint256(other))
 	check.PanicIfNot(!overflow)
 	return Value{res}
 }
 
 func (v Value) Cmp(other Value) int {
-	return v.Uint256.cmp(other.Uint256)
+	return v.cmp(other.Uint256)
 }
 
 func (v Value) ToGas(price Value) Gas {
-	return Gas(v.Uint256.div64(price.Uint256))
+	return Gas(v.div64(price.Uint256))
 }
 
 func (v Value) ToBig() *big.Int {

--- a/nil/internal/vm/eips.go
+++ b/nil/internal/vm/eips.go
@@ -277,8 +277,8 @@ func opMcopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]by
 // opBlobHash implements the BLOBHASH opcode
 func opBlobHash(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	index := scope.Stack.peek()
-	if index.LtUint64(uint64(len(interpreter.evm.TxContext.BlobHashes))) {
-		blobHash := interpreter.evm.TxContext.BlobHashes[index.Uint64()]
+	if index.LtUint64(uint64(len(interpreter.evm.BlobHashes))) {
+		blobHash := interpreter.evm.BlobHashes[index.Uint64()]
 		index.SetBytes32(blobHash[:])
 	} else {
 		index.Clear()

--- a/nil/internal/vm/precompiled.go
+++ b/nil/internal/vm/precompiled.go
@@ -690,7 +690,7 @@ func (a *verifySignature) Run(input []byte) ([]byte, error) {
 	pubkey, ok1 := values[0].([]byte)
 	hash, ok2 := values[1].(*big.Int)
 	sig, ok3 := values[2].([]byte)
-	if !(ok1 && ok2 && ok3 && len(sig) == common.SignatureSize) {
+	if !ok1 || !ok2 || !ok3 || len(sig) != common.SignatureSize {
 		return common.EmptyHash[:], nil
 	}
 	result := crypto.VerifySignature(pubkey, common.BigToHash(hash).Bytes(), sig[:64])

--- a/nil/services/cliservice/block.go
+++ b/nil/services/cliservice/block.go
@@ -51,7 +51,7 @@ func (m *transactionWithHash) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
 		*types.Transaction
 		Hash common.Hash `json:"hash"`
-	}{&m.Transaction, m.Transaction.Hash()})
+	}{&m.Transaction, m.Hash()})
 }
 
 func (s *Service) debugBlockToJson(shardId types.ShardId, block *types.BlockWithExtractedData) ([]byte, error) {
@@ -84,7 +84,7 @@ func (s *Service) debugBlockToJson(shardId types.ShardId, block *types.BlockWith
 		toWithHashTransactions(block.OutTransactions),
 		block.Receipts,
 		block.Errors,
-		block.Block.Hash(shardId),
+		block.Hash(shardId),
 		shardId,
 		block.BaseFee,
 		block.GasUsed,

--- a/nil/services/nil_load_generator/contracts/factory.go
+++ b/nil/services/nil_load_generator/contracts/factory.go
@@ -22,7 +22,7 @@ func (f *Factory) Deploy(smartAccount SmartAccount) error {
 	if err != nil {
 		return err
 	}
-	code := append(f.Contract.Code.Clone(), argsPacked...)
+	code := append(f.Code.Clone(), argsPacked...)
 	f.Addr, err = DeployContract(smartAccount.CliService, smartAccount.Addr, code)
 	return err
 }

--- a/nil/services/nilservice/config.go
+++ b/nil/services/nilservice/config.go
@@ -171,7 +171,7 @@ func (c *Config) Validate() error {
 
 	for _, shard := range c.MyShards {
 		if shard >= uint(c.NShards) {
-			return fmt.Errorf("Shard %d is out of range (nShards = %d)", shard, c.NShards)
+			return fmt.Errorf("shard %d is out of range (nShards = %d)", shard, c.NShards)
 		}
 	}
 

--- a/nil/services/nilservice/config_test.go
+++ b/nil/services/nilservice/config_test.go
@@ -20,7 +20,7 @@ func TestValidateInvalidMyShards(t *testing.T) {
 	cfg.MyShards = []uint{100}
 
 	err := cfg.Validate()
-	require.ErrorContains(t, err, "Shard 100 is out of range (nShards = 5)")
+	require.ErrorContains(t, err, "shard 100 is out of range (nShards = 5)")
 }
 
 func TestValidateInvalidNShards(t *testing.T) {

--- a/nil/services/nilservice/service.go
+++ b/nil/services/nilservice/service.go
@@ -490,7 +490,7 @@ func CreateNode(
 		}))
 	case RpcRunMode:
 		if networkManager == nil {
-			err := errors.New("Failed to start rpc node without network configuration")
+			err := errors.New("failed to start rpc node without network configuration")
 			logger.Error().Err(err).Send()
 			return nil, err
 		}

--- a/nil/services/relayer/internal/l1/event_listener_test.go
+++ b/nil/services/relayer/internal/l1/event_listener_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/NilFoundation/nil/nil/internal/db"
 	"github.com/NilFoundation/nil/nil/services/relayer/internal/storage"
 	ethcommon "github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/jonboulle/clockwork"
@@ -194,7 +193,7 @@ func (s *EventListenerTestSuite) TestFetchHistoricalEvents() {
 			return []*L1MessageSent{
 				{
 					MessageHash: getMsgHash(msgSourceFetcher, callNumber+1),
-					Raw: types.Log{
+					Raw: ethtypes.Log{
 						BlockNumber: from,
 						BlockHash:   ethcommon.BytesToHash([]byte{1, 2, 3, 4}),
 					},
@@ -217,7 +216,7 @@ func (s *EventListenerTestSuite) TestFetchHistoricalEvents() {
 		err = s.storage.IterateEventsByBatch(s.ctx, 100, func(events []*Event) error {
 			s.Len(events, eventCount)
 			for i, event := range events {
-				s.EqualValues(expectedRanges[i].from, event.BlockNumber)
+				s.Equal(expectedRanges[i].from, event.BlockNumber)
 				s.EqualValues(i, event.SequenceNumber)
 			}
 			return nil
@@ -268,7 +267,7 @@ func (s *EventListenerTestSuite) TestFetchEventsFromSubscription() {
 				for i := 1; i < 4; i++ {
 					sink <- &L1MessageSent{
 						MessageHash: getMsgHash(msgSourceSubscription, i),
-						Raw: types.Log{
+						Raw: ethtypes.Log{
 							BlockNumber: 1024 + uint64(i),
 							BlockHash:   ethcommon.BytesToHash([]byte{1, 2, 3, byte(i)}),
 						},
@@ -332,7 +331,7 @@ func (s *EventListenerTestSuite) TestSmoke() {
 			for i := 1; i < 4; i++ {
 				sink <- &L1MessageSent{
 					MessageHash: getMsgHash(msgSourceSubscription, i),
-					Raw: types.Log{
+					Raw: ethtypes.Log{
 						BlockNumber: 1024 + uint64(i),
 						BlockHash:   ethcommon.BytesToHash([]byte{1, 2, 3, byte(i)}),
 					},
@@ -367,7 +366,7 @@ func (s *EventListenerTestSuite) TestSmoke() {
 		return []*L1MessageSent{
 			{
 				MessageHash: getMsgHash(msgSourceFetcher, callNumber+1),
-				Raw: types.Log{
+				Raw: ethtypes.Log{
 					BlockNumber: from,
 					BlockHash:   ethcommon.BytesToHash([]byte{1, 2, 3, 4}),
 				},

--- a/nil/services/rpc/internal/http/stack_test.go
+++ b/nil/services/rpc/internal/http/stack_test.go
@@ -78,7 +78,7 @@ func Test_checkPath(t *testing.T) {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Parallel()
 
-			assert.Equal(t, tt.expected, checkPath(tt.req, tt.prefix)) //nolint:scopelint
+			assert.Equal(t, tt.expected, checkPath(tt.req, tt.prefix))
 		})
 	}
 }

--- a/nil/services/rpc/internal/http/testaide.go
+++ b/nil/services/rpc/internal/http/testaide.go
@@ -51,7 +51,7 @@ func DoTestServer(
 
 		resp2 := rpcRequest(t, u, "origin", "bad")
 		defer resp2.Body.Close()
-		assert.Equal(t, "", resp2.Header.Get("Access-Control-Allow-Origin"))
+		assert.Empty(t, resp2.Header.Get("Access-Control-Allow-Origin"))
 	})
 
 	// TestVhosts makes sure vhosts is properly handled on the http server.

--- a/nil/services/rpc/jsonrpc/db_api.go
+++ b/nil/services/rpc/jsonrpc/db_api.go
@@ -39,7 +39,7 @@ func NewDbAPI(db db.ReadOnlyDB, logger logging.Logger) *DbAPIImpl {
 
 func (dbApi *DbAPIImpl) createRoTx(ctx context.Context) (db.RoTx, error) {
 	if dbApi.ts == nil {
-		return nil, errors.New("Timestamp is not initialized in DB API")
+		return nil, errors.New("timestamp is not initialized in DB API")
 	}
 	return dbApi.db.CreateRoTxAt(ctx, db.Timestamp(*dbApi.ts))
 }

--- a/nil/services/rpc/jsonrpc/eth_filters_test.go
+++ b/nil/services/rpc/jsonrpc/eth_filters_test.go
@@ -123,8 +123,8 @@ func (s *SuiteEthFilters) TestLogs() {
 	log1, ok := logs[1].(*RPCLog)
 	s.Require().True(ok)
 
-	s.Require().EqualValues(logsInput[0].Data, log0.Data)
-	s.Require().EqualValues(logsInput[3].Data, log1.Data)
+	s.Require().Equal(logsInput[0].Data, log0.Data)
+	s.Require().Equal(logsInput[3].Data, log1.Data)
 
 	logs, err = s.api.GetFilterChanges(s.ctx, id2)
 
@@ -135,8 +135,8 @@ func (s *SuiteEthFilters) TestLogs() {
 
 	s.Require().NoError(err)
 	s.Require().Len(logs, 2)
-	s.Require().EqualValues(logsInput[0].Data, log0.Data)
-	s.Require().EqualValues(logsInput2[0].Data, log1.Data)
+	s.Require().Equal(logsInput[0].Data, log0.Data)
+	s.Require().Equal(logsInput2[0].Data, log1.Data)
 }
 
 func (s *SuiteEthFilters) TestBlocks() {

--- a/nil/services/rpc/jsonrpc/test_block.go
+++ b/nil/services/rpc/jsonrpc/test_block.go
@@ -32,7 +32,7 @@ func writeTestBlock(t *testing.T, tx db.RwTx, shardId types.ShardId, blockNumber
 	hash := block.Hash(types.BaseShardId)
 	require.NoError(t, db.WriteBlock(tx, types.BaseShardId, hash, &block))
 
-	require.Equal(t, len(transactions), len(receipts))
+	require.Len(t, receipts, len(transactions))
 	inTxnHashes := make([]common.Hash, len(transactions))
 	for i, r := range receipts {
 		inTxnHashes[i] = r.TxnHash

--- a/nil/services/rpc/jsonrpc/types.go
+++ b/nil/services/rpc/jsonrpc/types.go
@@ -514,10 +514,10 @@ func toOutTransactions(input []*rpctypes.OutTransaction) ([]*OutTransaction, err
 			Transaction: &types.Transaction{},
 			ForwardKind: txn.ForwardKind,
 		}
-		if err := decoded.Transaction.UnmarshalSSZ(txn.TransactionSSZ); err != nil {
+		if err := decoded.UnmarshalSSZ(txn.TransactionSSZ); err != nil {
 			return nil, err
 		}
-		decoded.TxnHash = decoded.Transaction.Hash()
+		decoded.TxnHash = decoded.Hash()
 
 		output[i] = &OutTransaction{
 			Transaction:     decoded,

--- a/nil/services/rpc/rawapi/client.go
+++ b/nil/services/rpc/rawapi/client.go
@@ -276,7 +276,7 @@ func discoverAppropriatePeer(
 ) (network.PeerID, error) {
 	peersWithSpecifiedShard := networkManager.GetPeersForProtocol(protocol)
 	if len(peersWithSpecifiedShard) == 0 {
-		return "", fmt.Errorf("No peers with shard %d found", shardId)
+		return "", fmt.Errorf("no peers with shard %d found", shardId)
 	}
 	return peersWithSpecifiedShard[0], nil
 }

--- a/nil/services/rpc/rawapi/local_call.go
+++ b/nil/services/rpc/rawapi/local_call.go
@@ -87,7 +87,7 @@ func (api *LocalShardApi) handleOutTransactions(
 	outTransactions := make([]*rpctypes.OutTransaction, len(outTxns))
 
 	for i, outTxn := range outTxns {
-		raw, err := outTxn.Transaction.MarshalSSZ()
+		raw, err := outTxn.MarshalSSZ()
 		if err != nil {
 			return nil, err
 		}

--- a/nil/services/rpc/server_test.go
+++ b/nil/services/rpc/server_test.go
@@ -27,14 +27,14 @@ func TestParseSocketUrl(t *testing.T) {
 
 		socketUrl, err := url.Parse("unix:///some/file/path.sock")
 		require.NoError(t, err)
-		require.EqualValues(t, "/some/file/path.sock", socketUrl.Host+socketUrl.EscapedPath())
+		require.Equal(t, "/some/file/path.sock", socketUrl.Host+socketUrl.EscapedPath())
 	})
 	t.Run("tcp", func(t *testing.T) {
 		t.Parallel()
 
 		socketUrl, err := url.Parse("tcp://localhost:1234")
 		require.NoError(t, err)
-		require.EqualValues(t, "localhost:1234", socketUrl.Host+socketUrl.EscapedPath())
+		require.Equal(t, "localhost:1234", socketUrl.Host+socketUrl.EscapedPath())
 	})
 }
 

--- a/nil/services/synccommittee/core/batches/encode/v1/decoder.go
+++ b/nil/services/synccommittee/core/batches/encode/v1/decoder.go
@@ -27,7 +27,7 @@ func NewDecoder(logger logging.Logger) *decoder {
 	}
 }
 
-// decodes data data from binary format into human readable
+// decodes data from binary format into human readable
 // intermediate form (transaction in proto format encoded to protojson)
 // in case of need to access decoded data programmatically (from sync_committee or other cluster parts)
 // this decoder might be extended with returning something like types.BlockBatch functionality

--- a/nil/services/synccommittee/core/proposer_test.go
+++ b/nil/services/synccommittee/core/proposer_test.go
@@ -181,7 +181,7 @@ func (s *ProposerTestSuite) TestSendProof() {
 }
 
 // Only UpdateState tx should be created
-func (s *ProposerTestSuite) TestSendProofCommitedBatch() {
+func (s *ProposerTestSuite) TestSendProofCommittedBatch() {
 	// Calls inside CommitBatch
 	s.callContractMock.AddExpectedCall("isBatchCommitted", true)
 	// Calls inside UpdateState

--- a/nil/services/synccommittee/internal/rollupcontract/commit_batch.go
+++ b/nil/services/synccommittee/internal/rollupcontract/commit_batch.go
@@ -28,7 +28,7 @@ func (r *Wrapper) CommitBatch(
 ) (*ethtypes.Transaction, error) {
 	callOpts, cancel := r.getEthCallOpts(ctx)
 	defer cancel()
-	isCommited, err := r.rollupContract.IsBatchCommitted(callOpts, batchIndex)
+	isCommitted, err := r.rollupContract.IsBatchCommitted(callOpts, batchIndex)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func (r *Wrapper) CommitBatch(
 		return nil, err
 	}
 
-	if isCommited {
+	if isCommitted {
 		return signedTx, ErrBatchAlreadyCommitted
 	}
 

--- a/nil/services/synccommittee/internal/storage/block_storage_test.go
+++ b/nil/services/synccommittee/internal/storage/block_storage_test.go
@@ -392,10 +392,7 @@ func (s *BlockStorageTestSuite) Test_TryGetNextProposalData_Concurrently() {
 	var receivedData []*scTypes.ProposalData
 	proofGroup.Go(func() error {
 		// poll all blocks data from the storage
-		for {
-			if len(receivedData) == batchesCount {
-				break
-			}
+		for len(receivedData) != batchesCount {
 			select {
 			case <-s.ctx.Done():
 				return s.ctx.Err()

--- a/nil/services/synccommittee/prover/commands/aggregate_challenges.go
+++ b/nil/services/synccommittee/prover/commands/aggregate_challenges.go
@@ -40,11 +40,11 @@ func (cmd *aggregateChallengesCmd) BeforeCommandExecuted(
 	for i, filename := range thetaPowerFiles {
 		bytes, err := os.ReadFile(filename)
 		if err != nil {
-			return fmt.Errorf("Cannot read theta power file: %w", err)
+			return fmt.Errorf("cannot read theta power file: %w", err)
 		}
 		num, err := strconv.Atoi(strings.TrimSpace(string(bytes)))
 		if err != nil {
-			return fmt.Errorf("Couldn't convert theta file content to integer: %w", err)
+			return fmt.Errorf("couldn't convert theta file content to integer: %w", err)
 		}
 		thetas[i] = num
 	}

--- a/nil/services/synccommittee/prover/commands/combined_q.go
+++ b/nil/services/synccommittee/prover/commands/combined_q.go
@@ -30,10 +30,10 @@ func fetchStartingThetaPower(task *types.Task) (int, error) {
 	var aggregatedThetas []int
 	marshaledThetas, err := os.ReadFile(aggThetasFile)
 	if err != nil {
-		return 0, fmt.Errorf("Unable to read aggregated theta file: %w", err)
+		return 0, fmt.Errorf("unable to read aggregated theta file: %w", err)
 	}
 	if err := json.Unmarshal(marshaledThetas, &aggregatedThetas); err != nil {
-		return 0, fmt.Errorf("Unable to unmarshal aggregated theta file: %w", err)
+		return 0, fmt.Errorf("unable to unmarshal aggregated theta file: %w", err)
 	}
 	return aggregatedThetas[uint8(task.CircuitType)-types.CircuitStartIndex], nil
 }

--- a/nil/services/synccommittee/prover/commands/commands.go
+++ b/nil/services/synccommittee/prover/commands/commands.go
@@ -72,7 +72,7 @@ func aggregateCircuitDependencies(
 			path, ok := res.OutputArtifacts[resultType]
 			if !ok {
 				return nil,
-					fmt.Errorf("Inconsistent task %v , dependencyType %v has no expected result %v",
+					fmt.Errorf("inconsistent task %v , dependencyType %v has no expected result %v",
 						task.Id.String(),
 						dependencyType.String(),
 						resultType.String())
@@ -82,7 +82,7 @@ func aggregateCircuitDependencies(
 	}
 	if len(depFiles) != int(types.CircuitAmount) {
 		return nil,
-			fmt.Errorf("Insufficient input for task %v with type %v on %v dependency: expected %d, actual %d",
+			fmt.Errorf("insufficient input for task %v with type %v on %v dependency: expected %d, actual %d",
 				task.Id.String(),
 				task.TaskType.String(),
 				dependencyType,
@@ -108,7 +108,7 @@ func findDependencyResult(
 		if res.TaskType == dependencyType {
 			if foundFile != "" {
 				return "", fmt.Errorf(
-					"More then one %v files was found as a result for %v dependency",
+					"more then one %v files was found as a result for %v dependency",
 					resultType.String(), dependencyType.String())
 			}
 			path, ok := res.OutputArtifacts[resultType]

--- a/nil/services/synccommittee/prover/tracer/stack_op_tracer.go
+++ b/nil/services/synccommittee/prover/tracer/stack_op_tracer.go
@@ -352,7 +352,7 @@ func (sot *StackOpTracer) TraceOp(opCode vm.OpCode, pc uint64, scope tracing.OpC
 	sot.scope = scope
 
 	if !sot.traceBasicOp() && !sot.traceDupOp() && !sot.traceSwapOp() {
-		return fmt.Errorf("No stack save info for opcode: %v", opCode)
+		return fmt.Errorf("no stack save info for opcode: %v", opCode)
 	}
 	return nil
 }

--- a/nil/services/synccommittee/prover/tracer/storage_tracer_test.go
+++ b/nil/services/synccommittee/prover/tracer/storage_tracer_test.go
@@ -31,10 +31,11 @@ func traceStorageOperation(t *testing.T, tracer *StorageOpTracer, opCode vm.OpCo
 	traced, err := tracer.TraceOp(opCode, pc, context)
 	require.NoError(t, err)
 
-	if opCode == vm.SSTORE {
+	switch opCode { //nolint: exhaustive
+	case vm.SSTORE:
 		// mimic `opSstore`
 		stack = stack[:0]
-	} else if opCode == vm.SLOAD {
+	case vm.SLOAD:
 		// mimic `opSload`
 		stack = []uint256.Int{val}
 	}

--- a/nil/services/synccommittee/prover/tracer/tracer_mock_client_test.go
+++ b/nil/services/synccommittee/prover/tracer/tracer_mock_client_test.go
@@ -500,8 +500,8 @@ func (s *TracerMockClientTestSuite) TestKeccakOpCodeTracing() {
 
 	// check keccak tracer
 	s.Require().Len(traceData.KeccakTraces, 2)
-	s.EqualValues(dataToCopy, traceData.KeccakTraces[0].buf)
+	s.Equal(dataToCopy, traceData.KeccakTraces[0].buf)
 	s.EqualValues(expectedHash, traceData.KeccakTraces[0].hash)
-	s.EqualValues(dataToCopy, traceData.KeccakTraces[1].buf)
+	s.Equal(dataToCopy, traceData.KeccakTraces[1].buf)
 	s.EqualValues(expectedHash, traceData.KeccakTraces[1].hash)
 }

--- a/nil/services/synccommittee/prover/tracer/tracer_nild_test.go
+++ b/nil/services/synccommittee/prover/tracer/tracer_nild_test.go
@@ -261,12 +261,12 @@ func (s *TracerNildTestSuite) checkTracesSerialization(traces *ExecutionTraces) 
 
 	// Check if no data was lost after deserialization
 
-	s.Require().Equal(len(deserializedTraces.StackOps), len(traces.StackOps))
-	s.Require().Equal(len(deserializedTraces.MemoryOps), len(traces.MemoryOps))
-	s.Require().Equal(len(deserializedTraces.StorageOps), len(traces.StorageOps))
-	s.Require().Equal(len(deserializedTraces.ContractsBytecode), len(traces.ContractsBytecode))
-	s.Require().Equal(len(deserializedTraces.CopyEvents), len(traces.CopyEvents))
-	s.Require().Equal(len(deserializedTraces.ZKEVMStates), len(traces.ZKEVMStates))
+	s.Require().Len(traces.StackOps, len(deserializedTraces.StackOps))
+	s.Require().Len(traces.MemoryOps, len(deserializedTraces.MemoryOps))
+	s.Require().Len(traces.StorageOps, len(deserializedTraces.StorageOps))
+	s.Require().Len(traces.ContractsBytecode, len(deserializedTraces.ContractsBytecode))
+	s.Require().Len(traces.CopyEvents, len(deserializedTraces.CopyEvents))
+	s.Require().Len(traces.ZKEVMStates, len(deserializedTraces.ZKEVMStates))
 }
 
 // Even smart account deploy is handled in multiple blocks, trace last N blocks for each shard to include

--- a/nil/services/synccommittee/prover/tracer/zkevm_state_tracer.go
+++ b/nil/services/synccommittee/prover/tracer/zkevm_state_tracer.go
@@ -120,7 +120,7 @@ func (zst *ZKEVMStateTracer) TraceOp(
 func (zst *ZKEVMStateTracer) SetLastStateStorage(key, value types.Uint256) error {
 	stateNum := len(zst.res)
 	if stateNum == 0 {
-		return errors.New("Attempt to add storage operation without initializing zkEVM state")
+		return errors.New("attempt to add storage operation without initializing zkEVM state")
 	}
 
 	lastRes := &zst.res[stateNum-1]

--- a/nil/services/txnpool/txnpool_test.go
+++ b/nil/services/txnpool/txnpool_test.go
@@ -354,7 +354,7 @@ func (s *SuiteTxnPool) checkTransactionsOrder(vals ...int) {
 
 	txns := s.getTransactions()
 
-	s.Require().Equal(len(vals), len(txns))
+	s.Require().Len(txns, len(vals))
 
 	correct := true
 	for i, txn := range txns {

--- a/nil/tests/archive_node/archive_node_test.go
+++ b/nil/tests/archive_node/archive_node_test.go
@@ -123,7 +123,7 @@ func (s *SuiteArchiveNode) TestRestarts() {
 func (s *SuiteArchiveNode) TestGetFaucetBalance() {
 	value, err := s.DefaultClient.GetBalance(s.Context, types.FaucetAddress, "latest")
 	s.Require().NoError(err)
-	s.Positive(value.Uint64())
+	s.NotZero(value.Uint64())
 }
 
 func TestArchiveNodeWithBootstrapPeers(t *testing.T) {

--- a/nil/tests/basic/basic_test.go
+++ b/nil/tests/basic/basic_test.go
@@ -319,7 +319,7 @@ func (s *SuiteRpc) TestRpcCallWithTransactionSend() { //nolint:maintidx
 
 		txnEstimation, err = s.Client.EstimateFee(s.Context, callArgs, "latest")
 		s.Require().NoError(err)
-		s.Positive(txnEstimation.FeeCredit.Uint64())
+		s.NotZero(txnEstimation.FeeCredit.Uint64())
 	})
 
 	intTxn := &types.InternalTransactionPayload{
@@ -349,7 +349,7 @@ func (s *SuiteRpc) TestRpcCallWithTransactionSend() { //nolint:maintidx
 	s.Run("Estimate external transaction fee", func() {
 		estimation, err = s.Client.EstimateFee(s.Context, callArgs, "latest")
 		s.Require().NoError(err)
-		s.Positive(estimation.FeeCredit.Uint64())
+		s.NotZero(estimation.FeeCredit.Uint64())
 	})
 
 	s.Run("Call without override", func() {

--- a/nil/tests/cli/cli_test.go
+++ b/nil/tests/cli/cli_test.go
@@ -200,7 +200,7 @@ func (s *SuiteCliService) TestContract() {
 	balanceAfter, err := s.cli.GetBalance(addr)
 	s.Require().NoError(err)
 
-	s.EqualValues(uint64(100), balanceAfter.Uint64()-balanceBefore.Uint64())
+	s.Equal(uint64(100), balanceAfter.Uint64()-balanceBefore.Uint64())
 }
 
 func (s *SuiteCliService) testNewSmartAccountOnShard(shardId types.ShardId) {

--- a/nil/tests/faucet/faucet_test.go
+++ b/nil/tests/faucet/faucet_test.go
@@ -108,7 +108,7 @@ func (s *SuiteFaucet) TestDeployContractViaFaucet() {
 	balance, err := s.DefaultClient.GetBalance(s.Context, smartAccountAddr, "latest")
 	s.Require().NoError(err)
 	s.Require().Less(balance.Uint64(), value.Uint64())
-	s.Require().Positive(balance.Uint64())
+	s.Require().NotZero(balance.Uint64())
 	logging.GlobalLogger.Info().Msgf("Spent %s nil", value.Sub(balance))
 }
 

--- a/nil/tests/faucet_service/faucet_service_test.go
+++ b/nil/tests/faucet_service/faucet_service_test.go
@@ -105,7 +105,7 @@ func (s *FaucetRpc) TestSendToken() {
 		expectedTokens[types.TokenId(addr.Bytes())] = amount
 		s.topUpAndWait(addr, wallet, amount)
 	}
-	tokens, err := s.RpcSuite.Client.GetTokens(s.Context, wallet, "latest")
+	tokens, err := s.Client.GetTokens(s.Context, wallet, "latest")
 	s.Require().NoError(err)
 	s.Require().Equal(expectedTokens, tokens)
 }

--- a/nil/tests/multitoken/multitoken_test.go
+++ b/nil/tests/multitoken/multitoken_test.go
@@ -545,7 +545,7 @@ func (s *SuiteMultiTokenRpc) TestTokenViaCall() {
 	}, "latest", nil)
 	s.Require().NoError(err)
 	s.Require().Empty(res.Error)
-	s.Require().Positive(res.CoinsUsed.Uint64())
+	s.Require().NotZero(res.CoinsUsed.Uint64())
 }
 
 func (s *SuiteMultiTokenRpc) TestRemoveEmptyToken() {

--- a/nil/tests/nil_load_generator_service/nil_load_generator_test.go
+++ b/nil/tests/nil_load_generator_service/nil_load_generator_test.go
@@ -91,7 +91,7 @@ func (s *NilLoadGeneratorRpc) TestSmartAccountBalanceModification() {
 	}, 60*time.Second, 100*time.Millisecond)
 
 	for i, addr := range resSmartAccounts {
-		s.Require().Positive(smartAccountsBalance[i].Uint64(),
+		s.Require().NotZero(smartAccountsBalance[i].Uint64(),
 			"Zero balance for smart account %d, addr %s", i, addr)
 	}
 

--- a/nil/tests/rpc_node/rpc_node_test.go
+++ b/nil/tests/rpc_node/rpc_node_test.go
@@ -59,7 +59,7 @@ func (s *SuiteRpcNode) TestRpcNode() {
 		s.Require().NoError(err)
 		s.Require().NotNil(block)
 		s.NotEmpty(block.ChildBlocks)
-		s.Positive(block.DbTimestamp)
+		s.NotZero(block.DbTimestamp)
 	})
 
 	s.Run("TestGetBlockTransactionCount", func() {
@@ -113,11 +113,11 @@ func (s *SuiteRpcNode) TestRpcNode() {
 	s.Run("TestGasPrice", func() {
 		value, err := s.DefaultClient.GasPrice(s.Context, types.MainShardId)
 		s.Require().NoError(err)
-		s.Positive(value.Uint64())
+		s.NotZero(value.Uint64())
 
 		value, err = s.DefaultClient.GasPrice(s.Context, types.BaseShardId)
 		s.Require().NoError(err)
-		s.Positive(value.Uint64())
+		s.NotZero(value.Uint64())
 	})
 }
 

--- a/nil/tests/rpc_service/rpc_service_test.go
+++ b/nil/tests/rpc_service/rpc_service_test.go
@@ -109,7 +109,7 @@ func (s *SuiteRpcService) TestRpcDebugModules() {
 	s.Require().NoError(err)
 
 	s.Require().NotEmpty(block.Id)
-	s.Require().NotEqual(common.EmptyHash, block.Block.Hash(types.BaseShardId))
+	s.Require().NotEqual(common.EmptyHash, block.Hash(types.BaseShardId))
 	s.Require().NotEmpty(res.Content)
 
 	fullRes, err := s.Client.GetDebugBlock(s.Context, types.BaseShardId, "latest", true)

--- a/nix/nil.nix
+++ b/nix/nil.nix
@@ -12,8 +12,6 @@
 , go-tools
 , gotools
 , golangci-lint
-, gofumpt
-, gci
 , delve
 , gopls
 , protoc-gen-go
@@ -73,8 +71,6 @@ buildGo124Module rec {
     (overrideBuildGoModule go-tools)
     (overrideBuildGoModule gopls)
     golangci-lint
-    (overrideBuildGoModule gofumpt)
-    (overrideBuildGoModule gci)
     (overrideBuildGoModule delve)
     (overrideBuildGoModule protoc-gen-go)
   ];

--- a/nix/nildocs.nix
+++ b/nix/nildocs.nix
@@ -52,7 +52,6 @@ stdenv.mkDerivation rec {
   '';
 
   preBuild = ''
-    export HOME="$TMPDIR"
     mkdir -p ~/.gsolc-select/artifacts/solc-0.8.28
     ln -f -s ${solc}/bin/solc ~/.gsolc-select/artifacts/solc-0.8.28/solc-0.8.28
   '';


### PR DESCRIPTION
New major release of golangci-lint - 2.0.0.

Should suppress https://github.com/NilFoundation/nil/pull/700