### PR TITLE
Version command in SC binaries

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -137,15 +137,12 @@
 
                 mv ./usr/bin/cometa ./usr/bin/nil-cometa
 
-                bash ${
-                  ./scripts/binary_patch_version.sh
-                } ./usr/bin/nild ${versionFull}
-                bash ${
-                  ./scripts/binary_patch_version.sh
-                } ./usr/bin/nil ${versionFull}
-                bash ${
-                  ./scripts/binary_patch_version.sh
-                } ./usr/bin/nil-cometa ${versionFull}
+                for binary in ./usr/bin/*; do
+                    if [ -f "$binary" ]; then
+                        bash ${ ./scripts/binary_patch_version.sh } "$binary" ${versionFull}
+                    fi
+                done
+
                 ${pkgs.fpm}/bin/fpm -s dir -t deb --name ${pkg.pname} -v ${version} --deb-compression xz --deb-use-file-permissions usr
               '';
               installPhase = ''

--- a/nil/cmd/proof_provider/main.go
+++ b/nil/cmd/proof_provider/main.go
@@ -16,6 +16,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const appTitle = "=nil; Proof Provider"
+
 type cmdConfig struct {
 	*proofprovider.Config `yaml:",inline"`
 
@@ -44,11 +46,10 @@ func execute() error {
 			return run(cfg)
 		},
 	}
-
 	addFlags(runCmd, cfg)
 
-	rootCmd.AddCommand(runCmd)
-
+	versionCmd := cobrax.VersionCmd(appTitle)
+	rootCmd.AddCommand(runCmd, versionCmd)
 	return rootCmd.Execute()
 }
 

--- a/nil/cmd/prover/main.go
+++ b/nil/cmd/prover/main.go
@@ -19,6 +19,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const appTitle = "=nil; Prover"
+
 func main() {
 	check.PanicIfNotCancelledErr(execute())
 }
@@ -58,8 +60,6 @@ func execute() error {
 	addCommonFlags(rootCmd, commonCfg)
 	runCmd.Flags().StringVar(&runConfig.DbPath, "db-path", runConfig.DbPath, "path to database")
 
-	rootCmd.AddCommand(runCmd)
-
 	traceConfig := tracer.TraceConfig{}
 	var marshalModePlaceholder string
 	generateTraceCmd := &cobra.Command{
@@ -89,7 +89,6 @@ func execute() error {
 		},
 	}
 	addMarshalModeFlag(generateTraceCmd, &marshalModePlaceholder)
-	rootCmd.AddCommand(generateTraceCmd)
 
 	var printConfig PrintConfig
 	printTraceCmd := &cobra.Command{
@@ -102,8 +101,9 @@ func execute() error {
 		},
 	}
 	addMarshalModeFlag(printTraceCmd, &printConfig.MarshalMode)
-	rootCmd.AddCommand(printTraceCmd)
 
+	versionCmd := cobrax.VersionCmd(appTitle)
+	rootCmd.AddCommand(runCmd, generateTraceCmd, printTraceCmd, versionCmd)
 	return rootCmd.Execute()
 }
 

--- a/nil/cmd/sync_committee/main.go
+++ b/nil/cmd/sync_committee/main.go
@@ -14,6 +14,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const appTitle = "=nil; Sync Committee"
+
 type cmdConfig struct {
 	*core.Config `yaml:",inline"`
 
@@ -42,11 +44,10 @@ func execute() error {
 			return run(cfg)
 		},
 	}
-
 	addFlags(runCmd, cfg)
 
-	rootCmd.AddCommand(runCmd)
-
+	versionCmd := cobrax.VersionCmd(appTitle)
+	rootCmd.AddCommand(runCmd, versionCmd)
 	return rootCmd.Execute()
 }
 

--- a/nil/cmd/sync_committee_cli/main.go
+++ b/nil/cmd/sync_committee_cli/main.go
@@ -9,9 +9,12 @@ import (
 	"github.com/NilFoundation/nil/nil/cmd/sync_committee_cli/internal/flags"
 	"github.com/NilFoundation/nil/nil/common/check"
 	"github.com/NilFoundation/nil/nil/common/logging"
+	"github.com/NilFoundation/nil/nil/internal/cobrax"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/public"
 	"github.com/spf13/cobra"
 )
+
+const appTitle = "=nil; Sync Committee CLI"
 
 func main() {
 	check.PanicIfErr(execute())
@@ -35,11 +38,10 @@ func execute() error {
 	if err != nil {
 		return err
 	}
-	rootCmd.AddCommand(getTaskTreeCmd)
 
 	decodeBatchCmd := buildDecodeBatchCmd(executorParams, logger)
-	rootCmd.AddCommand(decodeBatchCmd)
-
+	versionCmd := cobrax.VersionCmd(appTitle)
+	rootCmd.AddCommand(getTaskTreeCmd, decodeBatchCmd, versionCmd)
 	return rootCmd.Execute()
 }
 
@@ -51,7 +53,7 @@ func buildGetTasksCmd(commonParam *commands.ExecutorParams, logger logging.Logge
 	}
 
 	cmd := &cobra.Command{
-		Use:   "get_tasks",
+		Use:   "get-tasks",
 		Short: "Get tasks from the node's storage based on provided filter and ordering parameters",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return commands.NewExecutor(os.Stdout, cmdParams, logger).Run(commands.GetTasks)
@@ -93,7 +95,7 @@ func buildGetTaskTreeCmd(commonParam *commands.ExecutorParams, logger logging.Lo
 	}
 
 	cmd := &cobra.Command{
-		Use:   "get_task_tree",
+		Use:   "get-task-tree",
 		Short: "Retrieve full task tree structure for a specific task",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			eventLoop := commands.NewExecutor(os.Stdout, cmdParams, logger)


### PR DESCRIPTION
### Add version command to Sync Committee binaries

Added `version` to the following binaries using `cobrax.VersionCmd`:
- `sync_committee`
- `sync_committee_cli`
- `proof_provider`
- `prover`

Renamed commands in `sync_committee_cli` for consistency: `get_tasks` -> `get-tasks`, `get_task_tree` -> `get-task-tree`

### flake.nix: Refactor version patching

* Replaced repetitive version patching commands with a loop
* Added all binaries to the patching process