### PR TITLE
[txpool] Fix seqno gap

### DIFF
--- a/nil/services/rpc/rawapi/local_txnpool.go
+++ b/nil/services/rpc/rawapi/local_txnpool.go
@@ -27,7 +27,7 @@ func (api *LocalShardApi) SendTransaction(ctx context.Context, encoded []byte) (
 }
 
 func (api *LocalShardApi) GetTxpoolStatus(ctx context.Context) (uint64, error) {
-	return uint64(api.txnpool.GetPendingLength()), nil
+	return uint64(api.txnpool.GetSize()), nil
 }
 
 func (api *LocalShardApi) GetTxpoolContent(ctx context.Context) ([]*types.Transaction, error) {

--- a/nil/services/rpc/transport/server.go
+++ b/nil/services/rpc/transport/server.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	MetadataApi             = "rpc"
-	defaultBatchConcurrency = 1 // trnasactions from batch maust be processed in order
+	defaultBatchConcurrency = 2
 	defaultBatchLimit       = 100
 )
 


### PR DESCRIPTION
The problem was in the following.
Consider the case where two transactions with `seqno` 1 and 4 are added to the same account. Previously, after executing the transaction with `seqno` 1, the next `seqno` was set to 4. As a result, transactions with `seqno` 2 and 3 were rejected with a `Seqno too low` error. Now, the next `seqno` is set to 2, allowing transactions with `seqno` 2 and 3 to be processed as expected.