### PR TITLE
Corrected Typos in Key Function and Variable Names

### DIFF
--- a/nil/services/synccommittee/core/proposer_test.go
+++ b/nil/services/synccommittee/core/proposer_test.go
@@ -181,7 +181,7 @@ func (s *ProposerTestSuite) TestSendProof() {
 }
 
 // Only UpdateState tx should be created
-func (s *ProposerTestSuite) TestSendProofCommitedBatch() {
+func (s *ProposerTestSuite) TestSendProofCommittedBatch() {
 	// Calls inside CommitBatch
 	s.callContractMock.AddExpectedCall("isBatchCommitted", true)
 	// Calls inside UpdateState

--- a/nil/services/synccommittee/internal/rollupcontract/commit_batch.go
+++ b/nil/services/synccommittee/internal/rollupcontract/commit_batch.go
@@ -28,7 +28,7 @@ func (r *Wrapper) CommitBatch(
 ) (*ethtypes.Transaction, error) {
 	callOpts, cancel := r.getEthCallOpts(ctx)
 	defer cancel()
-	isCommited, err := r.rollupContract.IsBatchCommitted(callOpts, batchIndex)
+	isCommitted, err := r.rollupContract.IsBatchCommitted(callOpts, batchIndex)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func (r *Wrapper) CommitBatch(
 		return nil, err
 	}
 
-	if isCommited {
+	if isCommitted {
 		return signedTx, ErrBatchAlreadyCommitted
 	}
 


### PR DESCRIPTION
This PR addresses critical typos in both function and variable identifiers which could lead to confusion, reduce code quality, and hinder maintainability.

proposer_test.go
Function renamed:

TestSendProofCommitedBatch ➝ TestSendProofCommittedBatch

🛠 Fixes a spelling error in the function name, ensuring clarity and alignment with naming conventions.

commit_batch.go
Variable renamed:

isCommited ➝ isCommitted (fixed in two places)

✅ Enhances accuracy and readability in core logic for checking batch commitment status.