### PR TITLE
[execution] Fix big transactions processing

### DIFF
--- a/nil/contracts/solidity/tests/Stresser.sol
+++ b/nil/contracts/solidity/tests/Stresser.sol
@@ -14,6 +14,7 @@ contract Stresser {
         return value;
     }
 
+    // Consumes gas by using hot SSTORE(~529 gas per iteration)
     function gasConsumer(uint256 v) public returns(uint256) {
         for (uint256 i = 1; i < v; i++) {
             value *= 2;

--- a/nil/contracts/solidity/tests/Test.sol
+++ b/nil/contracts/solidity/tests/Test.sol
@@ -277,4 +277,15 @@ contract Test is NilBase {
     }
 }
 
+contract HeavyConstructor {
+    uint256 public value;
+
+    // Consumes gas by using hot SSTORE(~529 gas per iteration)
+    constructor(uint256 n) payable {
+        for (uint256 i = 1; i < n; i++) {
+            value *= 2;
+        }
+    }
+}
+
 contract Empty {}

--- a/nil/internal/collate/proposer.go
+++ b/nil/internal/collate/proposer.go
@@ -327,11 +327,11 @@ func (p *proposer) handleTransactionsFromPool() error {
 		if ok, err := handle(txn); err != nil {
 			return err
 		} else if ok {
+			p.proposal.ExternalTxns = append(p.proposal.ExternalTxns, txn.Transaction)
 			if p.executionState.GasUsed > p.params.MaxGasInBlock {
+				unverified = append(unverified, txn.Hash())
 				break
 			}
-
-			p.proposal.ExternalTxns = append(p.proposal.ExternalTxns, txn.Transaction)
 		}
 	}
 

--- a/nil/internal/collate/proposer_test.go
+++ b/nil/internal/collate/proposer_test.go
@@ -80,7 +80,7 @@ func (s *ProposerTestSuite) TestBlockGas() {
 	})
 
 	s.Run("MaxGasInBlockFor1Txn", func() {
-		params.MaxGasInBlock = 12000
+		params.MaxGasInBlock = 2000
 		p := newTestProposer(params, pool)
 
 		proposal := s.generateProposal(p)

--- a/nil/internal/contracts/contract.go
+++ b/nil/internal/contracts/contract.go
@@ -71,21 +71,29 @@ func GetAbiData(name string) (string, error) {
 	return string(data), nil
 }
 
-func CalculateAddress(name string, shardId types.ShardId, salt []byte, ctorArgs ...any) (types.Address, error) {
+func CreateDeployPayload(name string, salt []byte, ctorArgs ...any) (types.DeployPayload, error) {
 	code, err := GetCode(name)
 	if err != nil {
-		return types.Address{}, err
+		return types.DeployPayload{}, err
 	}
 
 	if len(ctorArgs) != 0 {
 		argsPacked, err := NewCallData(name, "", ctorArgs...)
 		if err != nil {
-			return types.Address{}, err
+			return types.DeployPayload{}, err
 		}
 		code = append(code, argsPacked...)
 	}
 	payload := types.BuildDeployPayload(code, common.BytesToHash(salt))
 
+	return payload, nil
+}
+
+func CalculateAddress(name string, shardId types.ShardId, salt []byte, ctorArgs ...any) (types.Address, error) {
+	payload, err := CreateDeployPayload(name, salt, ctorArgs...)
+	if err != nil {
+		return types.Address{}, err
+	}
 	return types.CreateAddress(shardId, payload), nil
 }
 

--- a/nil/internal/types/exec_errors.go
+++ b/nil/internal/types/exec_errors.go
@@ -188,6 +188,8 @@ const (
 	ErrorBaseFeeTooHigh
 	// ErrorMaxFeePerGasIsZero is returned when the MaxFeePerGas is zero. It is not allowed to have zero MaxFeePerGas.
 	ErrorMaxFeePerGasIsZero
+	// ErrorTransactionExceedsBlockGasLimit is returned when the transaction consumes more than the block gas limit.
+	ErrorTransactionExceedsBlockGasLimit
 )
 
 type ExecError interface {
@@ -228,14 +230,6 @@ func IsValidError(err error) bool {
 	return ToError(err) != nil
 }
 
-func ToBaseError(err error) *BaseError {
-	var base *BaseError
-	if errors.As(err, &base) {
-		return base
-	}
-	return nil
-}
-
 func ToError(err error) ExecError {
 	if e, ok := err.(ExecError); ok { //nolint:errorlint
 		return e
@@ -256,7 +250,7 @@ func IsOutOfGasError(err error) bool {
 }
 
 func GetErrorCode(err error) ErrorCode {
-	if base := ToBaseError(err); base != nil {
+	if base := ToError(err); base != nil {
 		return base.Code()
 	}
 	return ErrorUnknown

--- a/nix/tests-heavy.txt
+++ b/nix/tests-heavy.txt
@@ -20,7 +20,6 @@ nil/tests/multitoken
 nil/tests/nil_load_generator_service
 nil/tests/opcodes
 nil/tests/read_through
-nil/tests/regression
 nil/tests/rpc_node
 nil/tests/rpc_service
 nil/tests/smart-account

--- a/nix/tests-ibft.txt
+++ b/nix/tests-ibft.txt
@@ -1,3 +1,4 @@
 nil/go-ibft/core
 nil/go-ibft/messages
 nil/services/txnpool
+nil/tests/regression


### PR DESCRIPTION
Previously, big transactions just stuck in the pool/blocks, and the node tried to execute them again and again. Thus, a kind of infinite loop was observed.
This patch fixes it by adding constraint to the EVM that transaction cannot consume more than block gas limit. Also, the check for exceeding the gas limit has now been moved after adding a transaction, otherwise such a transaction would never appear in the block.
This solution has a drawback that the block can exceed its gas limit by two times in the worst case. In the future, we'll probably want to solve it more appropriately by reducing the possible excess of the block gas limit.

Relates to #79