### PR TITLE
feat: implemented nil config commands

### DIFF
--- a/clijs/src/commands/config/get.ts
+++ b/clijs/src/commands/config/get.ts
@@ -1,0 +1,40 @@
+import { Args } from "@oclif/core";
+import { BaseCommand } from "../../base.js";
+import { ConfigKeys } from "../../common/config.js";
+
+export default class ConfigGet extends BaseCommand {
+  static override description = "Get the value of a key from the config file";
+
+  static override examples = ["<%= config.bin %> <%= command.id %>"];
+
+  static args = {
+    key: Args.string({
+      description: "The key to get from the config file",
+      required: true,
+    }),
+  };
+
+  public async run(): Promise<string | undefined> {
+    const { args } = await this.parse(ConfigGet);
+    const { key } = args;
+
+    if (!this.configManager) {
+      this.error("Config manager is not initialized");
+    }
+
+    const value = this.configManager.getConfigValue(ConfigKeys.NilSection, key);
+
+    if (value === undefined) {
+      this.warn(`Key "${key}" is not found in the config file`);
+      return undefined;
+    }
+
+    if (this.quiet) {
+      this.log(value);
+    } else {
+      this.log(`${key}: ${value}`);
+    }
+
+    return value;
+  }
+}

--- a/clijs/src/commands/config/index.ts
+++ b/clijs/src/commands/config/index.ts
@@ -1,0 +1,9 @@
+import { Command } from "@oclif/core";
+
+export default class Config extends Command {
+  static override description = "Manage the =nil; CLI config";
+
+  async run(): Promise<void> {
+    await this.config.runCommand("help", ["config"]);
+  }
+}

--- a/clijs/src/commands/config/init.ts
+++ b/clijs/src/commands/config/init.ts
@@ -1,0 +1,13 @@
+import { BaseCommand } from "../../base.js";
+
+export default class ConfigInit extends BaseCommand {
+  static override description = "Initialize the config file";
+
+  static override examples = ["<%= config.bin %> <%= command.id %>"];
+
+  public async run(): Promise<string> {
+    await this.init();
+
+    return "config initialized";
+  }
+}

--- a/clijs/src/commands/config/set.ts
+++ b/clijs/src/commands/config/set.ts
@@ -1,0 +1,48 @@
+import { Args } from "@oclif/core";
+import { BaseCommand } from "../../base.js";
+import { ConfigKeys } from "../../common/config.js";
+
+// Supported options in the config file
+const supportedOptions = new Set([
+  ConfigKeys.RpcEndpoint,
+  ConfigKeys.CometaEndpoint,
+  ConfigKeys.FaucetEndpoint,
+  ConfigKeys.PrivateKey,
+  ConfigKeys.Address,
+]);
+
+export default class ConfigSet extends BaseCommand {
+  static override description = "Set the value of a key in the config file";
+
+  static override examples = ["<%= config.bin %> <%= command.id %>"];
+
+  static args = {
+    key: Args.string({
+      description: "The key to set in the config file",
+      required: true,
+    }),
+    value: Args.string({
+      description: "The value to set for the key",
+      required: true,
+    }),
+  };
+
+  public async run(): Promise<string> {
+    const { args } = await this.parse(ConfigSet);
+    const { key, value } = args;
+
+    if (!this.configManager) {
+      this.error("Config manager is not initialized");
+    }
+
+    if (!supportedOptions.has(key as ConfigKeys)) {
+      this.error(`Key "${key}" is not known`);
+    }
+
+    this.configManager.updateConfig(ConfigKeys.NilSection, key, value);
+
+    const formattedOutput = `Set "${key}" to "${value}"`;
+
+    return formattedOutput;
+  }
+}

--- a/clijs/src/commands/config/show.ts
+++ b/clijs/src/commands/config/show.ts
@@ -1,0 +1,28 @@
+import { BaseCommand } from "../../base.js";
+import { ConfigKeys } from "../../common/config.js";
+
+export default class ConfigShow extends BaseCommand {
+  static override description = "Show the contents of the config file";
+
+  static override examples = ["<%= config.bin %> <%= command.id %>"];
+
+  public async run(): Promise<string> {
+    if (!this.configManager) {
+      this.error("Config manager is not initialized");
+    }
+
+    const config = this.configManager.loadConfig();
+    const nilSection = config[ConfigKeys.NilSection] as Record<string, string>;
+
+    // Build the formatted output
+    let formattedOutput = "";
+
+    if (nilSection) {
+      for (const [key, value] of Object.entries(nilSection)) {
+        formattedOutput += `${key.padEnd(18)}: ${value}\n`;
+      }
+    }
+
+    return formattedOutput;
+  }
+}

--- a/clijs/src/sea.ts
+++ b/clijs/src/sea.ts
@@ -10,6 +10,11 @@ import AbiCommand from "./commands/abi";
 import AbiDecode from "./commands/abi/decode";
 import AbiEncode from "./commands/abi/encode";
 import BlockCommand from "./commands/block";
+import Config from "./commands/config";
+import ConfigGet from "./commands/config/get";
+import ConfigInit from "./commands/config/init";
+import ConfigSet from "./commands/config/set";
+import ConfigShow from "./commands/config/show";
 import SmartAccountBalance from "./commands/smart-account/balance.js";
 import SmartAccountCallReadOnly from "./commands/smart-account/call-readonly";
 import SmartAccountDeploy from "./commands/smart-account/deploy.js";
@@ -32,6 +37,12 @@ export const COMMANDS: Record<string, Command.Class> = {
   "abi:encode": AbiEncode,
 
   block: BlockCommand,
+
+  config: Config,
+  "config:get": ConfigGet,
+  "config:set": ConfigSet,
+  "config:init": ConfigInit,
+  "config:show": ConfigShow,
 
   keygen: Keygen,
   "keygen:new": KeygenNew,

--- a/clijs/test/commands/config/get.test.ts
+++ b/clijs/test/commands/config/get.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect } from "vitest";
+import ConfigManager from "../../../src/common/config.js";
+import { ConfigKeys } from "../../../src/common/config.js";
+import { CliTest } from "../../setup.js";
+
+describe("config:get", () => {
+  CliTest("gets a value from the config file", async ({ cfgPath, runCommand }) => {
+    const { result } = await runCommand(["config", "get", ConfigKeys.RpcEndpoint]);
+    const configManager = new ConfigManager(cfgPath);
+
+    expect(result).to.equal(
+      configManager.getConfigValue(ConfigKeys.NilSection, ConfigKeys.RpcEndpoint),
+    );
+  });
+
+  CliTest("returns undefined for non-existent key", async ({ runCommand }) => {
+    const { result } = await runCommand(["config", "get", "non_existent_key"]);
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/clijs/test/commands/config/init.test.ts
+++ b/clijs/test/commands/config/init.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect } from "vitest";
+import { CliTest } from "../../setup.js";
+
+describe("config:init", () => {
+  CliTest("initializes a new config file", async ({ runCommand }) => {
+    const { result } = await runCommand(["config", "init"]);
+
+    expect(result).toBeTypeOf("string");
+    expect(result).toBe("config initialized");
+  });
+});

--- a/clijs/test/commands/config/set.test.ts
+++ b/clijs/test/commands/config/set.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect } from "vitest";
+import ConfigManager from "../../../src/common/config.js";
+import { ConfigKeys } from "../../../src/common/config.js";
+import { CliTest } from "../../setup.js";
+
+describe("config:set", () => {
+  CliTest("sets a value in the config file", async ({ cfgPath, runCommand }) => {
+    const testKey = ConfigKeys.RpcEndpoint;
+    const testValue = "http://test.example.com:8529";
+    const { result } = await runCommand(["config", "set", testKey, testValue]);
+
+    expect(result).toEqual(`Set "${testKey}" to "${testValue}"`);
+
+    const configManager = new ConfigManager(cfgPath);
+    const value = configManager.getConfigValue(ConfigKeys.NilSection, testKey);
+    expect(value).toBe(testValue);
+  });
+
+  CliTest("returns undefined for unsupported key", async ({ runCommand }) => {
+    const { result, stderr } = await runCommand(["config", "set", "unsupported_key", "value"]);
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/clijs/test/commands/config/show.test.ts
+++ b/clijs/test/commands/config/show.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect } from "vitest";
+import ConfigManager from "../../../src/common/config.js";
+import { ConfigKeys } from "../../../src/common/config.js";
+import { CliTest } from "../../setup.js";
+
+describe("config:show", () => {
+  CliTest("shows the contents of the config file", async ({ cfgPath, runCommand }) => {
+    const configManager = new ConfigManager(cfgPath);
+    const testKey1 = ConfigKeys.RpcEndpoint;
+    const testValue1 = "http://test1.example.com:8529";
+    const testKey2 = ConfigKeys.CometaEndpoint;
+    const testValue2 = "http://test2.example.com:8529";
+
+    configManager.updateConfig(ConfigKeys.NilSection, testKey1, testValue1);
+    configManager.updateConfig(ConfigKeys.NilSection, testKey2, testValue2);
+
+    const { result } = await runCommand(["config", "show"]);
+
+    expect(result).toContain(`${testValue1}`);
+    expect(result).toContain(`${testValue2}`);
+  });
+});


### PR DESCRIPTION
## Short Summary
Implemented `clijs` config commands includng `get`, `show`, `init` and `set`

## What Changes Were Made

<!-- List the changes introduced in this PR -->

- implemented `nil config get` command
- implemented `nil config show` command
- implemented `nil config init` command
- implemented `nil config set` command

## Related Issue

<!-- If this PR addresses an existing issue, please link it here -->

Fixes #454
or  
Related to #[Issue Number]

## Breaking Changes (if any)

<!-- OPTIONAL: Describe any breaking changes this PR introduces -->

## Screenshots / Visual Changes

<!-- OPTIONAL: Add screenshots, recordings, or visual references if relevant -->

## Checklist

_Please mark each item with an `x` inside the brackets (e.g., [x]) once completed._

- [x] I have read and followed the [Contributing Guide](https://github.com/NilFoundation/nil/blob/main/CONTRIBUTION-GUIDE.md)
- [x] I have tested the changes locally
- [x] I have added relevant tests (if applicable)
- [ ] I have updated documentation/comments (if applicable)
