### PR TITLE
Allow fetching contract info with "nil contract [address]"

### DIFF
--- a/nil/cmd/nil/internal/contract/contract.go
+++ b/nil/cmd/nil/internal/contract/contract.go
@@ -1,15 +1,29 @@
 package contract
 
 import (
+	"fmt"
+
 	"github.com/NilFoundation/nil/nil/cmd/nil/common"
+	libcommon "github.com/NilFoundation/nil/nil/common"
+
+	"github.com/NilFoundation/nil/nil/internal/types"
+	"github.com/NilFoundation/nil/nil/services/cliservice"
 	"github.com/spf13/cobra"
 )
 
 func GetCommand(cfg *common.Config) *cobra.Command {
-	serverCmd := &cobra.Command{
-		Use:   "contract",
-		Short: "Interact with a contract on the cluster",
+	params := &contractParams{
+		Params: &common.Params{},
 	}
+	serverCmd := &cobra.Command{
+		Use:   "contract [address]",
+		Short: "Interact with a contract on the cluster",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runContract(cmd, args, cfg, params)
+		},
+	}
+	setContractFlags(serverCmd, params)
 
 	serverCmd.AddCommand(
 		GetAddressCommand(cfg),
@@ -25,4 +39,37 @@ func GetCommand(cfg *common.Config) *cobra.Command {
 	)
 
 	return serverCmd
+}
+
+func setContractFlags(cmd *cobra.Command, params *contractParams) {
+	cmd.Flags().StringVar(&params.blockId, "block", "latest", "Block number, hash or tag")
+}
+
+func runContract(cmd *cobra.Command, args []string, cfg *common.Config, params *contractParams) error {
+	var address types.Address
+	if err := address.Set(args[0]); err != nil {
+		return err
+	}
+
+	service := cliservice.NewService(cmd.Context(), common.GetRpcClient(), cfg.PrivateKey, nil)
+
+	debugRPCContract, _ := service.GetDebugContract(address, params.blockId)
+
+	if debugRPCContract != nil {
+		contract := new(types.SmartContract)
+		if err := contract.UnmarshalSSZ(debugRPCContract.Contract); err != nil {
+			return err
+		}
+
+		hash := libcommon.PoseidonHash(debugRPCContract.Contract)
+
+		fmt.Println("Hash:", hash)
+		fmt.Println("Address:", contract.Address.String())
+		fmt.Println("Balance:", contract.Balance.Uint256.String())
+		fmt.Println("Seqno:", contract.Seqno.String())
+		fmt.Println("ExtSeqno:", contract.ExtSeqno.String())
+		fmt.Println("StorageRoot:", contract.StorageRoot.String())
+	}
+
+	return nil
 }

--- a/nil/cmd/nil/internal/contract/contract.go
+++ b/nil/cmd/nil/internal/contract/contract.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 
 	"github.com/NilFoundation/nil/nil/cmd/nil/common"
-	libcommon "github.com/NilFoundation/nil/nil/common"
-
 	"github.com/NilFoundation/nil/nil/internal/types"
 	"github.com/NilFoundation/nil/nil/services/cliservice"
 	"github.com/spf13/cobra"
@@ -61,9 +59,7 @@ func runContract(cmd *cobra.Command, args []string, cfg *common.Config, params *
 			return err
 		}
 
-		hash := libcommon.PoseidonHash(debugRPCContract.Contract)
-
-		fmt.Println("Hash:", hash)
+		fmt.Println("Hash:", contract.Hash())
 		fmt.Println("Address:", contract.Address.String())
 		fmt.Println("Balance:", contract.Balance.Uint256.String())
 		fmt.Println("Seqno:", contract.Seqno.String())

--- a/nil/cmd/nil/internal/contract/params.go
+++ b/nil/cmd/nil/internal/contract/params.go
@@ -32,4 +32,5 @@ type contractParams struct {
 	salt     types.Uint256
 	shardId  types.ShardId
 	value    types.Value
+	blockId  string
 }

--- a/nil/services/cliservice/contract.go
+++ b/nil/services/cliservice/contract.go
@@ -78,6 +78,17 @@ func (s *Service) GetTokens(contractAddress types.Address) (types.TokensMap, err
 	return tokens, nil
 }
 
+func (s *Service) GetDebugContract(contractAddress types.Address, blockId any) (*jsonrpc.DebugRPCContract, error) {
+	contract, err := s.client.GetDebugContract(s.ctx, contractAddress, blockId)
+
+	if err != nil {
+		s.logger.Error().Err(err).Msg("Failed to get contract debug information")
+		return nil, err
+	}
+
+	return contract, nil
+}
+
 // RunContract runs bytecode on the specified contract address
 func (s *Service) RunContract(smartAccount types.Address, bytecode []byte, fee types.FeePack, value types.Value,
 	tokens []types.TokenBalance, contract types.Address,

--- a/nil/services/cliservice/contract.go
+++ b/nil/services/cliservice/contract.go
@@ -80,7 +80,6 @@ func (s *Service) GetTokens(contractAddress types.Address) (types.TokensMap, err
 
 func (s *Service) GetDebugContract(contractAddress types.Address, blockId any) (*jsonrpc.DebugRPCContract, error) {
 	contract, err := s.client.GetDebugContract(s.ctx, contractAddress, blockId)
-
 	if err != nil {
 		s.logger.Error().Err(err).Msg("Failed to get contract debug information")
 		return nil, err

--- a/nil/tests/cli/cli_test.go
+++ b/nil/tests/cli/cli_test.go
@@ -405,6 +405,16 @@ faucet_endpoint = {{ .FaucetUrl }}
 		s.Contains(res, "uint256: 123321")
 	})
 
+	s.Run("Call read-only 'get' function of contract", func() {
+		res := s.RunCli("-c", cfgPath, "contract", addr)
+		s.Contains(res, "Hash: ")
+		s.Contains(res, "Address: "+addr)
+		s.Contains(res, "Balance: 0")
+		s.Contains(res, "Seqno: 2")
+		s.Contains(res, "ExtSeqno: 0")
+		s.Contains(res, "StorageRoot: ")
+	})
+
 	s.Run("Estimate fee", func() {
 		isNum := func(str string) {
 			s.T().Helper()


### PR DESCRIPTION
## Short Summary

We had a long debugging session yesterday with Oleg, trying to understand where the archive node's state has diverged from the validator. It would have been a bit easier to figure out which contract to blame if we could request the hash and storage root hash of that contract.

## What Changes Were Made

Fortunately, we already have the API for fetching debug information about smart contracts, which Sync Committee uses. I've just added an extension to our nil cli.

This will fetch and print contract information for the latest block:

```
nil contract [address]
```

And this will look at a particular block:

```
nil contract --block <block-id-or-tag> [address]
```

## Breaking Changes (if any)

None

## Screenshots / Visual Changes

This is what the output looks like:

```
$ nil  contract 0x000414c4fffc36c28bea0ad38561b12ee628fdac

Hash: 0x0a66240be103e330b192c341e9587fbd1a4e93941c951a26ebd55a6e1eed3ef8
Address: 0x000414c4fffc36c28bea0ad38561b12ee628fdac
Balance: 6629294100000000
Seqno: 4807
ExtSeqno: 4803
StorageRoot: 0x2e33ace89e368ecf328b0aa2b5939e3a42d197539a437f6a9af5fda62dcd2327

```

## Checklist

_Please mark each item with an `x` inside the brackets (e.g., [x]) once completed._

- [x] I have read and followed the [Contributing Guide](https://github.com/NilFoundation/nil/blob/main/CONTRIBUTION-GUIDE.md)
- [x] I have tested the changes locally
- [x] I have added relevant tests (if applicable)
- [x] I have updated documentation/comments (if applicable)
