### PR TITLE
Support config files for sync_committee binaries

### DIFF
--- a/nil/cmd/prover/main.go
+++ b/nil/cmd/prover/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/NilFoundation/nil/nil/common/check"
 	"github.com/NilFoundation/nil/nil/common/logging"
+	"github.com/NilFoundation/nil/nil/internal/cobrax"
 	"github.com/NilFoundation/nil/nil/internal/db"
 	"github.com/NilFoundation/nil/nil/internal/profiling"
 	"github.com/NilFoundation/nil/nil/internal/types"
@@ -25,8 +26,9 @@ func main() {
 type CommonConfig = prover.Config
 
 type RunConfig struct {
-	*CommonConfig
-	DbPath string
+	*CommonConfig `yaml:",inline"`
+
+	DbPath string `yaml:"dbPath"`
 }
 
 type PrintConfig struct {
@@ -40,9 +42,11 @@ func execute() error {
 		Short: "Run nil prover node",
 	}
 
-	commonCfg := prover.NewDefaultConfig()
+	runConfig, err := loadRunConfig()
+	if err != nil {
+		return err
+	}
 
-	runConfig := &RunConfig{CommonConfig: commonCfg}
 	runCmd := &cobra.Command{
 		Use:   "run",
 		Short: "Run the prover service",
@@ -50,8 +54,9 @@ func execute() error {
 			return run(runConfig)
 		},
 	}
-	addCommonFlags(runCmd, commonCfg)
-	runCmd.Flags().StringVar(&runConfig.DbPath, "db-path", "prover.db", "path to database")
+	commonCfg := runConfig.CommonConfig
+	addCommonFlags(rootCmd, commonCfg)
+	runCmd.Flags().StringVar(&runConfig.DbPath, "db-path", runConfig.DbPath, "path to database")
 
 	rootCmd.AddCommand(runCmd)
 
@@ -83,7 +88,6 @@ func execute() error {
 			return tracer.CollectTracesToFile(context.Background(), client, &traceConfig)
 		},
 	}
-	addCommonFlags(generateTraceCmd, commonCfg)
 	addMarshalModeFlag(generateTraceCmd, &marshalModePlaceholder)
 	rootCmd.AddCommand(generateTraceCmd)
 
@@ -97,23 +101,36 @@ func execute() error {
 			return readTrace(&printConfig)
 		},
 	}
-	addCommonFlags(printTraceCmd, commonCfg)
 	addMarshalModeFlag(printTraceCmd, &printConfig.MarshalMode)
 	rootCmd.AddCommand(printTraceCmd)
 
 	return rootCmd.Execute()
 }
 
+func loadRunConfig() (*RunConfig, error) {
+	cfg := &RunConfig{
+		CommonConfig: prover.NewDefaultConfig(),
+		DbPath:       "prover.db",
+	}
+
+	if err := cobrax.LoadConfigFromFile(cobrax.GetConfigNameFromArgs(), cfg); err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}
+
 func addCommonFlags(cmd *cobra.Command, cfg *CommonConfig) {
-	cmd.Flags().StringVar(
+	cobrax.AddConfigFlag(cmd.PersistentFlags())
+	cmd.PersistentFlags().StringVar(
 		&cfg.ProofProviderRpcEndpoint,
 		"proof-provider-endpoint",
 		cfg.ProofProviderRpcEndpoint,
 		"proof provider rpc endpoint")
-	cmd.Flags().StringVar(&cfg.NilRpcEndpoint, "nil-endpoint", cfg.NilRpcEndpoint, "nil rpc endpoint")
-	logLevel := cmd.Flags().String("log-level", "info", "log level: trace|debug|info|warn|error|fatal|panic")
+	cmd.PersistentFlags().StringVar(&cfg.NilRpcEndpoint, "nil-endpoint", cfg.NilRpcEndpoint, "nil rpc endpoint")
+	logLevel := cmd.PersistentFlags().String("log-level", "info", "log level: trace|debug|info|warn|error|fatal|panic")
 
-	cmd.PreRun = func(cmd *cobra.Command, args []string) {
+	cmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		logging.SetupGlobalLogger(*logLevel)
 	}
 }

--- a/nil/services/synccommittee/core/aggregator.go
+++ b/nil/services/synccommittee/core/aggregator.go
@@ -43,8 +43,8 @@ type AggregatorBlockStorage interface {
 }
 
 type AggregatorConfig struct {
-	RpcPollingInterval time.Duration
-	MaxBlobsInTx       uint
+	RpcPollingInterval time.Duration `yaml:"pollingDelay,omitempty"`
+	MaxBlobsInTx       uint          `yaml:"-"`
 }
 
 func NewAggregatorConfig(rpcPollingInterval time.Duration) AggregatorConfig {

--- a/nil/services/synccommittee/core/config.go
+++ b/nil/services/synccommittee/core/config.go
@@ -10,12 +10,12 @@ const (
 )
 
 type Config struct {
-	RpcEndpoint             string
-	TaskListenerRpcEndpoint string
-	AggregatorConfig        AggregatorConfig
-	ProposerParams          ProposerConfig
-	ContractWrapperConfig   rollupcontract.WrapperConfig
-	Telemetry               *telemetry.Config
+	RpcEndpoint             string                       `yaml:"endpoint,omitempty"`
+	TaskListenerRpcEndpoint string                       `yaml:"ownEndpoint,omitempty"`
+	AggregatorConfig        AggregatorConfig             `yaml:",inline"`
+	ProposerParams          ProposerConfig               `yaml:"-"`
+	ContractWrapperConfig   rollupcontract.WrapperConfig `yaml:",inline"`
+	Telemetry               *telemetry.Config            `yaml:",inline"`
 }
 
 func NewDefaultConfig() *Config {

--- a/nil/services/synccommittee/internal/rollupcontract/wrapper.go
+++ b/nil/services/synccommittee/internal/rollupcontract/wrapper.go
@@ -39,11 +39,11 @@ type Wrapper interface {
 }
 
 type WrapperConfig struct {
-	Endpoint           string
-	RequestsTimeout    time.Duration
-	DisableL1          bool
-	PrivateKeyHex      string
-	ContractAddressHex string
+	Endpoint           string        `yaml:"l1Endpoint,omitempty"`
+	RequestsTimeout    time.Duration `yaml:"l1ClientTimeout,omitempty"`
+	DisableL1          bool          `yaml:"disableL1,omitempty"`
+	PrivateKeyHex      string        `yaml:"l1PrivateKey,omitempty"`
+	ContractAddressHex string        `yaml:"l1ContractAddress,omitempty"`
 }
 
 func NewDefaultWrapperConfig() WrapperConfig {

--- a/nil/services/synccommittee/proofprovider/service.go
+++ b/nil/services/synccommittee/proofprovider/service.go
@@ -17,11 +17,11 @@ import (
 )
 
 type Config struct {
-	SyncCommitteeRpcEndpoint string
-	TaskListenerRpcEndpoint  string
-	SkipRate                 int
-	MaxConcurrentBatches     uint32
-	Telemetry                *telemetry.Config
+	SyncCommitteeRpcEndpoint string            `yaml:"syncCommitteeEndpoint,omitempty"`
+	TaskListenerRpcEndpoint  string            `yaml:"ownEndpoint,omitempty"`
+	SkipRate                 int               `yaml:"skipRate,omitempty"`
+	MaxConcurrentBatches     uint32            `yaml:"maxConcurrentBatches,omitempty"`
+	Telemetry                *telemetry.Config `yaml:",inline"`
 }
 
 func NewDefaultConfig() *Config {

--- a/nil/services/synccommittee/prover/service.go
+++ b/nil/services/synccommittee/prover/service.go
@@ -18,9 +18,9 @@ import (
 )
 
 type Config struct {
-	ProofProviderRpcEndpoint string
-	NilRpcEndpoint           string
-	Telemetry                *telemetry.Config
+	ProofProviderRpcEndpoint string            `yaml:"proofProviderEndpoint,omitempty"`
+	NilRpcEndpoint           string            `yaml:"nilEndpoint,omitempty"`
+	Telemetry                *telemetry.Config `yaml:",inline"`
 }
 
 func NewDefaultConfig() *Config {


### PR DESCRIPTION
Currently we pass some secret data via cmd options which is insecure. This commit introduces a possibility to read the same options from config files also. It still keeps all the flags, and in case of two values passed from both a config and an option, the option value will be used.

- [x] I have read and followed the [Contributing Guide](https://github.com/NilFoundation/nil/blob/main/CONTRIBUTION-GUIDE.md)
- [x] I have tested the changes locally
- [x] I have added relevant tests (if applicable)
- [x] I have updated documentation/comments (if applicable)
