### PR TITLE
[misc] corrected licence files in READMEs

### DIFF
--- a/create-nil-hardhat-project/README.MD
+++ b/create-nil-hardhat-project/README.MD
@@ -110,4 +110,4 @@ This project is currently under active development. Not all features are fully i
 
 ## License
 
-[MIT](./LICENSE)
+[MIT](./LICENCE)

--- a/docs/README.md
+++ b/docs/README.md
@@ -74,4 +74,4 @@ npm run test path/to/test
 
 ## License
 
-[MIT](./LICENSE)
+[MIT](./LICENCE)

--- a/smart-contracts/README.md
+++ b/smart-contracts/README.md
@@ -49,9 +49,3 @@ pragma solidity ^0.8.0;
 
 import "@nilfoundation/smart-contracts/contracts/SmartAccount.sol";
 ```
-
-## License
-
-[MIT](./LICENSE)
-
-


### PR DESCRIPTION
## Short Summary

This diff corrects three README files so they point to correct licences if applicable. The contribution was made by @donatik27.

## What Changes Were Made

- Changed `create-hardhard-project` README to point to the correct licence file
- Changed docs README to the correct licence file
- Removed licence information from `smart-contracts` README

## Related Issue

Addresses #707 

## Checklist

_Please mark each item with an `x` inside the brackets (e.g., [x]) once completed._

- [x] I have read and followed the [Contributing Guide](https://github.com/NilFoundation/nil/blob/main/CONTRIBUTION-GUIDE.md)
- [x] I have tested the changes locally
- [x] I have added relevant tests (if applicable)
- [x] I have updated documentation/comments (if applicable)
