### PR TITLE
[playground] : added support for inputting arrays and tuple result parsing

### DIFF
--- a/explorer_frontend/src/features/contracts/components/Management/MethodInput.tsx
+++ b/explorer_frontend/src/features/contracts/components/Management/MethodInput.tsx
@@ -32,6 +32,13 @@ const MethodInput: FC<MethodInputProps> = ({
   const { type, name } = input;
   const [css, theme] = useStyletron();
 
+  const extractInputValue = (val: unknown) => {
+    if (typeof val === "object" && val !== null && "value" in val) {
+      return val.value;
+    }
+    return val;
+  };
+
   return (
     <div>
       {isAbiParameterTuple(input) ? (
@@ -94,7 +101,7 @@ const MethodInput: FC<MethodInputProps> = ({
                 },
               },
             }}
-            value={params?.[paramName] ? String(params[paramName]) : ""}
+            value={params?.[paramName] ? String(extractInputValue(params[paramName])) : ""}
             onChange={(e) => {
               const value = e.target.value;
               paramsHandler({ functionName: methodName, paramName, value });

--- a/explorer_frontend/src/features/contracts/utils.tsx
+++ b/explorer_frontend/src/features/contracts/utils.tsx
@@ -2,7 +2,15 @@ import type { AbiInternalType, AbiParameter } from "abitype";
 
 export function getResultDisplay(result: unknown): string {
   if (Array.isArray(result)) {
-    return result.map(getResultDisplay).join(", ");
+    return `[ ${result.map(getResultDisplay).join(", ")} ]`;
+  }
+
+  if (typeof result === "object" && result !== null) {
+    const entries = Object.entries(result)
+      .filter(([key]) => !/^\d+$/.test(key))
+      .map(([key, value]) => `${key}: ${getResultDisplay(value)}`);
+
+    return `{ ${entries.join(", ")} }`;
   }
 
   return String(result);

--- a/explorer_frontend/src/features/logs/init.tsx
+++ b/explorer_frontend/src/features/logs/init.tsx
@@ -9,6 +9,7 @@ import {
   registerContractInCometaFx,
   sendMethodFx,
 } from "../contracts/models/base";
+import { getResultDisplay } from "../contracts/utils.tsx";
 import {
   tutorialContractStepFailedEvent,
   tutorialContractStepPassedEvent,
@@ -209,7 +210,9 @@ $logs.on(callFx.doneData, (logs, { result, appName, functionName }) => {
         >{`${appName}.${functionName}()`}</MonoParagraphMedium>
       ),
       payload: (
-        <MonoParagraphMedium color={COLORS.gray400}>{`Result: ${result}`}</MonoParagraphMedium>
+        <MonoParagraphMedium
+          color={COLORS.gray400}
+        >{`Result: ${getResultDisplay(result)}`}</MonoParagraphMedium>
       ),
       timestamp: Date.now(),
     },


### PR DESCRIPTION
## Short Summary

This PR adds support to work with arrays in the playground and also parses tuple results which was not possible before. 

## What Changes Were Made

- Fix `MethodInput.tsx` for accepting an input. Previously, it would fill the input tab with `[object Object]` when you enter anything in the input placeholder
- Add support to input array type elements
- Fix parsing of tuples upon a view function call which returns a tuuple. Previously this would have resulted in `[object Object]` as the result of the function call

## Related Issue

<!-- If this PR addresses an existing issue, please link it here -->

Fixes https://github.com/NilFoundation/nil/issues/496
## Breaking Changes (if any)

None

## Screenshots / Visual Changes
None

## Additional Notes
This PR aims at solving the issues related to inputs that have been remained till now. To test all the inputs, there is a test contract. Copy this contract into the playground(local version) and compile and deploy and then call all the `store` functions. After that, call all the `stored` or `get` functions. You would be able to test that you can input almost every input type and see the results parsed of almsot all the input types. The contract to test, as mentioned is:
```solidity
// SPDX-License-Identifier: MIT
pragma solidity 0.8.26;

contract DataReceiver {
    struct MyTuple {
        uint256 id;
        string name;
        address owner;
    }

    MyTuple public storedTuple;

    uint256[] public uintArray;
    string[] public stringArray;

    bytes public storedBytes;
    uint256 public storedUint;
    string public storedString;
    address public storedAddress;
    bool public storedBool; 

    // Setters
    function storeTuple(uint256 _id, string memory _name, address _owner) external {
        storedTuple = MyTuple(_id, _name, _owner);
    }

    function storeBytes(bytes calldata _data) external {
        storedBytes = _data;
    }

    function storeUint(uint256 _num) external {
        storedUint = _num;
    }

    function storeString(string calldata _text) external {
        storedString = _text;
    }

    function storeAddress(address _addr) external {
        storedAddress = _addr;
    }

    function storeBool(bool _value) external payable {
        storedBool = _value;
    }

    function appendToUintArray(uint256[] calldata _values) external {
        for (uint256 i = 0; i < _values.length; i++) {
            uintArray.push(_values[i]);
        }
    }

    function appendToStringArray(string[] calldata _values) external {
        for (uint256 i = 0; i < _values.length; i++) {
            stringArray.push(_values[i]);
        }
    }

    // View functions
    function getTuple() external view returns (MyTuple memory) {
        return storedTuple;
    }

    function getUintArray() external view returns (uint256[] memory) {
        return uintArray;
    }

    function getStringArray() external view returns (string[] memory) {
        return stringArray;
    }

    function getBytes() external view returns (bytes memory) {
        return storedBytes;
    }

    function getUint() external view returns (uint256) {
        return storedUint;
    }

    function getString() external view returns (string memory) {
        return storedString;
    }

    function getAddress() external view returns (address) {
        return storedAddress;
    }

    function getBool() external view returns (bool) {
        return storedBool;
    }
}


```

You can also access the contract here: https://explore.nil.foundation/playground/e4e9a9b0b82512b2638f9aca62bc0dd54665dbad68479f6f16c5966cae17823f

## Checklist

_Please mark each item with an `x` inside the brackets (e.g., [x]) once completed._

- [x] I have read and followed the [Contributing Guide](https://github.com/NilFoundation/nil/blob/main/CONTRIBUTION-GUIDE.md)
- [x] I have tested the changes locally
- [ ] I have added relevant tests (if applicable)
- [ ] I have updated documentation/comments (if applicable)
