### PR TITLE
feat(rollup contract): add state reset function

### DIFF
--- a/rollup-bridge-contracts/contracts/interfaces/INilRollup.sol
+++ b/rollup-bridge-contracts/contracts/interfaces/INilRollup.sol
@@ -22,6 +22,10 @@ interface INilRollup is INilAccessControl {
         bytes32 newStateRoot
     );
 
+    /// @notice Emitted when the state is successfully reset to a provided state root.
+    /// @param stateRoot The state root to which the system was reset.
+    event StateReset(bytes32 stateRoot);
+
     /*//////////////////////////////////////////////////////////////////////////
                                        STRUCTS
     //////////////////////////////////////////////////////////////////////////*/
@@ -63,9 +67,6 @@ interface INilRollup is INilAccessControl {
     /// @return The latest finalized batch index.
     function getLastFinalizedBatchIndex() external view returns (string memory);
 
-    /// @return The last committed batch index.
-    function getLastCommittedBatchIndex() external view returns (string memory);
-
     /// @param batchIndex The index of the batch.
     /// @return The state root of a finalized batch.
     function finalizedStateRoots(
@@ -99,6 +100,13 @@ interface INilRollup is INilAccessControl {
     function batchIndexOfRoot(
         bytes32 stateRoot
     ) external view returns (string memory);
+
+    /// @notice Returns the previous state root in the finalized batch history.
+    /// @param stateRoot The state root of a finalized batch.
+    /// @return The state root that immediately precedes the given stateRoot in the history.
+    function previousStateRoot(
+        bytes32 stateRoot
+    ) external view returns (bytes32);
 
     function getCurrentStateRoot() external view returns (bytes32);
 

--- a/rollup-bridge-contracts/test/BaseTest.sol
+++ b/rollup-bridge-contracts/test/BaseTest.sol
@@ -221,9 +221,6 @@ contract BaseTest is Test {
 
       vm.stopPrank();
 
-      string memory lastCommittedBatchIndex = rollup.getLastCommittedBatchIndex();
-      assertEq(lastCommittedBatchIndex, batchIndex);
-
       assertTrue(rollup.isBatchCommitted(batchIndex));
       assertFalse(rollup.isBatchFinalized(batchIndex));
 


### PR DESCRIPTION
## Short Summary

Add state reset function to the rollup contract so an admin could revert to specified state root.

## What Changes Were Made

- Added `resetState` function. When called, it traverses a chain of `batchInfoRecords` (chained via `oldStateRoot`) until `newStateRoot` equals `targetStateRoot`, removing batch info and corresponding `stateRootIndex` entries. Any unrelated or dangling batch entries are left untouched.
- Remove `lastCommittedBatchIndex` since it is not used anyway, and to keep it consistent during state reset we had to introduce another `committedBatchHistory`.

## Checklist

- [x] I have read and followed the [Contributing Guide](https://github.com/NilFoundation/nil/blob/main/CONTRIBUTION-GUIDE.md)
- [x] I have tested the changes locally
- [ ] I have added relevant tests (if applicable)
- [ ] I have updated documentation/comments (if applicable)
