### PR TITLE
[telemetry] Metrics for validators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ format: generated
 	GOPROXY= go mod vendor
 	golangci-lint fmt
 
-lint: format golangci-lint
+lint: format golangci-lint checklocks
 
 checklocks: generated
 	@export GOFLAGS="$$GOFLAGS -tags=test,goexperiment.synctest"; \

--- a/nil/internal/telemetry/telattr/metric.go
+++ b/nil/internal/telemetry/telattr/metric.go
@@ -5,6 +5,8 @@ import (
 	"go.opentelemetry.io/otel/metric"
 )
 
-func With(attrs ...attribute.KeyValue) metric.MeasurementOption {
+type MetricOption = metric.MeasurementOption
+
+func With(attrs ...attribute.KeyValue) MetricOption {
 	return metric.WithAttributeSet(attribute.NewSet(attrs...))
 }

--- a/nil/services/nilservice/service.go
+++ b/nil/services/nilservice/service.go
@@ -718,7 +718,10 @@ func createValidators(
 			}
 		}
 
-		list[i] = collate.NewValidator(params, list[0], database, txpool, networkManager)
+		list[i], err = collate.NewValidator(params, list[0], database, txpool, networkManager)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return list, nil
 }


### PR DESCRIPTION
Moved metrics from block generator to validator.
Validator is the correct place, because generator shouldn't produce side effects.

Separated block id from other metrics, so that it can be reported by syncers, not only by producers.

Part of https://github.com/NilFoundation/nil/issues/770
