### PR TITLE
autocreate ClickHouse db if not exists

### DIFF
--- a/nil/cmd/exporter/internal/clickhouse/clickhouse.go
+++ b/nil/cmd/exporter/internal/clickhouse/clickhouse.go
@@ -120,7 +120,10 @@ func NewLogWithBinary(log *types.Log, binary []byte, receipt *types.Receipt) *Lo
 	return res
 }
 
-func NewClickhouseDriver(_ context.Context, endpoint, login, password, database string) (*ClickhouseDriver, error) {
+func NewClickhouseDriver(ctx context.Context, endpoint, login, password, database string) (*ClickhouseDriver, error) {
+	if err := common.CreateClickHouseDbIfNotExists(ctx, database, login, password, endpoint); err != nil {
+		return nil, err
+	}
 	// Create connection to Clickhouse
 	connectionOptions := clickhouse.Options{
 		Auth: clickhouse.Auth{

--- a/nil/common/clickhouse.go
+++ b/nil/common/clickhouse.go
@@ -22,15 +22,5 @@ func CreateClickHouseDbIfNotExists(ctx context.Context, dbname, user, password, 
 	}
 	defer conn.Close()
 
-	rows, err := conn.Query(ctx, "SELECT name FROM system.databases WHERE name = ?", dbname)
-	if err != nil {
-		return err
-	}
-	defer rows.Close()
-
-	if !rows.Next() {
-		err = conn.Exec(ctx, fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", dbname))
-		return err
-	}
-	return nil
+	return conn.Exec(ctx, fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", dbname))
 }

--- a/nil/common/clickhouse.go
+++ b/nil/common/clickhouse.go
@@ -1,0 +1,36 @@
+package common
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+)
+
+func CreateClickHouseDbIfNotExists(ctx context.Context, dbname, user, password, endpoint string) error {
+	connectionOptions := clickhouse.Options{
+		Auth: clickhouse.Auth{
+			Database: "system",
+			Username: user,
+			Password: password,
+		},
+		Addr: []string{endpoint},
+	}
+	conn, err := clickhouse.Open(&connectionOptions)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	rows, err := conn.Query(ctx, "SELECT name FROM system.databases WHERE name = ?", dbname)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	if !rows.Next() {
+		err = conn.Exec(ctx, fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", dbname))
+		return err
+	}
+	return nil
+}

--- a/nil/services/cometa/clickhouse.go
+++ b/nil/services/cometa/clickhouse.go
@@ -23,6 +23,10 @@ const SchemaVersion = 1
 var _ Storage = new(StorageClick)
 
 func NewStorageClick(ctx context.Context, cfg *Config) (*StorageClick, error) {
+	if err := common.CreateClickHouseDbIfNotExists(ctx, cfg.DbName, cfg.DbUser, cfg.DbPassword, cfg.DbEndpoint); err != nil {
+		return nil, err
+	}
+
 	connectionOptions := clickhouse.Options{
 		Auth: clickhouse.Auth{
 			Database: cfg.DbName,

--- a/nil/tests/cometa/cometa_test.go
+++ b/nil/tests/cometa/cometa_test.go
@@ -2,6 +2,7 @@ package cometa
 
 import (
 	"os/exec"
+	"syscall"
 	"testing"
 	"time"
 
@@ -68,18 +69,12 @@ func (s *SuiteCometaClickhouse) SetupSuite() {
 		"--mysql_port=",
 		"--path="+dir,
 	)
+	s.clickhouse.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	s.clickhouse.Dir = dir
 	err := s.clickhouse.Start()
 	s.Require().NoError(err)
 
 	time.Sleep(1 * time.Second)
-	createDb := exec.Command( //nolint:gosec
-		"clickhouse-client",
-		"--port=9002",
-		"--query",
-		"CREATE DATABASE IF NOT EXISTS "+s.cometaCfg.DbName)
-	out, err := createDb.CombinedOutput()
-	s.Require().NoErrorf(err, "output: %s", out)
 
 	s.SuiteCometa.SetupSuite()
 
@@ -88,7 +83,12 @@ func (s *SuiteCometaClickhouse) SetupSuite() {
 
 func (s *SuiteCometaClickhouse) TearDownSuite() {
 	if s.clickhouse != nil {
-		err := s.clickhouse.Process.Kill()
+		// https://stackoverflow.com/questions/22470193/why-wont-go-kill-a-child-process-correctly
+		// simple s.clickhouse.Kill() won't work on child process
+		// this leads to errors in sequential test runs
+		pgid, err := syscall.Getpgid(s.clickhouse.Process.Pid)
+		s.Require().NoError(err)
+		err = syscall.Kill(-pgid, syscall.SIGTERM)
 		s.Require().NoError(err)
 	}
 }


### PR DESCRIPTION
currently Cometa and Exporter fail if particular ClickHouse DB doesn't exist. however they may simply create it in this case

during debugging I encountered a nasty issue with CH processes not being killed properly and hence causing different side effects (such as connecting to old CH server, etc)