### PR TITLE
sync-committee: child tasks cancellation

### DIFF
--- a/nil/services/synccommittee/core/block_tasks_integration_test.go
+++ b/nil/services/synccommittee/core/block_tasks_integration_test.go
@@ -146,11 +146,10 @@ func (s *BlockTasksIntegrationTestSuite) Test_Provide_Tasks_And_Handle_Failure_R
 	s.Require().NoError(err)
 	s.Require().Nil(proposalData)
 
-	// status for ProofBatch task should be updated
+	// failed ProofBatch task should be removed
 	batchProofEntry, err := s.taskStorage.TryGetTaskEntry(s.ctx, taskToExecute.Id)
 	s.Require().NoError(err)
-	s.Require().NotNil(batchProofEntry)
-	s.Require().Equal(types.Failed, batchProofEntry.Status)
+	s.Require().Nil(batchProofEntry)
 }
 
 func newTestSuccessProviderResult(taskToExecute *types.Task, executorId types.TaskExecutorId) *types.TaskResult {

--- a/nil/services/synccommittee/core/block_tasks_integration_test.go
+++ b/nil/services/synccommittee/core/block_tasks_integration_test.go
@@ -146,10 +146,11 @@ func (s *BlockTasksIntegrationTestSuite) Test_Provide_Tasks_And_Handle_Failure_R
 	s.Require().NoError(err)
 	s.Require().Nil(proposalData)
 
-	// failed ProofBatch task should be removed
+	// status for ProofBatch task should be updated
 	batchProofEntry, err := s.taskStorage.TryGetTaskEntry(s.ctx, taskToExecute.Id)
 	s.Require().NoError(err)
-	s.Require().Nil(batchProofEntry)
+	s.Require().NotNil(batchProofEntry)
+	s.Require().Equal(types.Failed, batchProofEntry.Status)
 }
 
 func newTestSuccessProviderResult(taskToExecute *types.Task, executorId types.TaskExecutorId) *types.TaskResult {

--- a/nil/services/synccommittee/internal/api/task_request_handler.go
+++ b/nil/services/synccommittee/internal/api/task_request_handler.go
@@ -7,9 +7,10 @@ import (
 )
 
 const (
-	TaskRequestHandlerNamespace     = "TaskRequestHandler"
-	TaskRequestHandlerGetTask       = TaskRequestHandlerNamespace + "_getTask"
-	TaskRequestHandlerSetTaskResult = TaskRequestHandlerNamespace + "_setTaskResult"
+	TaskRequestHandlerNamespace         = "TaskRequestHandler"
+	TaskRequestHandlerGetTask           = TaskRequestHandlerNamespace + "_getTask"
+	TaskRequestHandlerCheckIfTaskExists = TaskRequestHandlerNamespace + "_checkIfTaskExists"
+	TaskRequestHandlerSetTaskResult     = TaskRequestHandlerNamespace + "_setTaskResult"
 )
 
 type TaskRequest struct {
@@ -20,8 +21,21 @@ func NewTaskRequest(executorId types.TaskExecutorId) *TaskRequest {
 	return &TaskRequest{ExecutorId: executorId}
 }
 
+type TaskCheckRequest struct {
+	TaskId     types.TaskId         `json:"taskId"`
+	ExecutorId types.TaskExecutorId `json:"executorId"`
+}
+
+func NewTaskCheckRequest(taskId types.TaskId, executorId types.TaskExecutorId) *TaskCheckRequest {
+	return &TaskCheckRequest{
+		TaskId:     taskId,
+		ExecutorId: executorId,
+	}
+}
+
 type TaskRequestHandler interface {
 	GetTask(context context.Context, request *TaskRequest) (*types.Task, error)
+	CheckIfTaskExists(context context.Context, request *TaskCheckRequest) (bool, error)
 	SetTaskResult(context context.Context, result *types.TaskResult) error
 }
 

--- a/nil/services/synccommittee/internal/executor/task_executor_test.go
+++ b/nil/services/synccommittee/internal/executor/task_executor_test.go
@@ -50,7 +50,7 @@ func newTaskRequestHandlerMock() *api.TaskRequestHandlerMock {
 		GetTaskFunc: func(_ context.Context, request *api.TaskRequest) (*types.Task, error) {
 			return testaide.NewTask(), nil
 		},
-		SetTaskResultFunc: func(ctx context.Context, result *types.TaskResult) error {
+		SetTaskResultFunc: func(_ context.Context, result *types.TaskResult) error {
 			return nil
 		},
 	}

--- a/nil/services/synccommittee/internal/rpc/task_request_rpc_client.go
+++ b/nil/services/synccommittee/internal/rpc/task_request_rpc_client.go
@@ -28,6 +28,15 @@ func (r *taskRequestRpcClient) GetTask(ctx context.Context, request *api.TaskReq
 	)
 }
 
+func (r *taskRequestRpcClient) CheckIfTaskExists(ctx context.Context, request *api.TaskCheckRequest) (bool, error) {
+	return doRPCCall[*api.TaskCheckRequest, bool](
+		ctx,
+		r.client,
+		api.TaskRequestHandlerCheckIfTaskExists,
+		request,
+	)
+}
+
 func (r *taskRequestRpcClient) SetTaskResult(ctx context.Context, result *types.TaskResult) error {
 	_, err := doRPCCall[*types.TaskResult, any](
 		ctx,

--- a/nil/services/synccommittee/internal/scheduler/task_cancel_checker.go
+++ b/nil/services/synccommittee/internal/scheduler/task_cancel_checker.go
@@ -1,0 +1,82 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/NilFoundation/nil/nil/common/logging"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/api"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/srv"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
+)
+
+type TaskCancelCheckerConfig struct {
+	UpdateInterval time.Duration
+}
+
+func MakeDefaultCheckerConfig() TaskCancelCheckerConfig {
+	return TaskCancelCheckerConfig{
+		UpdateInterval: 60 * time.Second,
+	}
+}
+
+type TaskSource interface {
+	CancelTasksByParentId(ctx context.Context, isActive func(context.Context, types.TaskId) (bool, error)) (uint, error)
+}
+
+type TaskCancelChecker struct {
+	srv.WorkerLoop
+
+	requestHandler api.TaskRequestHandler
+	taskSource     TaskSource
+	executorId     types.TaskExecutorId
+	logger         logging.Logger
+	config         TaskCancelCheckerConfig
+}
+
+func NewTaskCancelChecker(
+	requestHandler api.TaskRequestHandler,
+	taskSource TaskSource,
+	executorId types.TaskExecutorId,
+	logger logging.Logger,
+) *TaskCancelChecker {
+	checker := &TaskCancelChecker{
+		requestHandler: requestHandler,
+		taskSource:     taskSource,
+		executorId:     executorId,
+		config:         MakeDefaultCheckerConfig(),
+	}
+
+	checker.WorkerLoop = srv.NewWorkerLoop("task_cancel_checker", checker.config.UpdateInterval, checker.runIteration)
+	checker.logger = srv.WorkerLogger(logger, checker)
+	return checker
+}
+
+func (c *TaskCancelChecker) runIteration(ctx context.Context) {
+	if err := c.processRunningTasks(ctx); err != nil {
+		c.logger.Error().Err(err).Msg("failed to check cancelled tasks")
+	}
+}
+
+func (c *TaskCancelChecker) processRunningTasks(ctx context.Context) error {
+	canceledCounter, err := c.taskSource.CancelTasksByParentId(ctx, c.isActive)
+	if err != nil {
+		return fmt.Errorf("failed to cancel dead tasks: %w", err)
+	}
+	if canceledCounter == 0 {
+		c.logger.Debug().Msg("no task canceled")
+	} else {
+		c.logger.Warn().Msgf("canceled %d dead tasks", canceledCounter)
+	}
+	return nil
+}
+
+func (c *TaskCancelChecker) isActive(ctx context.Context, taskId types.TaskId) (bool, error) {
+	taskRequest := api.NewTaskCheckRequest(taskId, c.executorId)
+	isExists, err := c.requestHandler.CheckIfTaskExists(ctx, taskRequest)
+	if err != nil {
+		return isExists, fmt.Errorf("failed to check task: %w", err)
+	}
+	return isExists, nil
+}

--- a/nil/services/synccommittee/internal/scheduler/task_cancel_checker_test.go
+++ b/nil/services/synccommittee/internal/scheduler/task_cancel_checker_test.go
@@ -1,0 +1,154 @@
+package scheduler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/NilFoundation/nil/nil/common/logging"
+	"github.com/NilFoundation/nil/nil/internal/db"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/api"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/metrics"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/srv"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/storage"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/testaide"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
+	"github.com/stretchr/testify/suite"
+)
+
+type TaskCancelCheckerSuite struct {
+	suite.Suite
+
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	database    db.DB
+	taskStorage *storage.TaskStorage
+
+	logger logging.Logger
+}
+
+func TestTaskCancelCheckerSuite(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(TaskCancelCheckerSuite))
+}
+
+func (s *TaskCancelCheckerSuite) SetupSuite() {
+	s.ctx, s.cancel = context.WithCancel(context.Background())
+
+	database, err := db.NewBadgerDbInMemory()
+	s.Require().NoError(err)
+	s.database = database
+
+	logger := logging.NewLogger("task_cancel_checker_test")
+
+	metricsHandler, err := metrics.NewSyncCommitteeMetrics()
+	s.Require().NoError(err)
+
+	clock := testaide.NewTestClock()
+
+	s.taskStorage = storage.NewTaskStorage(database, clock, metricsHandler, logger)
+}
+
+func (s *TaskCancelCheckerSuite) TearDownSuite() {
+	s.cancel()
+}
+
+func (s *TaskCancelCheckerSuite) TearDownTest() {
+	err := s.database.DropAll()
+	s.Require().NoError(err, "failed to clear database in TearDownTest")
+}
+
+func (s *TaskCancelCheckerSuite) Test_Check_Empty_Storage() {
+	handlerMock := &api.TaskRequestHandlerMock{}
+	cancelChecker := s.newTestTaskCancelChecker(handlerMock)
+
+	err := cancelChecker.processRunningTasks(s.ctx)
+	s.Require().NoError(err)
+	s.Require().Zero(handlerMock.CheckIfTaskExistsCalls())
+}
+
+func (s *TaskCancelCheckerSuite) Test_Check_Alive_Task() {
+	parentTaskId := types.NewTaskId()
+	task := types.Task{
+		Id:           types.NewTaskId(),
+		ParentTaskId: &parentTaskId,
+	}
+	expectedTaskEntry := types.TaskEntry{
+		Task:   task,
+		Status: types.WaitingForExecutor,
+	}
+	err := s.taskStorage.AddTaskEntries(s.ctx, &expectedTaskEntry)
+	s.Require().NoError(err)
+
+	handlerMock := &api.TaskRequestHandlerMock{
+		CheckIfTaskExistsFunc: func(contextMoqParam context.Context, request *api.TaskCheckRequest) (bool, error) {
+			return true, nil
+		},
+	}
+
+	cancelChecker := s.newTestTaskCancelChecker(handlerMock)
+
+	err = cancelChecker.processRunningTasks(s.ctx)
+	s.Require().NoError(err)
+
+	// Parent task was checked
+	checkTaskCall := handlerMock.CheckIfTaskExistsCalls()
+	s.Require().Len(checkTaskCall, 1)
+	s.Require().Equal(parentTaskId, checkTaskCall[0].Request.TaskId)
+	// Checked task was not removed
+	taskEntry, err := s.taskStorage.TryGetTaskEntry(s.ctx, task.Id)
+	s.Require().NoError(err)
+	s.Require().NotNil(taskEntry)
+	s.Require().Equal(taskEntry.Task.Id, expectedTaskEntry.Task.Id)
+}
+
+func (s *TaskCancelCheckerSuite) Test_Check_Dead_Task() {
+	parentTaskId := types.NewTaskId()
+	task := types.Task{
+		Id:           types.NewTaskId(),
+		ParentTaskId: &parentTaskId,
+	}
+	expectedTaskEntry := types.TaskEntry{
+		Task:   task,
+		Status: types.WaitingForExecutor,
+	}
+	err := s.taskStorage.AddTaskEntries(s.ctx, &expectedTaskEntry)
+	s.Require().NoError(err)
+
+	handlerMock := &api.TaskRequestHandlerMock{
+		CheckIfTaskExistsFunc: func(contextMoqParam context.Context, request *api.TaskCheckRequest) (bool, error) {
+			return false, nil
+		},
+	}
+
+	cancelChecker := s.newTestTaskCancelChecker(handlerMock)
+
+	err = cancelChecker.processRunningTasks(s.ctx)
+	s.Require().NoError(err)
+
+	// Parent task was checked
+	checkTaskCall := handlerMock.CheckIfTaskExistsCalls()
+	s.Require().Len(checkTaskCall, 1)
+	s.Require().Equal(parentTaskId, checkTaskCall[0].Request.TaskId)
+	// Checked task was not removed
+	taskEntry, err := s.taskStorage.TryGetTaskEntry(s.ctx, task.Id)
+	s.Require().NoError(err)
+	s.Require().Nil(taskEntry)
+}
+
+func (s *TaskCancelCheckerSuite) newTestTaskCancelChecker(handler api.TaskRequestHandler) *TaskCancelChecker {
+	s.T().Helper()
+	checker := &TaskCancelChecker{
+		requestHandler: handler,
+		taskSource:     s.taskStorage,
+		config:         MakeDefaultCheckerConfig(),
+	}
+
+	checker.WorkerLoop = srv.NewWorkerLoop(
+		"task_cancel_checker_test",
+		checker.config.UpdateInterval,
+		checker.runIteration,
+	)
+	checker.logger = srv.WorkerLogger(s.logger, checker)
+	return checker
+}

--- a/nil/services/synccommittee/internal/scheduler/task_cancel_checker_test.go
+++ b/nil/services/synccommittee/internal/scheduler/task_cancel_checker_test.go
@@ -133,7 +133,9 @@ func (s *TaskCancelCheckerSuite) Test_Check_Dead_Task() {
 	// Checked task was not removed
 	taskEntry, err := s.taskStorage.TryGetTaskEntry(s.ctx, task.Id)
 	s.Require().NoError(err)
-	s.Require().Nil(taskEntry)
+	s.Require().NotNil(taskEntry)
+	s.Require().Equal(taskEntry.Task.Id, expectedTaskEntry.Task.Id)
+	s.Require().Equal(types.Failed, taskEntry.Status)
 }
 
 func (s *TaskCancelCheckerSuite) newTestTaskCancelChecker(handler api.TaskRequestHandler) *TaskCancelChecker {

--- a/nil/services/synccommittee/internal/storage/task_storage_test.go
+++ b/nil/services/synccommittee/internal/storage/task_storage_test.go
@@ -349,7 +349,9 @@ func (s *TaskStorageSuite) Test_ProcessTaskResult_Concurrently() {
 
 func (s *TaskStorageSuite) Test_ProcessTaskResult_InvalidStateChange() {
 	taskStatuses := []types.TaskStatus{
-		types.TaskStatusNone,
+		types.WaitingForInput,
+		types.WaitingForExecutor,
+		types.Failed,
 	}
 
 	taskResults := getTestTaskResults(false)
@@ -526,7 +528,8 @@ func (s *TaskStorageSuite) Test_TaskCancelation() {
 	s.Require().NoError(err)
 	s.Require().Equal(uint(0x1), canceledCount)
 
-	emptyEntry, err := s.ts.TryGetTaskEntry(s.ctx, taskEntry.Task.Id)
+	failedEntry, err := s.ts.TryGetTaskEntry(s.ctx, taskEntry.Task.Id)
 	s.Require().NoError(err)
-	s.Require().Nil(emptyEntry)
+	s.Require().Equal(taskEntry.Task, failedEntry.Task)
+	s.Require().Equal(types.Failed, failedEntry.Status)
 }

--- a/nil/services/synccommittee/internal/types/errors.go
+++ b/nil/services/synccommittee/internal/types/errors.go
@@ -50,6 +50,9 @@ const (
 	// TaskErrOutOfMemory indicated that managed memory allocation failure occurred during the proof generation
 	TaskErrOutOfMemory
 
+	// TaskErrCancelled indicated that child task was cancelled becuse parent task not exists any more
+	TaskErrCancelled
+
 	// TaskErrUnknown indicates an unspecified task error.
 	TaskErrUnknown
 )

--- a/nil/services/synccommittee/internal/types/errors.go
+++ b/nil/services/synccommittee/internal/types/errors.go
@@ -50,7 +50,7 @@ const (
 	// TaskErrOutOfMemory indicated that managed memory allocation failure occurred during the proof generation
 	TaskErrOutOfMemory
 
-	// TaskErrCancelled indicated that child task was cancelled becuse parent task not exists any more
+	// TaskErrCancelled indicated that child task was cancelled
 	TaskErrCancelled
 
 	// TaskErrUnknown indicates an unspecified task error.

--- a/nil/services/synccommittee/proofprovider/service.go
+++ b/nil/services/synccommittee/proofprovider/service.go
@@ -82,7 +82,7 @@ func New(config *Config, database db.DB) (*ProofProvider, error) {
 		&rpc.TaskListenerConfig{HttpEndpoint: config.TaskListenerRpcEndpoint}, taskScheduler, logger,
 	)
 
-	taskCanclelChecker := scheduler.NewTaskCancelChecker(
+	taskCancelChecker := scheduler.NewTaskCancelChecker(
 		taskRpcClient,
 		taskStorage,
 		taskExecutor.Id(),
@@ -92,7 +92,7 @@ func New(config *Config, database db.DB) (*ProofProvider, error) {
 	return &ProofProvider{
 		Service: srv.NewService(
 			logger,
-			taskExecutor, taskScheduler, taskListener, taskCanclelChecker, taskResultSender,
+			taskExecutor, taskScheduler, taskListener, taskCancelChecker, taskResultSender,
 		),
 	}, nil
 }

--- a/nil/services/synccommittee/proofprovider/service.go
+++ b/nil/services/synccommittee/proofprovider/service.go
@@ -82,10 +82,17 @@ func New(config *Config, database db.DB) (*ProofProvider, error) {
 		&rpc.TaskListenerConfig{HttpEndpoint: config.TaskListenerRpcEndpoint}, taskScheduler, logger,
 	)
 
+	taskCanclelChecker := scheduler.NewTaskCancelChecker(
+		taskRpcClient,
+		taskStorage,
+		taskExecutor.Id(),
+		logger,
+	)
+
 	return &ProofProvider{
 		Service: srv.NewService(
 			logger,
-			taskExecutor, taskScheduler, taskListener, taskResultSender,
+			taskExecutor, taskScheduler, taskListener, taskCanclelChecker, taskResultSender,
 		),
 	}, nil
 }

--- a/nil/services/synccommittee/public/task_view.go
+++ b/nil/services/synccommittee/public/task_view.go
@@ -109,7 +109,7 @@ func NewTaskTreeFromResult(result *types.TaskResultDetails) *TaskTreeView {
 			Type:        result.TaskType,
 			CircuitType: result.CircuitType,
 
-			ExecutionTime: &result.ExecutionTime,
+			ExecutionTime: result.ExecutionTime,
 			Owner:         result.Sender,
 			Status:        taskStatus,
 		},


### PR DESCRIPTION
## Short Summary

If parent task on `sync committee` level was cancelled, during reset the child tasks should not be executed.
This change affects only `proof-provider` .

## What Changes Were Made

- Added `CanlcelDeadTasks` public method to task storage
- Added `TaskCancelChecker` worker and run in under `proof-provider` process
- Extended `TaskRequestHandler` api by `CheckIfTaskExists` (implemented in `taskScheduler` and `taskRequestRpcClient`)
- Added tests for `TaskCancelChecker` and `TaskStorage::CanlcelDeadTasks`

## Related Issue

https://www.notion.so/nilfoundation/Child-tasks-cancellation-162c61485260803882b3e50b89d2f5c4

## Checklist

- [x] I have read and followed the [Contributing Guide](https://github.com/NilFoundation/nil/blob/main/CONTRIBUTION-GUIDE.md)
- [x] I have tested the changes locally
- [x] I have added relevant tests (if applicable)
- [ ] I have updated documentation/comments (if applicable)
