### PR TITLE
Add bundler and runner

### DIFF
--- a/explorer_frontend/package.json
+++ b/explorer_frontend/package.json
@@ -44,6 +44,7 @@
     "effector": "^22.8.6",
     "effector-react": "^22.5.3",
     "effector-storage": "^6.1.1",
+    "esbuild-wasm": "^0.25.2",
     "ethers": "^6.13.1",
     "eventemitter3": "^5.0.1",
     "history": "^5.3.0",

--- a/explorer_frontend/src/services/bundler/cdnResolverPlugin.ts
+++ b/explorer_frontend/src/services/bundler/cdnResolverPlugin.ts
@@ -1,0 +1,127 @@
+import type * as esbuild from 'esbuild';
+const cdnUrl = 'https://esm.sh/';
+
+export function cdnResolverPlugin(): esbuild.Plugin {
+  return {
+    name: 'cdn-resolver',
+    setup(build: esbuild.PluginBuild) {
+      // Handle bare imports (npm package names)
+
+      build.onResolve({ filter: /^[^./]|^\.[^./]|^\.\.[^/]/ }, async (args) => {
+        // Skip Node.js built-ins
+        if (args.path.match(/^(node:)?fs|path|crypto|buffer|stream|zlib|util|os|child_process|worker_threads|cluster$/)) {
+          return { external: true };
+        }
+
+        if (args.path.startsWith('/-/')) {
+            const resolved = new URL(args.path.replace('/-/', `${cdnUrl}pin/`), cdnUrl);
+            console.log('Resolved URL:', resolved);
+            return { path: resolved, namespace: 'unpkg' };
+        }
+        
+        // Handle package paths
+        let url: string;
+        if (args.path.includes('/')) {
+            console.log('Args:', args);
+            
+          // This is an import like 'lodash/get' or '@material-ui/core/Button'
+          url = `${cdnUrl}${args.path}`;
+        } else {
+          // This is a bare import like 'lodash' or 'react'
+          url = `${cdnUrl}${args.path}`;
+        }
+        
+        return { path: url, namespace: 'unpkg' };
+      });
+
+      build.onResolve({ filter: /^\// }, async (args) => {
+        // Handle package paths
+        const url = `${cdnUrl}${args.path.slice(1)}`;
+        
+        return { path: url, namespace: 'unpkg' };
+      });
+      
+      // Handle relative imports within packages
+      build.onResolve({ filter: /^\./, namespace: 'unpkg' }, (args) => {
+        // Skip data: URIs
+        if (args.path.startsWith('data:')) {
+          return { external: true };
+        }
+        
+        // Handle https:// URLs directly
+        if (args.path.startsWith('https://')) {
+          return { path: args.path, namespace: 'unpkg' };
+        }
+        
+        // Handle relative imports
+        if (args.path.startsWith('./') || args.path.startsWith('../')) {
+            console.log('Args:', args);
+          // Get the directory of the importer
+          const importerUrl = new URL(args.importer);
+          const baseUrl = importerUrl.href.endsWith('.js')? importerUrl.href.substring(0, importerUrl.href.lastIndexOf('/') + 1) : importerUrl.href;
+
+          console.log('Base URL:', baseUrl);
+            console.log('Importer URL:', importerUrl.href);
+          
+          // Resolve the relative path
+          const resolved = new URL(args.path, baseUrl).href;
+            console.log('Resolved URL:', resolved);
+          return { path: resolved, namespace: 'unpkg' };
+        }
+        
+        // Handle absolute paths within the package
+        if (args.path.startsWith('/')) {
+          const importerUrl = new URL(args.importer);
+          const packageRoot = `https://${importerUrl.host}`;
+          const resolved = new URL(args.path, packageRoot).href;
+          return { path: resolved, namespace: 'unpkg' };
+        }
+        
+        // For any other import pattern, assume it's a new package
+        return { path: `${cdnUrl}${args.path}`, namespace: 'unpkg' };
+      });
+      
+      // Load files from unpkg
+      build.onLoad({ filter: /.*/, namespace: 'unpkg' }, async (args) => {
+        try {
+          const response = await fetch(args.path);
+          
+          if (!response.ok) {
+            throw new Error(`Failed to fetch ${args.path}: ${response.status} ${response.statusText}`);
+          }
+          
+          const contents = await response.text();
+          
+          // Determine the loader based on file extension
+          const url = new URL(args.path);
+          const path = url.pathname;
+          let loader = 'js';
+          
+          if (path.endsWith('.json')) {
+            loader = 'json';
+          } else if (path.endsWith('.css')) {
+            loader = 'css';
+          } else if (path.endsWith('.jsx') || path.endsWith('.tsx')) {
+            loader = 'jsx';
+          } else if (path.endsWith('.ts')) {
+            loader = 'ts';
+          }
+          
+          return {
+            contents,
+            loader,
+          };
+        } catch (error) {
+          return {
+            errors: [
+              {
+                text: `Error loading ${args.path}: ${error.message}`,
+                location: { file: args.path },
+              },
+            ],
+          };
+        }
+      });
+    },
+  };
+}

--- a/explorer_frontend/src/services/bundler/index.ts
+++ b/explorer_frontend/src/services/bundler/index.ts
@@ -1,0 +1,66 @@
+import * as esbuild from 'esbuild-wasm';
+import { cdnResolverPlugin, } from './cdnResolverPlugin';
+const initilized = false;
+const esbuildVersion = '0.25.2';
+
+const virualEntryFileName = 'index.ts';
+const virtualEntryPlugin = (code: string) => ({
+    name: 'virtual-entry',
+    setup(build: esbuild.PluginBuild) {
+        build.onResolve({ filter: /.*/ }, (args) => {
+            if (args.path === virualEntryFileName) {
+                return { path: args.path, namespace: 'a' };
+            }
+        });
+
+        build.onLoad({ filter: /.*/, namespace: 'a' }, () => {
+            return {
+                contents: code,
+                loader: 'tsx',
+            };
+        });
+    },
+});
+
+
+export const bundle = async (
+    code: string,
+    injections: esbuild.Plugin[] = [],
+): Promise<string> => {
+    if (!initilized)  {
+        await esbuild.initialize({
+            wasmURL: `https://unpkg.com/esbuild-wasm@${esbuildVersion}/esbuild.wasm`,
+        });
+        console.log('esbuild initialized');
+    }
+
+    const build = await esbuild.build({
+    entryPoints: [virualEntryFileName],
+    bundle: true,
+    write: false,
+    plugins: [
+        virtualEntryPlugin(code),
+        cdnResolverPlugin(),
+        ...injections,
+    ],
+    format: 'esm',
+      target: ['es2020'],
+      minify: false,
+      sourcemap: 'inline',
+    });
+
+    if (build.errors.length > 0) {
+        const error = build.errors[0];
+        throw new Error(
+            `Error: ${error.text} \nLocation: ${error.location?.file}:${error.location?.line}:${error.location?.column}`
+        );
+    }
+    if (build.warnings.length > 0) {
+        console.warn('Warnings:', build.warnings);
+    }
+    if (build.outputFiles.length === 0) {
+        throw new Error('No output files found');
+    }
+
+    return build.outputFiles[0].text;
+}

--- a/explorer_frontend/src/services/runner.ts
+++ b/explorer_frontend/src/services/runner.ts
@@ -1,0 +1,5 @@
+export const run = (code: string) => {
+    const codeBlob = new Blob([code], { type: "text/javascript" });
+    
+    new Worker(URL.createObjectURL(codeBlob));
+}


### PR DESCRIPTION
## Short Summary

This pull request introduces a new CDN resolver plugin for esbuild and updates the bundling process in the `explorer_frontend` project. The most important changes include adding the `esbuild-wasm` dependency, creating the CDN resolver plugin, and updating the bundler and runner services to utilize the new plugin.

## What Changes Were Made

### Dependency Addition:
* [`explorer_frontend/package.json`](diffhunk://#diff-9978686fa0e80e554e28554b7446ba99bf3fa5c3a88a6fcbe9237c4200c7e932R47): Added `esbuild-wasm` dependency to the project.

### CDN Resolver Plugin:
* [`explorer_frontend/src/services/bundler/cdnResolverPlugin.ts`](diffhunk://#diff-b5d379f70e2be964b5245ab72ad2c76d705d587c8267dce536cdfa640b54875cR1-R127): Created a new CDN resolver plugin to handle npm package imports and resolve URLs for esbuild.

### Bundler Service:
* [`explorer_frontend/src/services/bundler/index.ts`](diffhunk://#diff-a2dc4066f6da9a3ff193adccd12412c01af828511c6ca0848fc4dba1a1050364R1-R66): Updated the bundler service to initialize esbuild with the new CDN resolver plugin and handle virtual entry files.

### Runner Service:
* [`explorer_frontend/src/services/runner.ts`](diffhunk://#diff-cbdcce3aa7f63d6b7940b64b13f1f4f2909e838afe0b51609500fefe7aa445d8R1-R5): Added a new `run` function to execute JavaScript code using a web worker.


Fixes #[Issue Number]  
or  
Related to #[Issue Number]

## Breaking Changes (if any)

<!-- OPTIONAL: Describe any breaking changes this PR introduces -->

## Screenshots / Visual Changes

<!-- OPTIONAL: Add screenshots, recordings, or visual references if relevant -->

## Checklist

_Please mark each item with an `x` inside the brackets (e.g., [x]) once completed._

- [ ] I have read and followed the [Contributing Guide](https://github.com/NilFoundation/nil/blob/main/CONTRIBUTION-GUIDE.md)
- [ ] I have tested the changes locally
- [ ] I have added relevant tests (if applicable)
- [ ] I have updated documentation/comments (if applicable)
