### PR TITLE
Several improvements after debugging cluster with Stresser

### DIFF
--- a/nil/cmd/indexer/main.go
+++ b/nil/cmd/indexer/main.go
@@ -83,6 +83,7 @@ You could config it via config file or flags or environment variables.`,
 	rootCmd.Flags().StringP("clickhouse-password", "p", "", "Clickhouse password")
 	rootCmd.Flags().StringP("clickhouse-database", "d", "", "Clickhouse database")
 	rootCmd.Flags().Bool("allow-db-clear", false, "Drop db if versions differ")
+	rootCmd.Flags().Bool("index-txpool", false, "Do indexing of txpool")
 
 	check.PanicIfErr(viper.BindPFlags(rootCmd.Flags()))
 
@@ -105,6 +106,7 @@ You could config it via config file or flags or environment variables.`,
 		Client:        rpc.NewClient(apiEndpoint, logger),
 		IndexerDriver: clickhouseDriver,
 		AllowDbDrop:   allowDbDrop,
+		DoIndexTxpool: viper.GetBool("index-txpool"),
 	}))
 
 	logger.Info().Msg("Indexer stopped")

--- a/nil/cmd/stresser/main.go
+++ b/nil/cmd/stresser/main.go
@@ -15,6 +15,7 @@ var logLevel *string
 
 func main() {
 	var configFile string
+	var taskName string
 	rootCmd := &cobra.Command{
 		Use:   "stresser --config <config-file>",
 		Short: "Run stresser",
@@ -22,7 +23,7 @@ func main() {
 			level, err := zerolog.ParseLevel(*logLevel)
 			check.PanicIfErr(err)
 			zerolog.SetGlobalLevel(level)
-			st, err := stresser.NewStresserFromFile(configFile)
+			st, err := stresser.NewStresserFromFile(configFile, taskName)
 			if err != nil {
 				return fmt.Errorf("failed to create stresser: %w", err)
 			}
@@ -34,6 +35,7 @@ func main() {
 	}
 
 	rootCmd.Flags().StringVarP(&configFile, "config", "c", "", "config file")
+	rootCmd.Flags().StringVarP(&taskName, "task", "t", "", "task name")
 	logLevel = rootCmd.Flags().StringP(
 		"log-level",
 		"l",

--- a/nil/contracts/solidity/tests/Stresser.sol
+++ b/nil/contracts/solidity/tests/Stresser.sol
@@ -3,9 +3,31 @@ pragma solidity ^0.8.26;
 
 import "../lib/NilTokenBase.sol";
 
+contract StresserFactory {
+
+    event deployed(address[] contracts);
+
+    function deployContracts(uint256 n, uint256 balance) public {
+        address[] memory res = new address[](n);
+        for (uint256 i = 0; i < n; i++) {
+            res[i] = address(new Stresser{salt: bytes32(abi.encodePacked(i)), value: balance}());
+        }
+        emit deployed(res);
+    }
+
+    function verifyExternal(
+        uint256,
+        bytes calldata
+    ) external pure returns (bool) {
+        return true;
+    }
+}
+
 contract Stresser {
 
     uint256 public value;
+    uint256[1024*1024] array;
+    mapping(uint256 => uint256) public map;
 
     constructor() payable {}
 
@@ -22,13 +44,24 @@ contract Stresser {
         return value;
     }
 
-    function sendTransactions(address[] memory addresses, uint256 v) public {
+    // Consumes gas by using cold SSTORE opcodes(~20331 gas per iteration)
+    function gasConsumerColdSSTORE(uint256 n) public returns(uint256) {
+        uint256 start = map[0];
+        for (uint256 i = start; i < n + start; i++) {
+            map[i] = i;
+        }
+        map[0] = start + n;
+        return start + n;
+    }
+
+    function asyncCalls(address[] memory addresses, uint256 n) public {
         for (uint256 i = 0; i < addresses.length; i++) {
+            gasConsumer(n/addresses.length);
             Nil.asyncCall(
                 addresses[i],
                 address(0),
                 0,
-                abi.encodeWithSignature("geometricSeq(uint256)", v)
+                abi.encodeWithSignature("gasConsumer(uint256)", n)
             );
         }
     }
@@ -51,7 +84,8 @@ contract Stresser {
         bool success,
         bytes memory,
         bytes memory
-    ) public pure {
+    ) public {
+        gasConsumer(10); // 5000 gas
         require(success, "Request failed");
     }
 
@@ -63,10 +97,16 @@ contract Stresser {
         if (n == 0) {
             return 1;
         }
+        if (gasConsumer(10) == n) { // 5000 gas
+            n++;
+        }
         bytes memory callData = abi.encodeWithSelector(this.factorialRec.selector, n - 1, address(this));
         (bytes memory returnData, bool success) = Nil.awaitCall(peer, Nil.ASYNC_REQUEST_MIN_GAS, callData);
         require(success, "awaitCall failed");
         uint256 prev = abi.decode(returnData, (uint256));
+        if (gasConsumer(10) == n) { // 5000 gas
+            n++;
+        }
         return n * prev;
     }
 

--- a/nil/internal/collate/proposer.go
+++ b/nil/internal/collate/proposer.go
@@ -21,7 +21,6 @@ import (
 )
 
 const (
-	defaultMaxInternalTxns               = 1000
 	defaultMaxGasInBlock                 = types.DefaultMaxGasInBlock
 	maxTxnsFromPool                      = 1000
 	defaultMaxForwardTransactionsInBlock = 200
@@ -48,9 +47,6 @@ type proposer struct {
 func newProposer(params *Params, topology ShardTopology, pool TxnPool, logger logging.Logger) *proposer {
 	if params.MaxGasInBlock == 0 {
 		params.MaxGasInBlock = defaultMaxGasInBlock
-	}
-	if params.MaxInternalTransactionsInBlock == 0 {
-		params.MaxInternalTransactionsInBlock = defaultMaxInternalTxns
 	}
 	if params.MaxForwardTransactionsInBlock == 0 {
 		params.MaxForwardTransactionsInBlock = defaultMaxForwardTransactionsInBlock
@@ -367,7 +363,6 @@ func (p *proposer) handleTransactionsFromNeighbors(tx db.RoTx) error {
 
 	checkLimits := func() bool {
 		return p.executionState.GasUsed < p.params.MaxGasInBlock &&
-			len(p.proposal.InternalTxnRefs) < p.params.MaxInternalTransactionsInBlock &&
 			len(p.proposal.ForwardTxnRefs) < p.params.MaxForwardTransactionsInBlock
 	}
 

--- a/nil/internal/collate/proposer.go
+++ b/nil/internal/collate/proposer.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	defaultMaxGasInBlock                 = types.DefaultMaxGasInBlock
-	maxTxnsFromPool                      = 1000
+	maxTxnsFromPool                      = 10_000
 	defaultMaxForwardTransactionsInBlock = 200
 
 	validatorPatchLevel = 1

--- a/nil/internal/collate/proposer_test.go
+++ b/nil/internal/collate/proposer_test.go
@@ -146,25 +146,14 @@ func (s *ProposerTestSuite) TestCollator() {
 		s.Equal(types.Value{}, s.getBalance(shardId, to))
 	})
 
-	// Now process internal transactions by one to test queueing.
-	p.params.MaxInternalTransactionsInBlock = 1
 	pool.Reset()
 
 	s.Run("ProcessInternalTransaction1", func() {
 		generateBlock()
 
 		s.Equal(balance, s.getMainBalance())
-		s.Equal(txnValue, s.getBalance(shardId, to))
+		s.Equal(txnValue.Mul(types.NewValueFromUint64(2)), s.getBalance(shardId, to))
 	})
-
-	s.Run("ProcessInternalTransaction2", func() {
-		generateBlock()
-
-		s.Equal(balance, s.getMainBalance())
-		s.Equal(txnValue.Add(txnValue), s.getBalance(shardId, to))
-	})
-
-	p.params.MaxInternalTransactionsInBlock = defaultMaxInternalTxns
 
 	s.Run("ProcessRefundTransactions", func() {
 		generateBlock()

--- a/nil/internal/collate/scheduler.go
+++ b/nil/internal/collate/scheduler.go
@@ -27,9 +27,8 @@ type Consensus interface {
 type Params struct {
 	execution.BlockGeneratorParams
 
-	MaxGasInBlock                  types.Gas
-	MaxInternalTransactionsInBlock int
-	MaxForwardTransactionsInBlock  int
+	MaxGasInBlock                 types.Gas
+	MaxForwardTransactionsInBlock int
 
 	CollatorTickPeriod time.Duration
 	Timeout            time.Duration

--- a/nil/internal/execution/state.go
+++ b/nil/internal/execution/state.go
@@ -1577,8 +1577,6 @@ func (es *ExecutionState) BuildBlock(blockId types.BlockNumber) (*BlockGeneratio
 			L1BlockNumber:       l1BlockNumber,
 			PatchLevel:          es.PatchLevel,
 			RollbackCounter:     es.RollbackCounter,
-			// TODO(@klonD90): remove this field after changing explorer
-			Timestamp: 0,
 		},
 		LogsBloom: types.CreateBloom(es.Receipts),
 	}

--- a/nil/internal/mpt/node.go
+++ b/nil/internal/mpt/node.go
@@ -5,7 +5,6 @@ import (
 
 	ssz "github.com/NilFoundation/fastssz"
 	"github.com/NilFoundation/nil/nil/common"
-	"github.com/iden3/go-iden3-crypto/poseidon"
 )
 
 type SszNodeKind = uint8
@@ -33,11 +32,7 @@ type Node interface {
 }
 
 func calcNodeKey(data []byte) []byte {
-	key := poseidon.Sum(data)
-	if len(key) != 32 {
-		key = common.BytesToHash(key).Bytes()
-	}
-	return key
+	return common.PoseidonHash(data).Bytes()
 }
 
 type NodeBase struct {

--- a/nil/internal/types/block.go
+++ b/nil/internal/types/block.go
@@ -47,7 +47,6 @@ type BlockData struct {
 	ChildBlocksRootHash common.Hash      `json:"childBlocksRootHash" ch:"child_blocks_root_hash"`
 	MainShardHash       common.Hash      `json:"mainShardHash" ch:"main_chain_hash"`
 	ConfigRoot          common.Hash      `json:"configRoot" ch:"config_root"`
-	Timestamp           uint64           `json:"timestamp" ch:"timestamp"`
 	BaseFee             Value            `json:"gasPrice" ch:"gas_price"`
 	GasUsed             Gas              `json:"gasUsed" ch:"gas_used"`
 	L1BlockNumber       uint64           `json:"l1BlockNumber" ch:"l1_block_number"`

--- a/nil/internal/types/ssz_test.go
+++ b/nil/internal/types/ssz_test.go
@@ -36,7 +36,7 @@ func TestSszBlock(t *testing.T) {
 	h, err := common.PoseidonSSZ(&block2)
 	require.NoError(t, err)
 
-	h2, err := hex.DecodeString("305b9ab7546ad01a500dd57f29935bc43648d3f428b8b3a8869ab33c543940db")
+	h2, err := hex.DecodeString("06411df0d6a1117252c30bb3aefdade2b02ffd9c87d445336859274266d74578")
 	require.NoError(t, err)
 
 	require.Equal(t, common.BytesToHash(h2), common.BytesToHash(h[:]))

--- a/nil/services/cliservice/block_format_test.go
+++ b/nil/services/cliservice/block_format_test.go
@@ -123,7 +123,6 @@ func TestDebugBlockToText(t *testing.T) {
 				ReceiptsRoot:        common.HexToHash("0xD15EA5E"),
 				ChildBlocksRootHash: common.HexToHash("0xDEADBABE"),
 				MainShardHash:       common.HexToHash("0xB16B055"),
-				Timestamp:           0x12345678,
 				GasUsed:             1234,
 			},
 			LogsBloom: types.Bloom{},
@@ -148,7 +147,7 @@ func TestDebugBlockToText(t *testing.T) {
 		text, err := s.debugBlockToText(types.ShardId(13), block, false, false)
 		require.NoError(t, err)
 
-		expectedText := `Block #100500 [0x000dba05b595d9709214a9f31c34785e40733b6a01d90f295a44e7ab9a861088] @ 13 shard
+		expectedText := `Block #100500 [0x000d56649371d4a16ffa8863401aa1d8c2bf71df8935a8349962b3d9ef0d3e8b] @ 13 shard
   PrevBlock: 0x00000000000000000000000000000000000000000000000000000000deadbeef
   BaseFee: 0
   GasUsed: 1234

--- a/nil/services/indexer/badger/badger.go
+++ b/nil/services/indexer/badger/badger.go
@@ -161,6 +161,10 @@ func (b *BadgerDriver) indexBlockTransactions(
 	return nil
 }
 
+func (d *BadgerDriver) IndexTxPool(ctx context.Context, txPoolStatuses []*driver.TxPoolStatus) error {
+	return errors.New("not implemented")
+}
+
 func getTransactionStatus(receipt *types.Receipt) indexertypes.AddressActionStatus {
 	if receipt.Success {
 		return indexertypes.Success

--- a/nil/services/indexer/badger/badger.go
+++ b/nil/services/indexer/badger/badger.go
@@ -133,13 +133,12 @@ func (b *BadgerDriver) indexBlockTransactions(
 		}
 
 		baseAction := indexertypes.AddressAction{
-			Hash:      hash,
-			From:      txn.From,
-			To:        txn.To,
-			Amount:    txn.Value,
-			Timestamp: db.Timestamp(block.Timestamp),
-			BlockId:   block.Id,
-			Status:    getTransactionStatus(receipt.decoded),
+			Hash:    hash,
+			From:    txn.From,
+			To:      txn.To,
+			Amount:  txn.Value,
+			BlockId: block.Id,
+			Status:  getTransactionStatus(receipt.decoded),
 		}
 
 		logger := logging.NewLogger("indexer-badger")
@@ -170,7 +169,7 @@ func getTransactionStatus(receipt *types.Receipt) indexertypes.AddressActionStat
 }
 
 func storeAddressAction(tx db.RwTx, address types.Address, action *indexertypes.AddressAction) error {
-	key := makeAddressActionKey(address, uint64(action.Timestamp), action.Hash)
+	key := makeAddressActionKey(address, uint64(action.BlockId), action.Hash)
 	value, err := json.Marshal(action)
 	if err != nil {
 		return fmt.Errorf("failed to serialize address action: %w", err)
@@ -196,7 +195,7 @@ func makeAddressActionTimestampKey(address types.Address, timestamp uint64) []by
 func (b *BadgerDriver) FetchAddressActions(
 	ctx context.Context,
 	address types.Address,
-	since db.Timestamp,
+	since types.BlockNumber,
 ) ([]indexertypes.AddressAction, error) {
 	actions := make([]indexertypes.AddressAction, 0)
 	const limit = 100

--- a/nil/services/indexer/cfg.go
+++ b/nil/services/indexer/cfg.go
@@ -10,4 +10,5 @@ type Cfg struct {
 	Client        client.Client
 	BlocksChan    chan *driver.BlockWithShardId
 	AllowDbDrop   bool
+	DoIndexTxpool bool
 }

--- a/nil/services/indexer/clickhouse/reflection.go
+++ b/nil/services/indexer/clickhouse/reflection.go
@@ -122,7 +122,11 @@ func reflectSchemeToClickhouse(f any) (reflectedScheme, error) {
 		if fieldNameInDb == "-" {
 			continue
 		}
-		if field.Type.Kind() == reflect.Struct {
+		switch {
+		case field.Type.PkgPath() == "time" && field.Type.Name() == "Time":
+			fieldTypes[fieldNameInDb] = "DateTime64"
+			fieldNames[field.Name] = fieldNameInDb
+		case field.Type.Kind() == reflect.Struct:
 			if field.Type.Name() == "Value" {
 				fieldTypes[fieldNameInDb] = "UInt256"
 				fieldNames[field.Name] = fieldNameInDb
@@ -138,7 +142,7 @@ func reflectSchemeToClickhouse(f any) (reflectedScheme, error) {
 				return reflectedScheme{}, err
 			}
 			additionalSchemes = append(additionalSchemes, scheme)
-		} else {
+		default:
 			fieldTypes[fieldNameInDb] = mapTypeToClickhouseType(field.Type)
 			fieldNames[field.Name] = fieldNameInDb
 		}

--- a/nil/services/indexer/driver/driver.go
+++ b/nil/services/indexer/driver/driver.go
@@ -14,7 +14,7 @@ type IndexerDriver interface {
 	FetchLatestProcessedBlockId(context.Context, types.ShardId) (*types.BlockNumber, error)
 	FetchEarliestAbsentBlockId(context.Context, types.ShardId) (types.BlockNumber, error)
 	FetchNextPresentBlockId(context.Context, types.ShardId, types.BlockNumber) (types.BlockNumber, error)
-	FetchAddressActions(context.Context, types.Address, db.Timestamp) ([]indexertypes.AddressAction, error)
+	FetchAddressActions(context.Context, types.Address, types.BlockNumber) ([]indexertypes.AddressAction, error)
 	SetupScheme(ctx context.Context, params SetupParams) error
 	IndexBlocks(context.Context, []*BlockWithShardId) error
 	HaveBlock(context.Context, types.ShardId, types.BlockNumber) (bool, error)

--- a/nil/services/indexer/driver/driver.go
+++ b/nil/services/indexer/driver/driver.go
@@ -2,11 +2,12 @@ package driver
 
 import (
 	"context"
+	"time"
 
 	"github.com/NilFoundation/nil/nil/common"
-	"github.com/NilFoundation/nil/nil/internal/db"
 	"github.com/NilFoundation/nil/nil/internal/types"
 	indexertypes "github.com/NilFoundation/nil/nil/services/indexer/types"
+	"github.com/NilFoundation/nil/nil/services/rpc/jsonrpc"
 )
 
 type IndexerDriver interface {
@@ -17,6 +18,7 @@ type IndexerDriver interface {
 	FetchAddressActions(context.Context, types.Address, types.BlockNumber) ([]indexertypes.AddressAction, error)
 	SetupScheme(ctx context.Context, params SetupParams) error
 	IndexBlocks(context.Context, []*BlockWithShardId) error
+	IndexTxPool(context.Context, []*TxPoolStatus) error
 	HaveBlock(context.Context, types.ShardId, types.BlockNumber) (bool, error)
 }
 
@@ -29,4 +31,10 @@ type SetupParams struct {
 	AllowDbDrop bool
 	// Version is the hash of the genesis block of the main shard (must become more complex later).
 	Version common.Hash
+}
+
+type TxPoolStatus struct {
+	jsonrpc.TxPoolStatus
+	ShardId   types.ShardId `ch:"shard_id"`
+	Timestamp time.Time     `ch:"timestamp"`
 }

--- a/nil/services/indexer/service.go
+++ b/nil/services/indexer/service.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/NilFoundation/nil/nil/common/logging"
-	"github.com/NilFoundation/nil/nil/internal/db"
 	"github.com/NilFoundation/nil/nil/internal/types"
 	"github.com/NilFoundation/nil/nil/services/indexer/badger"
 	"github.com/NilFoundation/nil/nil/services/indexer/clickhouse"
@@ -55,7 +54,7 @@ type IndexerJsonRpc interface {
 	GetAddressActions(
 		ctx context.Context,
 		address types.Address,
-		since db.Timestamp,
+		since types.BlockNumber,
 	) ([]indexertypes.AddressAction, error)
 }
 
@@ -98,7 +97,7 @@ func NewService(ctx context.Context, cfg *Config) (*Service, error) {
 func (s *Service) GetAddressActions(
 	ctx context.Context,
 	address types.Address,
-	since db.Timestamp,
+	since types.BlockNumber,
 ) ([]indexertypes.AddressAction, error) {
 	return s.Driver.FetchAddressActions(ctx, address, since)
 }

--- a/nil/services/indexer/service_test.go
+++ b/nil/services/indexer/service_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/NilFoundation/nil/nil/client"
-	"github.com/NilFoundation/nil/nil/internal/db"
 	"github.com/NilFoundation/nil/nil/internal/types"
 	"github.com/NilFoundation/nil/nil/services/indexer/driver"
 	indexertypes "github.com/NilFoundation/nil/nil/services/indexer/types"
@@ -89,8 +88,7 @@ func (s *SuiteServiceTest) TestGetAddressActions() {
 			BlockWithExtractedData: &types.BlockWithExtractedData{
 				Block: &types.Block{
 					BlockData: types.BlockData{
-						Id:        1,
-						Timestamp: 1000,
+						Id: 1,
 					},
 				},
 				InTransactions: []*types.Transaction{tx1},
@@ -102,8 +100,7 @@ func (s *SuiteServiceTest) TestGetAddressActions() {
 			BlockWithExtractedData: &types.BlockWithExtractedData{
 				Block: &types.Block{
 					BlockData: types.BlockData{
-						Id:        2,
-						Timestamp: 2000,
+						Id: 2,
 					},
 				},
 				InTransactions: []*types.Transaction{tx2},
@@ -121,7 +118,7 @@ func (s *SuiteServiceTest) TestGetAddressActions() {
 	tests := []struct {
 		name     string
 		address  types.Address
-		since    db.Timestamp
+		since    types.BlockNumber
 		expected []indexertypes.AddressAction
 	}{
 		{
@@ -130,41 +127,38 @@ func (s *SuiteServiceTest) TestGetAddressActions() {
 			since:   0,
 			expected: []indexertypes.AddressAction{
 				{
-					Hash:      tx1Hash,
-					From:      addr1,
-					To:        addr2,
-					Amount:    types.NewValueFromUint64(100),
-					Timestamp: 1000,
-					BlockId:   1,
-					Type:      indexertypes.SendEth,
-					Status:    indexertypes.Success,
+					Hash:    tx1Hash,
+					From:    addr1,
+					To:      addr2,
+					Amount:  types.NewValueFromUint64(100),
+					BlockId: 1,
+					Type:    indexertypes.SendEth,
+					Status:  indexertypes.Success,
 				},
 				{
-					Hash:      tx2Hash,
-					From:      addr2,
-					To:        addr1,
-					Amount:    types.NewValueFromUint64(200),
-					Timestamp: 2000,
-					BlockId:   2,
-					Type:      indexertypes.ReceiveEth,
-					Status:    indexertypes.Success,
+					Hash:    tx2Hash,
+					From:    addr2,
+					To:      addr1,
+					Amount:  types.NewValueFromUint64(200),
+					BlockId: 2,
+					Type:    indexertypes.ReceiveEth,
+					Status:  indexertypes.Success,
 				},
 			},
 		},
 		{
 			name:    "Get actions for addr1 since timestamp 1500",
 			address: addr1,
-			since:   1500,
+			since:   2,
 			expected: []indexertypes.AddressAction{
 				{
-					Hash:      tx2Hash,
-					From:      addr2,
-					To:        addr1,
-					Amount:    types.NewValueFromUint64(200),
-					Timestamp: 2000,
-					BlockId:   2,
-					Type:      indexertypes.ReceiveEth,
-					Status:    indexertypes.Success,
+					Hash:    tx2Hash,
+					From:    addr2,
+					To:      addr1,
+					Amount:  types.NewValueFromUint64(200),
+					BlockId: 2,
+					Type:    indexertypes.ReceiveEth,
+					Status:  indexertypes.Success,
 				},
 			},
 		},

--- a/nil/services/indexer/types/types.go
+++ b/nil/services/indexer/types/types.go
@@ -10,14 +10,13 @@ import (
 )
 
 type AddressAction struct {
-	Hash      common.Hash         `json:"hash"`
-	From      types.Address       `json:"from"`
-	To        types.Address       `json:"to"`
-	Amount    types.Value         `json:"amount"`
-	Timestamp db.Timestamp        `json:"timestamp"`
-	BlockId   types.BlockNumber   `json:"blockId"`
-	Type      AddressActionKind   `json:"type"`
-	Status    AddressActionStatus `json:"status"`
+	Hash    common.Hash         `json:"hash"`
+	From    types.Address       `json:"from"`
+	To      types.Address       `json:"to"`
+	Amount  types.Value         `json:"amount"`
+	BlockId types.BlockNumber   `json:"blockId"`
+	Type    AddressActionKind   `json:"type"`
+	Status  AddressActionStatus `json:"status"`
 }
 
 type AddressActionKind uint8

--- a/nil/services/indexer/types/types.go
+++ b/nil/services/indexer/types/types.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/NilFoundation/nil/nil/common"
-	"github.com/NilFoundation/nil/nil/internal/db"
 	"github.com/NilFoundation/nil/nil/internal/types"
 )
 

--- a/nil/services/rpc/jsonrpc/txpool_api.go
+++ b/nil/services/rpc/jsonrpc/txpool_api.go
@@ -9,8 +9,8 @@ import (
 )
 
 type TxPoolStatus struct {
-	Pending uint64 `json:"pending"`
-	Queued  uint64 `json:"queued"`
+	Pending uint64 `json:"pending" ch:"pending"`
+	Queued  uint64 `json:"queued" ch:"queued"`
 }
 
 type TxPoolContent struct {

--- a/nil/services/rpc/rawapi/local_txnpool.go
+++ b/nil/services/rpc/rawapi/local_txnpool.go
@@ -27,11 +27,11 @@ func (api *LocalShardApi) SendTransaction(ctx context.Context, encoded []byte) (
 }
 
 func (api *LocalShardApi) GetTxpoolStatus(ctx context.Context) (uint64, error) {
-	return uint64(api.txnpool.GetQueue().Len()), nil
+	return uint64(api.txnpool.GetPendingLength()), nil
 }
 
 func (api *LocalShardApi) GetTxpoolContent(ctx context.Context) ([]*types.Transaction, error) {
-	txns, err := api.txnpool.Peek(api.txnpool.GetQueue().Len())
+	txns, err := api.txnpool.Peek(0)
 	if err != nil {
 		return nil, err
 	}

--- a/nil/services/stresser/core/helper.go
+++ b/nil/services/stresser/core/helper.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/big"
 	"time"
 
 	"github.com/NilFoundation/nil/nil/client"
@@ -49,6 +50,89 @@ func (h *Helper) WaitClusterReady(numShards int) error {
 		})
 }
 
+func (h *Helper) DeployStressers(shardId types.ShardId, num int) ([]*Contract, error) {
+	code, err := contracts.GetCode("tests/StresserFactory")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get code for StresserFactory: %w", err)
+	}
+	payload := types.BuildDeployPayload(code, types.GenerateRandomHash())
+
+	addr := types.CreateAddress(shardId, payload)
+
+	topUpValue := types.GasToValue(100_000_000_000_000)
+	balancePerStresser := topUpValue.Sub(types.GasToValue(10_000_000_000)).Div(types.NewValueFromUint64(uint64(num)))
+	h.logger.Info().
+		Stringer("topUpValue", topUpValue).
+		Stringer("balancePerStresser", balancePerStresser).
+		Int("num", num).
+		Int("shard", int(shardId)).
+		Msg("Start deploying stresses")
+
+	topUpTries := 3
+	for ; topUpTries != 0; topUpTries-- {
+		if err = h.TopUp(addr, topUpValue); err != nil {
+			h.logger.Warn().Err(err).Msgf("Failed to top up %s", addr.Hex())
+		}
+	}
+	if topUpTries == 0 {
+		return nil, fmt.Errorf("failed to top up %s: %w", addr.Hex(), err)
+	}
+
+	txHash, addr, err := h.Client.DeployExternal(h.ctx, shardId, payload, types.NewFeePackFromGas(100_000_000))
+	if err != nil {
+		return nil, fmt.Errorf("failed to deploy StresserFactory at %s: %w", addr, err)
+	}
+	receipt, err := common.WaitForValue(h.ctx, 20*time.Second, 500*time.Millisecond,
+		func(ctx context.Context) (*jsonrpc.RPCReceipt, error) {
+			return h.Client.GetInTransactionReceipt(ctx, txHash)
+		})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get receipt: %w", err)
+	}
+	if !receipt.Success {
+		return nil, fmt.Errorf("failed to deploy contract at %s: %s", addr, receipt.Status)
+	}
+	balance, _ := h.Client.GetBalance(h.ctx, addr, "latest")
+	h.logger.Debug().Stringer("balance", balance).Msgf("Factory deployed on shard %d", shardId)
+
+	factory, err := NewContract("tests/StresserFactory", addr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create factory contract: %w", err)
+	}
+	txparams := &TxParams{FeePack: types.NewFeePackFromGas(100_000_000)}
+	receipt, err = h.CallAndWait(factory, "deployContracts", txparams, big.NewInt(int64(num)),
+		balancePerStresser.ToBig())
+	if err != nil {
+		return nil, fmt.Errorf("failed to deploy stresses: %w", err)
+	}
+	if len(receipt.Logs) != 1 {
+		return nil, fmt.Errorf("unexpected number of logs: %d(expected 1)", len(receipt.Logs))
+	}
+	unpacked, err := factory.Abi.Unpack("deployed", receipt.Logs[0].Data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unpack Deployed event: %w", err)
+	}
+	if len(unpacked) != 1 {
+		return nil, fmt.Errorf("unexpected number of arguments in `deployed` event: %d(expected 1)", len(unpacked))
+	}
+	addresses, ok := unpacked[0].([]types.Address)
+	if !ok {
+		return nil, errors.New("unexpected type of `deployed` event")
+	}
+	if len(addresses) != num {
+		return nil, fmt.Errorf("unexpected number of deployed contracts: %d(expected %d)", len(addresses), num)
+	}
+	res := make([]*Contract, num)
+	for i, addr := range addresses {
+		res[i], err = NewContract("tests/Stresser", addr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create stresser contract: %w", err)
+		}
+	}
+
+	return res, nil
+}
+
 func (h *Helper) DeployContract(name string, shardId types.ShardId) (*Contract, error) {
 	h.logger.Debug().Msgf("Start deploying contract: %s on shard %d", name, shardId)
 
@@ -61,11 +145,10 @@ func (h *Helper) DeployContract(name string, shardId types.ShardId) (*Contract, 
 
 	addr := types.CreateAddress(shardId, payload)
 
-	topUpValue := types.GasToValue(10_000_000_000)
+	topUpValue := types.GasToValue(100_000_000_000)
 
 	topUpTries := 3
 	for ; topUpTries != 0; topUpTries-- {
-		topUpValue = topUpValue.Mul(topUpValue)
 		if err = h.TopUp(addr, topUpValue); err == nil {
 			break
 		}
@@ -105,26 +188,46 @@ func (h *Helper) DeployContract(name string, shardId types.ShardId) (*Contract, 
 
 type TxParams struct {
 	FeePack types.FeePack
-	Value   *types.Value
+	Value   types.Value
 }
 
-func (h *Helper) Call(contract *Contract, method string, params *TxParams, args ...any) (*Transaction, error) {
+func (h *Helper) Call(contract *Contract, method string, params *TxParams, args ...any) (common.Hash, error) {
 	calldata, err := contract.PackCallData(method, args...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to pack call data: %w", err)
+		return common.EmptyHash, fmt.Errorf("failed to pack call data: %w", err)
 	}
 	feePack := params.FeePack
 	if feePack.FeeCredit.IsZero() {
 		feePack = types.NewFeePackFromGas(1_000_000)
 	}
-	tx, err := h.Client.SendExternalTransaction(h.ctx, calldata, contract.Address, nil, feePack)
+	txHash, err := h.Client.SendExternalTransaction(h.ctx, calldata, contract.Address, nil, feePack)
 	if err != nil {
-		return nil, fmt.Errorf("failed to send external transaction: %w", err)
+		return common.EmptyHash, fmt.Errorf("failed to send external transaction: %w", err)
 	}
+	return txHash, nil
+}
 
-	txn := NewTransaction(tx)
-
-	return txn, nil
+func (h *Helper) CallAndWait(
+	contract *Contract,
+	method string,
+	params *TxParams,
+	args ...any,
+) (*jsonrpc.RPCReceipt, error) {
+	txHash, err := h.Call(contract, method, params, args...)
+	if err != nil {
+		return nil, err
+	}
+	receipt, err := common.WaitForValue(h.ctx, 300*time.Second, 500*time.Millisecond,
+		func(ctx context.Context) (*jsonrpc.RPCReceipt, error) {
+			return h.Client.GetInTransactionReceipt(ctx, txHash)
+		})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get receipt: %w", err)
+	}
+	if !receipt.Success {
+		return nil, fmt.Errorf("failed to call %s: %s", method, receipt.Status)
+	}
+	return receipt, nil
 }
 
 func (h *Helper) TopUp(addr types.Address, value types.Value) error {
@@ -141,7 +244,7 @@ func (h *Helper) TopUp(addr types.Address, value types.Value) error {
 }
 
 func (h *Helper) WaitTx(tx common.Hash) (*jsonrpc.RPCReceipt, error) {
-	return common.WaitForValue(h.ctx, 30*time.Second, 500*time.Millisecond,
+	return common.WaitForValue(h.ctx, 10*time.Second, 1000*time.Millisecond,
 		func(ctx context.Context) (*jsonrpc.RPCReceipt, error) {
 			receipt, err := h.Client.GetInTransactionReceipt(ctx, tx)
 			if err != nil {

--- a/nil/services/stresser/instance.go
+++ b/nil/services/stresser/instance.go
@@ -21,6 +21,8 @@ type NildInstance struct {
 	logger     logging.Logger
 }
 
+var nildIndex = 0
+
 func (n *NildInstance) Init(nildPath string, workingDir string) error {
 	n.logger = logging.NewLogger(n.Name)
 
@@ -35,7 +37,13 @@ func (n *NildInstance) Init(nildPath string, workingDir string) error {
 	if n.IsRpc {
 		cmd = "rpc"
 	}
-	n.cmd = exec.Command(nildPath, cmd, "--config", cfgFile, "-l", "debug", "--log-filter", "-consensus", "--dev-api")
+
+	const profilePortBase = 6000
+	profPort := profilePortBase + nildIndex
+
+	nildIndex++
+	n.cmd = exec.Command(nildPath, cmd, "--config", cfgFile, "-l", "warn", "--log-filter", "-consensus", "--dev-api",
+		"--pprof-port", strconv.Itoa(profPort))
 	n.cmd.Dir = n.workingDir
 
 	return nil

--- a/nil/services/stresser/workload/await_call.go
+++ b/nil/services/stresser/workload/await_call.go
@@ -13,29 +13,22 @@ import (
 // It is quite expensive since it produces a lot of transactions. The intensity of the workload can be controlled
 // by setting N and ContractsNumToSend to a smaller value.
 type AwaitCall struct {
-	WorkloadBase       `yaml:",inline"`
-	N                  uint32 `yaml:"n"`                  // Depth of the factorial
-	ContractsNumToSend int    `yaml:"contractsNumToSend"` // Number of contracts to send transactions to
+	WorkloadBase `yaml:",inline"`
+	N            uint32 `yaml:"n"` // Depth of the factorial
 }
 
 func (w *AwaitCall) Init(ctx context.Context, client *core.Helper, args *WorkloadParams) error {
 	w.WorkloadBase.Init(ctx, client, args)
-	if w.ContractsNumToSend > len(args.Contracts) {
-		w.ContractsNumToSend = len(args.Contracts)
-	}
 	w.logger = logging.NewLogger("await_call")
 	return nil
 }
 
-func (w *AwaitCall) Run(ctx context.Context, args *RunParams) ([]*core.Transaction, error) {
+func (w *AwaitCall) Run(ctx context.Context, args *RunParams) error {
 	options := &core.TxParams{FeePack: types.NewFeePackFromGas(100_000_000)}
-	contractsNumToSend := w.ContractsNumToSend
-	start := 0
-	if contractsNumToSend < len(w.params.Contracts) {
-		start = rand.Intn(len(w.params.Contracts) - contractsNumToSend) //nolint:gosec
-	}
 
-	for i, contract := range w.params.Contracts[start : start+contractsNumToSend] {
+	start := rand.Intn(len(w.params.Contracts)) //nolint:gosec
+	for i := range w.Iterations {
+		contract := w.getContract(start + i)
 		var peer types.Address
 		if i == 0 {
 			peer = w.params.Contracts[len(w.params.Contracts)-1].Address
@@ -43,11 +36,9 @@ func (w *AwaitCall) Run(ctx context.Context, args *RunParams) ([]*core.Transacti
 			peer = w.params.Contracts[i-1].Address
 		}
 
-		if tx, err := w.client.Call(contract, "factorialAwait", options, w.N, peer); err != nil {
+		if _, err := w.client.Call(contract, "factorialAwait", options, w.N, peer); err != nil {
 			w.logger.Error().Err(err).Msg("failed to call factorialAwait")
-		} else {
-			w.AddTx(tx)
 		}
 	}
-	return w.txs, nil
+	return nil
 }

--- a/nil/services/stresser/workload/block_range.go
+++ b/nil/services/stresser/workload/block_range.go
@@ -31,9 +31,7 @@ func (w *BlockRange) Init(ctx context.Context, client *core.Helper, args *Worklo
 	return nil
 }
 
-func (w *BlockRange) Run(ctx context.Context, args *RunParams) (
-	[]*core.Transaction, error,
-) {
+func (w *BlockRange) Run(ctx context.Context, args *RunParams) error {
 	for shard := range w.params.NumShards {
 		block, err := w.client.Client.GetBlock(ctx, types.ShardId(shard), "latest", true)
 		if err != nil {
@@ -52,5 +50,5 @@ func (w *BlockRange) Run(ctx context.Context, args *RunParams) (
 		}
 	}
 
-	return w.txs, nil
+	return nil
 }

--- a/nil/services/stresser/workload/blockchain_metrics.go
+++ b/nil/services/stresser/workload/blockchain_metrics.go
@@ -10,10 +10,6 @@ import (
 	"go.opentelemetry.io/otel/metric"
 )
 
-const (
-	batchSize = 20
-)
-
 var (
 	meter               = telemetry.NewMeter("stresser")
 	blockTxsNum         = telemetry.Int64Gauge(meter, "block_txs_num")
@@ -46,7 +42,9 @@ func (w *BlockchainMetrics) Init(ctx context.Context, client *core.Helper, args 
 	return nil
 }
 
-func (w *BlockchainMetrics) Run(ctx context.Context, args *RunParams) ([]*core.Transaction, error) {
+func (w *BlockchainMetrics) Run(ctx context.Context, args *RunParams) error {
+	const batchSize = 20
+
 	for shard := range w.params.NumShards {
 		block, err := w.client.Client.GetBlock(ctx, types.ShardId(shard), "latest", true)
 		if err != nil {
@@ -97,5 +95,5 @@ func (w *BlockchainMetrics) Run(ctx context.Context, args *RunParams) ([]*core.T
 		}
 	}
 
-	return nil, nil
+	return nil
 }

--- a/nil/services/stresser/workload/do_panic.go
+++ b/nil/services/stresser/workload/do_panic.go
@@ -17,8 +17,8 @@ func (w *DoPanic) Init(ctx context.Context, client *core.Helper, params *Workloa
 	return nil
 }
 
-func (w *DoPanic) Run(ctx context.Context, args *RunParams) ([]*core.Transaction, error) {
+func (w *DoPanic) Run(ctx context.Context, args *RunParams) error {
 	_, err := w.client.Client.DoPanicOnShard(ctx, w.ShardId)
 	w.logger.Info().Err(err).Msg("do panic")
-	return nil, err
+	return err
 }

--- a/nil/services/stresser/workload/send_requests.go
+++ b/nil/services/stresser/workload/send_requests.go
@@ -13,29 +13,33 @@ type SendRequests struct {
 	WorkloadBase `yaml:",inline"`
 	GasRange     Range `yaml:"gasRange"`
 	RequestsNum  int   `yaml:"requestsNum"`
+	AsyncCall    bool  `yaml:"asyncCall"`
 	addresses    []types.Address
+	mathodName   string
 }
 
 func (w *SendRequests) Init(ctx context.Context, client *core.Helper, args *WorkloadParams) error {
 	w.WorkloadBase.Init(ctx, client, args)
 	w.addresses = make([]types.Address, 0, w.RequestsNum)
-	for _, cntr := range args.Contracts {
-		w.addresses = append(w.addresses, cntr.Address)
+	for range w.RequestsNum {
+		w.addresses = append(w.addresses, w.getRandomContract().Address)
 	}
 	w.logger = logging.NewLogger("send_requests")
+	w.mathodName = "sendRequests"
+	if w.AsyncCall {
+		w.mathodName = "asyncCalls"
+	}
 	return nil
 }
 
-func (w *SendRequests) Run(ctx context.Context, args *RunParams) ([]*core.Transaction, error) {
+func (w *SendRequests) Run(ctx context.Context, args *RunParams) error {
 	params := &core.TxParams{FeePack: types.NewFeePackFromGas(100_000_000)}
-	for _, contract := range w.params.Contracts {
+	for i := range w.Iterations {
+		contract := w.getContract(i)
 		n := getNumForGasConsumer(w.GasRange.RandomValue())
-		tx, err := w.client.Call(contract, "sendRequests", params, w.addresses, big.NewInt(int64(n)))
-		if err != nil {
+		if _, err := w.client.Call(contract, w.mathodName, params, w.addresses, big.NewInt(int64(n))); err != nil {
 			w.logger.Error().Err(err).Msg("failed to call sendRequests")
-		} else {
-			w.AddTx(tx)
 		}
 	}
-	return w.txs, nil
+	return nil
 }

--- a/nil/services/stresser/workload/send_value.go
+++ b/nil/services/stresser/workload/send_value.go
@@ -1,0 +1,32 @@
+package workload
+
+import (
+	"context"
+
+	"github.com/NilFoundation/nil/nil/internal/types"
+	"github.com/NilFoundation/nil/nil/services/stresser/core"
+)
+
+// SendValue is a workload that sends just a value(no calldata) to a contract.
+type SendValue struct {
+	WorkloadBase `yaml:",inline"`
+}
+
+func (w *SendValue) Init(ctx context.Context, client *core.Helper, params *WorkloadParams) error {
+	w.WorkloadBase.Init(ctx, client, params)
+	return nil
+}
+
+func (w *SendValue) Run(ctx context.Context, args *RunParams) error {
+	options := &core.TxParams{
+		FeePack: types.NewFeePackFromGas(100_000_000),
+		Value:   types.NewValueFromUint64(1000),
+	}
+	w.batchedFor(func(idx int) {
+		contract := w.getContract(idx)
+		if _, err := w.client.Call(contract, "", options); err != nil {
+			w.logger.Error().Err(err).Msg("failed to call contract")
+		}
+	})
+	return nil
+}

--- a/nil/services/stresser/workload/workload.go
+++ b/nil/services/stresser/workload/workload.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -14,23 +15,21 @@ import (
 
 type Workload interface {
 	Init(ctx context.Context, client *core.Helper, args *WorkloadParams) error
+	GetName() string
 	PreRun(ctx context.Context, args *RunParams)
-	Run(ctx context.Context, args *RunParams) ([]*core.Transaction, error)
+	Run(ctx context.Context, args *RunParams) error
 	TotalTxsNum() int
 	CheckIsReady() bool
 }
 
 type WorkloadBase struct {
-	Interval       time.Duration `yaml:"interval"`
-	WaitTxsTimeout time.Duration `yaml:"waitTxsTimeout"`
+	Interval   time.Duration `yaml:"interval"`
+	Iterations int           `yaml:"iterations"`
+	Name       string        `yaml:"name"`
 
 	params WorkloadParams
 	// Time of the workload last start, used to calculate the interval.
 	lastStartTm time.Time
-	// List of created transactions on each run. We can use local array and return it on each run, but we also need
-	// to take into account that we don't need to add transactions if WaitTxsTimeout!=0. Now it is checked in one place
-	// instead of checking it in each workload.
-	txs []*core.Transaction
 	// Total number of transactions sent by the workload
 	totalTxsNum atomic.Int64
 
@@ -49,11 +48,15 @@ func (w *WorkloadBase) Init(ctx context.Context, client *core.Helper, args *Work
 	w.client = client
 	w.params = *args
 	w.lastStartTm = time.Now()
+	check.PanicIfNotf(w.Name != "", "workload name should not be empty")
+	w.logger = logging.NewLogger(w.Name)
 }
 
-func (w *WorkloadBase) PreRun(ctx context.Context, args *RunParams) {
-	w.txs = nil
+func (w *WorkloadBase) GetName() string {
+	return w.Name
 }
+
+func (w *WorkloadBase) PreRun(ctx context.Context, args *RunParams) {}
 
 func (w *WorkloadBase) CheckIsReady() bool {
 	res := time.Since(w.lastStartTm) >= w.Interval
@@ -63,20 +66,33 @@ func (w *WorkloadBase) CheckIsReady() bool {
 	return res
 }
 
-func (w *WorkloadBase) AddTx(tx *core.Transaction) {
-	if w.shouldWaitTx() {
-		tx.Timeout = w.WaitTxsTimeout
-		w.txs = append(w.txs, tx)
-	}
-	w.totalTxsNum.Add(1)
-}
-
 func (w *WorkloadBase) TotalTxsNum() int {
 	return int(w.totalTxsNum.Load())
 }
 
-func (w *WorkloadBase) shouldWaitTx() bool {
-	return w.WaitTxsTimeout > 0
+func (w *WorkloadBase) getContract(idx int) *core.Contract {
+	return w.params.Contracts[idx%len(w.params.Contracts)]
+}
+
+func (w *WorkloadBase) getRandomContract() *core.Contract {
+	return w.params.Contracts[rand.Intn(len(w.params.Contracts)-1)] //nolint:gosec
+}
+
+// batchedFor executes the given function in batches of goroutines, with each batch sized according to the number of
+// contracts.
+func (w *WorkloadBase) batchedFor(fn func(int)) {
+	batchLimit := len(w.params.Contracts)
+	for i := 0; i < w.Iterations; i += batchLimit {
+		wg := &sync.WaitGroup{}
+		for j := 0; j < batchLimit && i+j < w.Iterations; j++ {
+			wg.Add(1)
+			go func(idx int) {
+				fn(idx)
+				wg.Done()
+			}(j)
+		}
+		wg.Wait()
+	}
 }
 
 func GetWorkload(name string) (Workload, error) {
@@ -92,6 +108,8 @@ func GetWorkload(name string) (Workload, error) {
 		wd = &SendRequests{}
 	case "blockchain_metrics":
 		wd = &BlockchainMetrics{}
+	case "send_value":
+		wd = &SendValue{}
 	case "do_panic":
 		wd = &DoPanic{}
 	default:

--- a/nil/tests/economy/economy_test.go
+++ b/nil/tests/economy/economy_test.go
@@ -90,11 +90,10 @@ func (s *SuiteEconomy) TearDownSuite() {
 	s.Cancel()
 }
 
-func getNumForGas(gas int) int {
-	return gas / 529
-}
-
 func (s *SuiteEconomy) TestGasConsumer() {
+	getNumForGas := func(gas int) int {
+		return gas / 529
+	}
 	abi, err := contracts.GetAbi(contracts.NameStresser)
 	s.Require().NoError(err)
 
@@ -119,6 +118,42 @@ func (s *SuiteEconomy) TestGasConsumer() {
 	for i := 1_000; i < 5_000; i += 1_000 {
 		run(i)
 	}
+}
+
+func (s *SuiteEconomy) TestGasConsumerColdSSTORE() {
+	const gasPerIteration = 20331
+	getNumForGas := func(gas int) int {
+		return gas / gasPerIteration
+	}
+	abi, err := contracts.GetAbi(contracts.NameStresser)
+	s.Require().NoError(err)
+
+	stresserCode, err := contracts.GetCode(contracts.NameStresser)
+	s.Require().NoError(err)
+
+	addr, receipt := s.DeployContractViaMainSmartAccount(types.BaseShardId,
+		types.BuildDeployPayload(stresserCode, common.EmptyHash), types.GasToValue(500_000_000_000))
+
+	run := func(n int) {
+		calldata := s.AbiPack(abi, "gasConsumerColdSSTORE", big.NewInt(int64(n)))
+		txHash, err := s.Client.SendExternalTransaction(s.Context, calldata, addr, nil,
+			types.NewFeePackFromGas(50_000_000))
+		s.Require().NoError(err)
+		receipt = s.WaitForReceipt(txHash)
+		s.Require().True(receipt.AllSuccess())
+
+		calcN := getNumForGas(int(receipt.GasUsed))
+		s.Require().Less(int(math.Abs(float64(n-calcN))), 10)
+	}
+
+	run(1)
+	run(111)
+	run(555)
+	run(777)
+	run(999)
+	run(1111)
+	run(1333)
+	run((int(types.DefaultMaxGasInBlock) / gasPerIteration) - 1)
 }
 
 func (s *SuiteEconomy) TestSeparateGasAndValue() {

--- a/niljs/src/clients/IndexerClient.test.ts
+++ b/niljs/src/clients/IndexerClient.test.ts
@@ -11,7 +11,6 @@ test("getAddressActions", async ({ expect }) => {
       from: addHexPrefix(defaultAddress),
       to: addHexPrefix(defaultAddress),
       amount: BigInt(1),
-      timestamp: 1000,
       blockId: 200,
       type: AddressActionKind.ReceiveEth,
       status: AddressActionStatus.Success,

--- a/niljs/src/clients/IndexerClient.ts
+++ b/niljs/src/clients/IndexerClient.ts
@@ -6,13 +6,13 @@ export class IndexerClient extends BaseClient {
   /**
    * Gets address actions page
    * @param address - The address to get actions for.
-   * @param sinceTimestamp - The timestamp to get actions since.
+   * @param sinceBlockNumber - The timestamp to get actions since.
    * @returns The page of address actions.
    */
-  public async getAddressActions(address: Hex, sinceTimestamp = 0) {
+  public async getAddressActions(address: Hex, sinceBlockNumber = 0) {
     return await this.request<AddressAction[]>({
       method: "indexer_getAddressActions",
-      params: [address, sinceTimestamp],
+      params: [address, sinceBlockNumber],
     });
   }
 }
@@ -22,7 +22,6 @@ export type AddressAction = {
   from: IAddress;
   to: IAddress;
   amount: bigint;
-  timestamp: number;
   blockId: number;
   type: AddressActionKind;
   status: AddressActionStatus;


### PR DESCRIPTION
- Improve Stresser:
	- Remove ability to check transactions result
	- Now the workload file can contain several different tasks, each of which can be accessed by name
- Remove `Timeout` field from Block struct
- Support txpool status in indexer
- Remove the limit on the maximum number of internal transactions in the Proposer