### PR TITLE
[playground] remove rpcUrl validation

### DIFF
--- a/explorer_frontend/biome.json
+++ b/explorer_frontend/biome.json
@@ -16,7 +16,7 @@
         "useKeyWithClickEvents": "off"
       },
       "correctness": {
-        "useExhaustiveDependencies": "off"
+        "useExhaustiveDependencies": "warn"
       }
     }
   },

--- a/explorer_frontend/src/features/account-connector/model.ts
+++ b/explorer_frontend/src/features/account-connector/model.ts
@@ -41,7 +41,10 @@ export const createSmartAccountFx = accountConnectorDomain.createEffect<
     privateKey: Hex;
     rpcUrl: string;
   },
-  SmartAccountV1
+  {
+    smartAccount: SmartAccountV1;
+    rpcUrl: string;
+  }
 >();
 
 export const topUpSmartAccountBalanceFx = accountConnectorDomain.createEffect<
@@ -49,7 +52,7 @@ export const topUpSmartAccountBalanceFx = accountConnectorDomain.createEffect<
   bigint
 >();
 
-export const initilizeSmartAccount = createEvent();
+export const initilizeSmartAccount = createEvent<string>();
 
 export const regenrateAccountEvent = createEvent();
 

--- a/explorer_frontend/src/features/account-connector/validation.ts
+++ b/explorer_frontend/src/features/account-connector/validation.ts
@@ -5,15 +5,6 @@ export type ValidationResult = {
   isValid: boolean;
 };
 
-// Validates if the provided RPC url matches the expected format
-export const validateRpcUrl = (rpcUrl: string): ValidationResult => {
-  const RPC_REGEX = /^https:\/\/api\.devnet\.nil\.foundation\/api\/.+\/.+$/;
-  if (RPC_REGEX.test(rpcUrl)) {
-    return { isValid: true, error: "" };
-  }
-  return { isValid: false, error: "Invalid RPC rpcUrl format" };
-};
-
 export const MAX_AMOUNT_NIL = 1;
 export const MIN_AMOUNT_NIL = 0.0001;
 export const MAX_AMOUNT_OTHER = 100;


### PR DESCRIPTION
This diff contains two changes:
- Validation of the rpc url is removed. The reason behind that is that validation was too strict and user was not able to develop playground locally. 
- Rpc url is now set only after successful wallet creation. It's kinda obvious - there is no need in rpc url if you don't have a wallet. There was a buggy scenario when user tries to create a wallet with some rpc url, which passed validation, but request is not successful. In that case rpc url is going to be set without wallet creation and user is going to receive message "Something wrong with the network" every time the page is open.