### PR TITLE
[tests] fix race in TestRpcNode

### DIFF
--- a/nil/tests/sharded_suite.go
+++ b/nil/tests/sharded_suite.go
@@ -354,7 +354,9 @@ func (s *ShardedSuite) EnsureArchiveNodeStarted(
 ) (client.Client, network.AddrInfo) {
 	s.T().Helper()
 
+	s.Wg.Add(1)
 	go func() {
+		defer s.Wg.Done()
 		err := <-rc
 		s.NoError(err)
 	}()


### PR DESCRIPTION
Because of working goroutine we had race condition in the code. This patch tries to fix it. Stacktrace was following:
```
2025-04-01T13:07:32.6077719Z nil> ==================
2025-04-01T13:07:32.6077836Z nil> WARNING: DATA RACE
2025-04-01T13:07:32.6077970Z nil> Write at 0x00c0004024d0 by goroutine 28:
2025-04-01T13:07:32.6078141Z nil>   github.com/stretchr/testify/suite.(*Suite).SetT()
2025-04-01T13:07:32.6078428Z nil>       /build/source/vendor/github.com/stretchr/testify/suite/suite.go:46 +0x136
2025-04-01T13:07:32.6078593Z nil>   github.com/stretchr/testify/suite.Run.func1.1()
2025-04-01T13:07:32.6078879Z nil>       /build/source/vendor/github.com/stretchr/testify/suite/suite.go:187 +0x347
2025-04-01T13:07:32.6078994Z nil>   runtime.deferreturn()
2025-04-01T13:07:32.6079398Z nil>       /nix/store/g29rrn8qqlg4yjqv543ryrkimr7fk43h-go-1.24.1/share/go/src/runtime/panic.go:610 +0x5d
...
2025-04-01T13:07:32.6185118Z nil>
2025-04-01T13:07:32.6185292Z nil> Previous read at 0x00c0004024d0 by goroutine 23854:
2025-04-01T13:07:32.6185636Z nil>   github.com/NilFoundation/nil/nil/tests.(*ShardedSuite).EnsureArchiveNodeStarted.func1()
2025-04-01T13:07:32.6185813Z nil>       /build/source/nil/tests/sharded_suite.go:359 +0x64
2025-04-01T13:07:32.6185900Z nil>
2025-04-01T13:07:32.6186020Z nil> Goroutine 28 (running) created at:
2025-04-01T13:07:32.6186138Z nil>   testing.(*T).Run()
2025-04-01T13:07:32.6186524Z nil>       /nix/store/g29rrn8qqlg4yjqv543ryrkimr7fk43h-go-1.24.1/share/go/src/testing/testing.go:1851 +0x8f2
2025-04-01T13:07:32.6186685Z nil>   github.com/stretchr/testify/suite.runTests()
2025-04-01T13:07:32.6186954Z nil>       /build/source/vendor/github.com/stretchr/testify/suite/suite.go:247 +0x17d
2025-04-01T13:07:32.6187100Z nil>   github.com/stretchr/testify/suite.Run()
2025-04-01T13:07:32.6187365Z nil>       /build/source/vendor/github.com/stretchr/testify/suite/suite.go:220 +0xa15
2025-04-01T13:07:32.6187614Z nil>   github.com/NilFoundation/nil/nil/tests/rpc_node.TestSuiteRpcNode()
2025-04-01T13:07:32.6187860Z nil>       /build/source/nil/tests/rpc_node/rpc_node_test.go:127 +0x46
2025-04-01T13:07:32.6187964Z nil>   testing.tRunner()
2025-04-01T13:07:32.6188362Z nil>       /nix/store/g29rrn8qqlg4yjqv543ryrkimr7fk43h-go-1.24.1/share/go/src/testing/testing.go:1792 +0x225
2025-04-01T13:07:32.6188497Z nil>   testing.(*T).Run.gowrap1()
2025-04-01T13:07:32.6188898Z nil>       /nix/store/g29rrn8qqlg4yjqv543ryrkimr7fk43h-go-1.24.1/share/go/src/testing/testing.go:1851 +0x44
2025-04-01T13:07:32.6188984Z nil>
2025-04-01T13:07:32.6189107Z nil> Goroutine 23854 (finished) created at:
2025-04-01T13:07:32.6189428Z nil>   github.com/NilFoundation/nil/nil/tests.(*ShardedSuite).EnsureArchiveNodeStarted()
2025-04-01T13:07:32.6189597Z nil>       /build/source/nil/tests/sharded_suite.go:357 +0x15c
2025-04-01T13:07:32.6189879Z nil>   github.com/NilFoundation/nil/nil/tests.(*ShardedSuite).StartArchiveNode()
2025-04-01T13:07:32.6190047Z nil>       /build/source/nil/tests/sharded_suite.go:370 +0x139
...
```