### PR TITLE
[indexer] Fix clickhouse driver for empty blocks table

### DIFF
--- a/nil/services/indexer/clickhouse/clickhouse.go
+++ b/nil/services/indexer/clickhouse/clickhouse.go
@@ -59,9 +59,6 @@ func (d *ClickhouseDriver) FetchLatestProcessedBlockId(ctx context.Context, id t
 	if err != nil {
 		return nil, err
 	}
-	if blockNum == types.InvalidBlockNumber {
-		return nil, nil
-	}
 	return &blockNum, nil
 }
 


### PR DESCRIPTION
Otherwise, it fails in `indexer.go:112` line due to nil pointer dereference.