### PR TITLE
[vm] use different salts for contracts that's created from EVM

### DIFF
--- a/nil/contracts/solidity/tests/Test.sol
+++ b/nil/contracts/solidity/tests/Test.sol
@@ -7,6 +7,7 @@ import "../lib/Nil.sol";
 contract Test is NilBase {
     event stubCalled(uint32 v);
     event testEvent(uint indexed a, uint indexed b);
+    event newContract(address);
 
     uint32 private internalValue = 0;
     uint256 private timestamp = 0;
@@ -274,6 +275,11 @@ contract Test is NilBase {
         bytes calldata
     ) external pure returns (bool) {
         return true;
+    }
+
+    function deployContract() public {
+        Empty newEmpty = new Empty();
+        emit newContract(address(newEmpty));
     }
 }
 

--- a/nil/tests/regression/regression_test.go
+++ b/nil/tests/regression/regression_test.go
@@ -449,6 +449,27 @@ func (s *SuiteRegression) TestBigTransactions() {
 	})
 }
 
+func (s *SuiteRegression) TestDeployFromContract() {
+	abi, err := contracts.GetAbi(contracts.NameTest)
+	s.Require().NoError(err)
+
+	calldata, err := abi.Pack("deployContract")
+	s.Require().NoError(err)
+
+	receipt := s.SendExternalTransactionNoCheck(calldata, s.testAddress)
+	s.Require().True(receipt.Success)
+
+	contractAddr1, err := abi.Unpack("newContract", receipt.Logs[0].Data)
+	s.Require().NoError(err)
+
+	receipt = s.SendExternalTransactionNoCheck(calldata, s.testAddress)
+	s.Require().True(receipt.Success)
+
+	contractAddr2, err := abi.Unpack("newContract", receipt.Logs[0].Data)
+	s.Require().NoError(err)
+	s.NotEqual(contractAddr1, contractAddr2)
+}
+
 func TestRegression(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Empty salt produced address collision error that can't be fixed. This patch doesn't solve a problem completely (since it's possible to construct a salt manually that will cause collision with suggested by Create function). But it makes factories at least usable.

"Uniqueness" of salt consists of following components: [part of address] + [seqno] + [ext seqno].
