### PR TITLE
fix duplication of shardId in logs

### DIFF
--- a/nil/internal/collate/validator.go
+++ b/nil/internal/collate/validator.go
@@ -447,7 +447,6 @@ func (s *Validator) replayBlockUnlocked(ctx context.Context, block *types.BlockW
 			s.logger.Error().
 				Uint64(logging.FieldBlockNumber, uint64(block.Id)).
 				Stringer(logging.FieldBlockHash, block.Hash(s.params.ShardId)).
-				Stringer(logging.FieldShardId, s.params.ShardId).
 				Stringer(logging.FieldSignature, block.Signature).
 				Err(err).
 				Msg("Failed to verify block signature")

--- a/nil/internal/execution/block_generator.go
+++ b/nil/internal/execution/block_generator.go
@@ -153,7 +153,6 @@ func (p *BlockGenerator) CollectGasPrices(prevBlockId types.BlockNumber) []types
 		block, err := db.ReadBlock(p.rwTx, shardId, shardHash)
 		if err != nil {
 			p.logger.Err(err).
-				Stringer(logging.FieldShardId, shardId).
 				Stringer(logging.FieldBlockHash, shardHash).
 				Msg("Get gas price from shard: failed to read block")
 			shards[shardId] = *types.DefaultGasPrice.Uint256

--- a/nil/internal/execution/state.go
+++ b/nil/internal/execution/state.go
@@ -302,10 +302,13 @@ func NewExecutionState(tx any, shardId types.ShardId, params StateParams) (*Exec
 		return nil, errors.New("invalid tx type")
 	}
 
-	logger := logging.NewLogger("execution")
+	l := logging.NewLogger("execution").
+		With().
+		Stringer(logging.FieldShardId, shardId)
 	if params.Mode != "" {
-		logger = logger.With().Str("mode", params.Mode).Logger()
+		l = l.Str("mode", params.Mode)
 	}
+	logger := l.Logger()
 
 	feeCalculator := params.FeeCalculator
 	if feeCalculator == nil {
@@ -1223,7 +1226,6 @@ func (es *ExecutionState) handleDeployTransaction(_ context.Context, transaction
 
 	es.logger.Debug().
 		Stringer(logging.FieldTransactionTo, addr).
-		Stringer(logging.FieldShardId, es.ShardId).
 		Msg("Handling deploy transaction...")
 
 	if err := es.newVm(transaction.IsInternal(), transaction.From, nil); err != nil {
@@ -1603,7 +1605,6 @@ func (es *ExecutionState) CommitBlock(src *BlockGenerationResult, params *types.
 	}
 
 	es.logger.Trace().
-		Stringer(logging.FieldShardId, es.ShardId).
 		Stringer(logging.FieldBlockNumber, block.Id).
 		Stringer(logging.FieldBlockHash, blockHash).
 		Msgf("Committed new block with %d in-txns and %d out-txns", len(es.InTransactions), block.OutTransactionsNum)

--- a/nil/services/txnpool/txnpool.go
+++ b/nil/services/txnpool/txnpool.go
@@ -170,7 +170,6 @@ func (p *TxnPool) add(txns ...*metaTxn) ([]DiscardReason, error) {
 		}
 		discardReasons[i] = NotSet // unnecessary
 		p.logger.Debug().
-			Uint64(logging.FieldShardId, uint64(txn.To.ShardId())).
 			Stringer(logging.FieldTransactionHash, txn.Hash()).
 			Stringer(logging.FieldTransactionTo, txn.To).
 			Int(logging.FieldTransactionSeqno, int(txn.Seqno)).
@@ -185,7 +184,6 @@ func (p *TxnPool) validateTxn(txn *metaTxn) (DiscardReason, bool) {
 	seqno, has := p.all.seqno(txn.To)
 	if has && seqno > txn.Seqno {
 		p.logger.Debug().
-			Uint64(logging.FieldShardId, uint64(txn.To.ShardId())).
 			Stringer(logging.FieldTransactionHash, txn.Hash()).
 			Uint64(logging.FieldAccountSeqno, seqno.Uint64()).
 			Uint64(logging.FieldTransactionSeqno, txn.Seqno.Uint64()).
@@ -394,7 +392,6 @@ func (p *TxnPool) removeCommitted(bySeqno *ByReceiverAndSeqno, txns []*types.Tra
 		bySeqno.ascend(senderID, func(txn *metaTxn) bool {
 			if txn.Seqno > seqno {
 				p.logger.Trace().
-					Uint64(logging.FieldShardId, uint64(txn.To.ShardId())).
 					Uint64(logging.FieldTransactionSeqno, txn.Seqno.Uint64()).
 					Uint64(logging.FieldAccountSeqno, seqno.Uint64()).
 					Msg("Removing committed, cmp seqnos")
@@ -403,7 +400,6 @@ func (p *TxnPool) removeCommitted(bySeqno *ByReceiverAndSeqno, txns []*types.Tra
 			}
 
 			p.logger.Trace().
-				Uint64(logging.FieldShardId, uint64(txn.To.ShardId())).
 				Stringer(logging.FieldTransactionHash, txn.Hash()).
 				Stringer(logging.FieldTransactionTo, txn.To).
 				Uint64(logging.FieldTransactionSeqno, txn.Seqno.Uint64()).


### PR DESCRIPTION
Zerolog doesn't deduplicate log entry tags. So it's enough to set shardId for root logger. Otherwise we will have shardId twice in JSON. This patch removes several FieldShardId fields in case if it's defined in the root logger.
