### PR TITLE
[explorer] add EXPLORER_CODE_SNIPPETS_DB_PATH env var to config

### DIFF
--- a/explorer_backend/config.ts
+++ b/explorer_backend/config.ts
@@ -17,6 +17,7 @@ const defaults = {
   TRACE_EXPORTER_URL: null,
   INTERVAL_CACHE_CHECKER: 1000,
   CACHE_DEADLINE: 5000,
+  EXPLORER_CODE_SNIPPETS_DB_PATH: "./database.db",
 };
 
 export const config = {
@@ -42,4 +43,6 @@ export const config = {
   CACHE_DEADLINE: process.env.CACHE_DEADLINE
     ? +process.env.CACHE_DEADLINE
     : defaults.CACHE_DEADLINE,
+  EXPLORER_CODE_SNIPPETS_DB_PATH:
+    process.env.EXPLORER_CODE_SNIPPETS_DB_PATH || defaults.EXPLORER_CODE_SNIPPETS_DB_PATH,
 } as const;

--- a/explorer_backend/services/sqlite.ts
+++ b/explorer_backend/services/sqlite.ts
@@ -1,7 +1,8 @@
 import { createHash } from "node:crypto";
 import sqlite3 from "node-sqlite3-wasm";
+import { config } from "../config";
 
-const db = new sqlite3.Database(process.env.EXPLORER_DB || "./database.db");
+const db = new sqlite3.Database(config.EXPLORER_CODE_SNIPPETS_DB_PATH);
 
 export { db };
 

--- a/nix/container.nix
+++ b/nix/container.nix
@@ -218,7 +218,7 @@ in
         StateDirectory = "explorer_backend";
         RuntimeDirectory = "explorer_backend";
         Environment = [
-          "EXPLORER_DB=/var/lib/explorer_backend/explorer.db"
+          "EXPLORER_CODE_SNIPPETS_DB_PATH=/var/lib/explorer_backend/explorer.db"
           "DB_URL=http://127.0.0.1:8123"
           "DB_USER=default"
           "DB_NAME=nil_database"


### PR DESCRIPTION
This diff adds EXPLORER_DB (after renaming EXPLORER_CODE_SNIPPETS_DB_PATH) to the config so we can correctly use it. Outside the config which imports `import "dotenv/config";` we can not simply read env variables like `process.env.EXPLORER_DB`

This is needed to use bundled backend version on deployment host.