### PR TITLE
[execution] don't inc ExtSeqno in case if tx is not included to block

### DIFF
--- a/nil/client/direct_client.go
+++ b/nil/client/direct_client.go
@@ -388,7 +388,11 @@ func (c *DirectClient) GetDebugContract(
 	contractAddr types.Address,
 	blockId any,
 ) (*jsonrpc.DebugRPCContract, error) {
-	panic("Not supported")
+	blockNrOrHash, err := transport.AsBlockReference(blockId)
+	if err != nil {
+		return nil, err
+	}
+	return c.debugApi.GetContract(ctx, contractAddr, transport.BlockNumberOrHash(blockNrOrHash))
 }
 
 func (c *DirectClient) ClientVersion(ctx context.Context) (string, error) {

--- a/nil/internal/contracts/testaide.go
+++ b/nil/internal/contracts/testaide.go
@@ -27,22 +27,39 @@ const (
 
 func GetDeployPayload(t *testing.T, name string) types.DeployPayload {
 	t.Helper()
+	return GetDeployPayloadWithSalt(t, name, common.EmptyHash)
+}
+
+func GetDeployPayloadWithSalt(t *testing.T, name string, salt common.Hash) types.DeployPayload {
+	t.Helper()
 
 	code, err := GetCode(name)
 	require.NoError(t, err)
-	return types.BuildDeployPayload(code, common.EmptyHash)
+	return types.BuildDeployPayload(code, salt)
 }
 
 func CounterDeployPayload(t *testing.T) types.DeployPayload {
 	t.Helper()
 
-	return GetDeployPayload(t, NameCounter)
+	return CounterDeployPayloadWithSalt(t, common.EmptyHash)
+}
+
+func CounterDeployPayloadWithSalt(t *testing.T, salt common.Hash) types.DeployPayload {
+	t.Helper()
+
+	return GetDeployPayloadWithSalt(t, NameCounter, salt)
 }
 
 func CounterAddress(t *testing.T, shardId types.ShardId) types.Address {
 	t.Helper()
 
-	return types.CreateAddress(shardId, CounterDeployPayload(t))
+	return CounterAddressWithSalt(t, shardId, common.EmptyHash)
+}
+
+func CounterAddressWithSalt(t *testing.T, shardId types.ShardId, salt common.Hash) types.Address {
+	t.Helper()
+
+	return types.CreateAddress(shardId, CounterDeployPayloadWithSalt(t, salt))
 }
 
 func FaucetDeployPayload(t *testing.T) types.DeployPayload {

--- a/nil/services/synccommittee/internal/rpc/task_debug_rpc_test.go
+++ b/nil/services/synccommittee/internal/rpc/task_debug_rpc_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/NilFoundation/nil/nil/common/logging"
 	"github.com/NilFoundation/nil/nil/internal/db"
+	"github.com/NilFoundation/nil/nil/services/rpc"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/api"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/metrics"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/scheduler"
@@ -62,7 +63,7 @@ func newTaskEntries(now time.Time) []*types.TaskEntry {
 
 func (s *TaskSchedulerDebugRpcTestSuite) SetupSuite() {
 	s.context, s.cancellation = context.WithCancel(context.Background())
-	const listenerEndpoint = "tcp://127.0.0.1:8532"
+	listenerEndpoint := rpc.GetSockPath(s.T())
 
 	logger := logging.NewLogger("task_debug_rpc_test")
 

--- a/nil/tests/async_await/async_await_test.go
+++ b/nil/tests/async_await/async_await_test.go
@@ -522,8 +522,7 @@ func (s *SuiteAsyncAwait) TestOnlyResponse() {
 func (s *SuiteAsyncAwait) checkAsyncContextEmpty(address types.Address) {
 	s.T().Helper()
 
-	index := tests.InstanceId(address.ShardId()) - 1
-	contract := tests.GetContract(s.T(), s.Context, s.Instances[index].Db, address)
+	contract := tests.GetContract(s.T(), s.DefaultClient, address)
 	s.Require().Equal(common.EmptyHash, contract.AsyncContextRoot)
 }
 

--- a/nil/tests/contracts/Unconstructable.sol
+++ b/nil/tests/contracts/Unconstructable.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract Unconstructable {
+    uint256 private value;
+
+    constructor() {
+        for (uint256 i = 0; i < 100; i++) {
+            value += i;
+        }
+        require(false, "this contract cannot be constructed");
+    }
+}

--- a/nil/tests/rpc_suite.go
+++ b/nil/tests/rpc_suite.go
@@ -245,22 +245,8 @@ func (s *RpcSuite) SendTransactionViaSmartAccountNoCheck(
 	tokens []types.TokenBalance,
 ) *jsonrpc.RPCReceipt {
 	s.T().Helper()
-
-	// Send the raw transaction
-	txHash, err := s.Client.SendTransactionViaSmartAccount(
-		s.Context, addrSmartAccount, calldata, fee, value, tokens, addrTo, key)
-	s.Require().NoError(err)
-
-	receipt := s.WaitIncludedInMain(txHash)
-	// We don't check the receipt for success here, as it can be failed on purpose
-	if receipt.Success {
-		// But if it is successful, we expect exactly one out receipt
-		s.Require().Len(receipt.OutReceipts, 1)
-	} else {
-		s.Require().NotEqual("Success", receipt.Status)
-	}
-
-	return receipt
+	return SendTransactionViaSmartAccountNoCheck(
+		s.T(), s.Client, addrSmartAccount, addrTo, key, calldata, fee, value, tokens)
 }
 
 func (s *RpcSuite) CallGetter(

--- a/nil/tests/sharded_suite.go
+++ b/nil/tests/sharded_suite.go
@@ -4,6 +4,7 @@ package tests
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"fmt"
 	"os"
 	"slices"
@@ -534,4 +535,18 @@ func (s *ShardedSuite) CallGetter(
 ) []byte {
 	s.T().Helper()
 	return CallGetter(s.T(), s.Context, s.DefaultClient, addr, calldata, blockId, overrides)
+}
+
+func (s *ShardedSuite) SendTransactionViaSmartAccountNoCheck(
+	addrSmartAccount types.Address,
+	addrTo types.Address,
+	key *ecdsa.PrivateKey,
+	calldata []byte,
+	fee types.FeePack,
+	value types.Value,
+	tokens []types.TokenBalance,
+) *jsonrpc.RPCReceipt {
+	s.T().Helper()
+	return SendTransactionViaSmartAccountNoCheck(
+		s.T(), s.DefaultClient, addrSmartAccount, addrTo, key, calldata, fee, value, tokens)
 }


### PR DESCRIPTION
The previous patch
(cbed7489a815956487b913a4d6ea96922e3ff28d) fixed the possibility of adding identical transactions to
multiple blocks. However, it introduced a regression.

Transactions that are not included in a block (and create so-called temporary receipts) could still
modify the state. This breaks replay, since the
account cannot be brought to the correct state
without that transaction.

This patch fixes the issue by rolling back ExtSeqno if the transaction is not included in a block.

This mainly affects deploy transactions. For
execution transactions, gas is paid if
`verifyExternal` succeeds, so state changes are valid in that case.
