### PR TITLE
[rpc] Do not return error if effective priority fee calculation failed

### DIFF
--- a/nil/services/rpc/rawapi/local.go
+++ b/nil/services/rpc/rawapi/local.go
@@ -19,6 +19,7 @@ type LocalShardApi struct {
 	enableDevApi bool
 
 	nodeApi NodeApi
+	logger  logging.Logger
 }
 
 var (
@@ -34,6 +35,7 @@ func NewLocalShardApi(shardId types.ShardId, db db.ReadOnlyDB, txnpool txnpool.P
 		ShardId:      shardId,
 		txnpool:      txnpool,
 		enableDevApi: enableDevApi,
+		logger:       logging.NewLogger("local_api"),
 	}
 }
 


### PR DESCRIPTION
It is a valid situation, in which case the status should be equal to `BaseFeeTooHigh`.