### PR TITLE
[docs] fix node_modules for docsaibackend.nix

### DIFF
--- a/nix/docsaibackend.nix
+++ b/nix/docsaibackend.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, callPackage, pnpm_10, nodejs }:
+{ lib, stdenv, callPackage, pnpm_10, nodejs, rsync }:
 
 stdenv.mkDerivation rec {
   name = "aibackend";
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   NODE_PATH = "$npmDeps";
 
-  nativeBuildInputs = [ nodejs nodejs.python pnpm_10 pnpm_10.configHook ];
+  nativeBuildInputs = [ nodejs nodejs.python pnpm_10 pnpm_10.configHook rsync ];
 
   preUnpack = ''
     echo "Setting UV_USE_IO_URING=0 to work around the io_uring kernel bug"
@@ -33,8 +33,9 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out
-    mv smart-contracts $out/smart-contracts
-    mv node_modules $out/node_modules
-    mv docs_ai_backend/ $out/docs_ai_backend
+    # replace pnpm synlinks in node_modules with real files
+    rsync -aL node_modules/ $out/node_modules/
+    rsync -aL docs_ai_backend/ $out/docs_ai_backend/
+    rsync -aL smart-contracts/ $out/smart-contracts/
   '';
 }


### PR DESCRIPTION
This diff fixes `node_modules` contents that are placed into the deb package.
Since we use `pnpm` as a node package manager, we have non-standard `node_modules` structure. It contains mostly symlinks to `pnpm` global store.

If i call `ls -la node_modules/next` i get `.pnpm/next@15.2.3_@opentelemetry+api@1.9.0_@playwright+test@1.51.1_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/next`. Obviously, it can not be used on the target deployment machine, because the `pnpm` store is not reproduced there.