### PR TITLE
[collate] add block number to log message

### DIFF
--- a/nil/cmd/nild/main.go
+++ b/nil/cmd/nild/main.go
@@ -128,7 +128,7 @@ func parseArgs() *nildconfig.Config {
 		&cfg.AdminSocketPath,
 		"admin-socket-path",
 		cfg.AdminSocketPath,
-		"unix socket path to start admin server on (disabled if empty)}")
+		"unix socket path to start admin server on (disabled if empty)")
 	rootCmd.PersistentFlags().StringVar(
 		&cfg.ReadThrough.SourceAddr,
 		"read-through-db-addr",

--- a/nil/internal/collate/scheduler.go
+++ b/nil/internal/collate/scheduler.go
@@ -143,7 +143,8 @@ func (s *Scheduler) doCollate(ctx context.Context) error {
 				cancelFn()
 				err := <-consCh
 				s.logger.Debug().
-					Uint64(logging.FieldBlockNumber, height).
+					Uint64(logging.FieldHeight, height).
+					Uint64(logging.FieldBlockNumber, uint64(event.blockNumber)).
 					Err(err).
 					Msg("Consensus interrupted by syncer")
 				return nil


### PR DESCRIPTION
It's possible that consensus is interrupted by syner if it committed more fresh block than consensus height. But it's quite interesting to be able to compare consensus height and block number. This patch adds such info.
