### PR TITLE
relayer debug: add smart account creation

### DIFF
--- a/nil/cmd/relayer/main.go
+++ b/nil/cmd/relayer/main.go
@@ -121,6 +121,25 @@ func addRunCommandFlags(runCmd *cobra.Command, cfg *Config) {
 		cfg.TransactionSenderConfig.DbPollInterval,
 		"Poll interval for L2 transaction sender",
 	)
+
+	// L2 debug mode flags
+	runCmd.Flags().BoolVar(&cfg.L2ContractConfig.DebugMode,
+		"l2-debug-mode", false, "Enable debug mode for L2 transaction sender",
+	)
+
+	runCmd.Flags().StringVar(
+		&cfg.L2ContractConfig.SmartAccountSalt,
+		"l2-smart-account-salt",
+		"",
+		"Salt for L2 smart account (debug-only)",
+	)
+
+	runCmd.Flags().StringVar(
+		&cfg.L2ContractConfig.FaucetAddress,
+		"l2-faucet-address",
+		"",
+		"Faucet address for L2 transaction sender (debug-only)",
+	)
 }
 
 func runService(ctx context.Context, cfg *Config) error {

--- a/nil/services/cliservice/faucet.go
+++ b/nil/services/cliservice/faucet.go
@@ -174,7 +174,7 @@ func (s *Service) CreateSmartAccount(
 		return types.EmptyAddress, err
 	}
 	if len(code) > 0 {
-		return types.EmptyAddress, fmt.Errorf("%w: %s", ErrSmartAccountExists, smartAccountAddress)
+		return smartAccountAddress, fmt.Errorf("%w: %s", ErrSmartAccountExists, smartAccountAddress)
 	}
 
 	// NOTE: we deploy smart account code with ext transaction

--- a/nil/services/relayer/internal/l2/init.go
+++ b/nil/services/relayer/internal/l2/init.go
@@ -1,0 +1,129 @@
+package l2
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/NilFoundation/nil/nil/client"
+	"github.com/NilFoundation/nil/nil/client/rpc"
+	"github.com/NilFoundation/nil/nil/common/check"
+	"github.com/NilFoundation/nil/nil/common/logging"
+	"github.com/NilFoundation/nil/nil/internal/types"
+	"github.com/NilFoundation/nil/nil/services/cliservice"
+	"github.com/NilFoundation/nil/nil/services/faucet"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+func InitL2(
+	ctx context.Context,
+	logger logging.Logger,
+	config *ContractConfig,
+) (client.Client, types.Address, error) {
+	l2Client := rpc.NewClient(
+		config.Endpoint,
+		logger,
+	)
+	ver, err := l2Client.ClientVersion(ctx)
+	if err != nil {
+		return nil, types.EmptyAddress, err
+	}
+	logger.Info().Str("client_version", ver).Msg("connected to L2")
+
+	if !config.DebugMode {
+		return l2Client, types.EmptyAddress, nil
+	}
+
+	addr, err := initDebugL2SmartAccount(ctx, l2Client, logger, config)
+	if err != nil {
+		return nil, types.EmptyAddress, fmt.Errorf("failed to init debug L2 smart account: %w", err)
+	}
+
+	return l2Client, addr, nil
+}
+
+func initDebugL2SmartAccount(
+	ctx context.Context,
+	l2Client client.Client,
+	logger logging.Logger,
+	config *ContractConfig,
+) (types.Address, error) {
+	logger = logger.With().Bool("debug_mode", true).Logger()
+	logger.Warn().Msg("key/account generation enabled, this is not recommended for production")
+
+	var keyExists bool
+	_, err := os.Stat(config.PrivateKeyPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return types.EmptyAddress, err
+		}
+	} else {
+		keyExists = true
+		logger.Debug().Str("key_path", config.PrivateKeyPath).Msg("found generated key")
+	}
+
+	var key *ecdsa.PrivateKey
+	if !keyExists {
+		logger.Warn().
+			Str("key_path", config.PrivateKeyPath).
+			Msg("private key not found, generating it")
+
+		key, err = crypto.GenerateKey()
+		if err != nil {
+			return types.EmptyAddress, err
+		}
+
+		if err := crypto.SaveECDSA(config.PrivateKeyPath, key); err != nil {
+			return types.EmptyAddress, err
+		}
+		logger.Info().Msg("key generated")
+	} else {
+		key, err = crypto.LoadECDSA(config.PrivateKeyPath)
+		if err != nil {
+			return types.EmptyAddress, fmt.Errorf("failed to load private key: %w", err)
+		}
+	}
+
+	faucetClient := faucet.NewClient(config.FaucetAddress)
+
+	debugDeployer := cliservice.NewService(ctx, l2Client, key, faucetClient)
+
+	amount := types.NewValueFromUint64(2_000_000_000_000_000)
+	fee := types.NewFeePackFromFeeCredit(types.NewValueFromUint64(200_000_000_000_000))
+
+	salt := types.NewUint256(0)
+	if len(config.SmartAccountSalt) > 0 {
+		salt, err = types.NewUint256FromDecimal(config.SmartAccountSalt)
+		if err != nil {
+			return types.EmptyAddress, fmt.Errorf("failed to parse smart account salt: %w", err)
+		}
+	} else {
+		logger.Warn().Msg("smart account salt is not set, using default")
+	}
+
+	addr, err := debugDeployer.CreateSmartAccount(
+		types.BaseShardId,
+		salt,
+		amount,
+		fee,
+		&key.PublicKey,
+	)
+	if errors.Is(err, cliservice.ErrSmartAccountExists) {
+		if config.SmartAccountAddress != "" {
+			check.PanicIfNotf(
+				config.SmartAccountAddress == addr.Hex(),
+				"smart account address mismatch: %s vs %s",
+				config.SmartAccountAddress, addr.Hex(),
+			)
+		}
+		logger.Info().Str("smart_account_address", addr.Hex()).Msg("smart account already exists")
+		return addr, nil
+	}
+	if err != nil {
+		return types.EmptyAddress, fmt.Errorf("failed to create smart account: %w", err)
+	}
+
+	return addr, nil
+}

--- a/nil/services/relayer/internal/l2/utils.go
+++ b/nil/services/relayer/internal/l2/utils.go
@@ -1,0 +1,25 @@
+package l2
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/NilFoundation/nil/nil/client"
+	"github.com/NilFoundation/nil/nil/internal/types"
+)
+
+func checkIfContractExists(
+	ctx context.Context,
+	nilClient client.Client,
+	addr types.Address,
+) (bool, error) {
+	accountCode, err := nilClient.GetCode(ctx, addr, "latest")
+	if err != nil {
+		return false, fmt.Errorf("failed to check presence of the relayer L2 smart account(%s): %w", addr, err)
+	}
+	if len(accountCode) == 0 {
+		return false, nil
+	}
+
+	return true, nil
+}


### PR DESCRIPTION
## Short Summary

This PR adds support for debug relayer CLI options

## What Changes Were Made

- Now with l2-debug CLI options salt and faucet service endpoint can be passed to service. It will try to automatically create smart account in nild in that case

## Checklist

- [x] I have read and followed the [Contributing Guide](https://github.com/NilFoundation/nil/blob/main/CONTRIBUTION-GUIDE.md)
- [x] I have tested the changes locally
- [x] I have updated documentation/comments (if applicable)
