### PR TITLE
Bundle docs_ai_backend

### DIFF
--- a/docs_ai_backend/next.config.js
+++ b/docs_ai_backend/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  output: 'standalone',
+};

--- a/docs_ai_backend/package.json
+++ b/docs_ai_backend/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev -p 7000",
     "build": "next build",
-    "start": "next start -p 8092"
+    "start": "PORT=8092 HOSTNAME=localhost node .next/standalone/docs_ai_backend/server.js"
   },
   "keywords": [],
   "author": "khannanov-nil",

--- a/docs_ai_backend/src/utils/populateDB.js
+++ b/docs_ai_backend/src/utils/populateDB.js
@@ -69,7 +69,7 @@ export const populateDB = async () => {
     docs = docs.concat(doc);
   }
   const contractsLoader = new DirectoryLoader(
-    path.resolve("../node_modules/@nilfoundation/smart-contracts/contracts"), {
+    path.resolve("../../../node_modules/@nilfoundation/smart-contracts/contracts"), {
     ".sol": (path) => new TextLoader(path)
   });
   const contractDocs = await contractsLoader.load();

--- a/nix/docsaibackend.nix
+++ b/nix/docsaibackend.nix
@@ -32,9 +32,10 @@ stdenv.mkDerivation rec {
   checkPhase = "";
 
   installPhase = ''
-    mkdir -p $out
-    mv smart-contracts $out/smart-contracts
-    mv node_modules $out/node_modules
-    mv docs_ai_backend/ $out/docs_ai_backend
+    mkdir -p $out/docs_ai_backend
+    mkdir -p $out/smart-contracts
+    cp -r docs_ai_backend/.next/static $out/docs_ai_backend
+    cp -r docs_ai_backend/.next/standalone $out/docs_ai_backend
+    mv smart-contracts/contracts $out/smart-contracts
   '';
 }


### PR DESCRIPTION
## Short Summary

It looks like it's not very difficult to bundle all necessary npm dependencies together with the docs_ai_backend. What is needed is just to specify `output: standalone` in the next.js config.

I've tried to start the server with `node` from the resulting build and it worked. However, I can't do any in-depth testing and will wait for Shukhrat to do that part.


## Related Issue

Part of #728

## Breaking Changes (if any)

It is possible that I didn't ship everything that is needed in the resulting distribution, so help is needed.

## Checklist

_Please mark each item with an `x` inside the brackets (e.g., [x]) once completed._

- [x] I have read and followed the [Contributing Guide](https://github.com/NilFoundation/nil/blob/main/CONTRIBUTION-GUIDE.md)
- [x] I have tested the changes locally
- [x] I have added relevant tests (if applicable)
- [x] I have updated documentation/comments (if applicable)
