### PR TITLE
[archive] Misc improvements concerning relays

### DIFF
--- a/nil/internal/collate/block_listener.go
+++ b/nil/internal/collate/block_listener.go
@@ -175,7 +175,7 @@ func unmarshalBlockSSZ(pbBlock *pb.RawFullBlock) (*types.BlockWithExtractedData,
 	return raw.DecodeSSZ()
 }
 
-func SetRequestHandler(
+func SetBlockRequestHandler(
 	ctx context.Context, networkManager network.Manager, shardId types.ShardId, database db.DB, logger logging.Logger,
 ) {
 	if networkManager == nil {

--- a/nil/internal/collate/scheduler.go
+++ b/nil/internal/collate/scheduler.go
@@ -78,9 +78,6 @@ func (s *Scheduler) Validator() *Validator {
 func (s *Scheduler) Run(ctx context.Context) error {
 	s.logger.Info().Msg("Starting collation...")
 
-	// Enable handler for blocks relaying
-	SetRequestHandler(ctx, s.networkManager, s.params.ShardId, s.txFabric, s.logger)
-
 	tickPeriodMs := s.params.CollatorTickPeriod.Milliseconds()
 	for {
 		var toRoundStartMs int64

--- a/nil/tests/async_await/async_await_test.go
+++ b/nil/tests/async_await/async_await_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/NilFoundation/nil/nil/internal/abi"
 	"github.com/NilFoundation/nil/nil/internal/contracts"
 	"github.com/NilFoundation/nil/nil/internal/execution"
-	"github.com/NilFoundation/nil/nil/internal/network"
 	"github.com/NilFoundation/nil/nil/internal/types"
 	"github.com/NilFoundation/nil/nil/services/nilservice"
 	"github.com/NilFoundation/nil/nil/services/rpc"
@@ -83,14 +82,8 @@ func (s *SuiteAsyncAwait) SetupSuite() {
 		DisableConsensus: disableConsensus,
 	}, port)
 
-	_, archiveNodeAddr := s.StartArchiveNode(&tests.ArchiveNodeConfig{
-		Port:               port + int(nShards),
-		WithBootstrapPeers: true,
-		DisableConsensus:   disableConsensus,
-	})
 	s.DefaultClient, _ = s.StartRPCNode(&tests.RpcNodeConfig{
 		WithDhtBootstrapByValidators: true,
-		ArchiveNodes:                 network.AddrInfoSlice{archiveNodeAddr},
 	})
 }
 
@@ -289,7 +282,7 @@ func (s *SuiteAsyncAwait) TestFactorial() {
 }
 
 func (s *SuiteAsyncAwait) TestFibonacci() {
-	data := s.AbiPack(s.abiTest, "fibonacci", int32(6))
+	data := s.AbiPack(s.abiTest, "fibonacci", int32(4))
 	receipt := s.SendExternalTransactionNoCheck(data, s.testAddress0)
 	s.Require().True(receipt.AllSuccess())
 
@@ -299,7 +292,7 @@ func (s *SuiteAsyncAwait) TestFibonacci() {
 	s.Require().NoError(err)
 	value, ok := nameRes[0].(int32)
 	s.Require().True(ok)
-	s.Require().Equal(int32(8), value)
+	s.Require().Equal(int32(3), value)
 }
 
 func (s *SuiteAsyncAwait) TestTwoRequests() {

--- a/nil/tests/common.go
+++ b/nil/tests/common.go
@@ -153,18 +153,11 @@ func WaitZerostate(t *testing.T, client client.Client, shardId types.ShardId) {
 func WaitShardTick(t *testing.T, client client.Client, shardId types.ShardId) {
 	t.Helper()
 
-	block, err := client.GetBlock(t.Context(), shardId, "latest", false)
-	require.NoError(t, err)
-
-	require.Eventuallyf(
-		t,
-		func() bool {
-			block, err := client.GetBlock(t.Context(), shardId, transport.BlockNumber(block.Number+1), false)
-			return err == nil && block != nil
-		},
-		ShardTickWaitTimeout,
-		ShardTickPollInterval,
-		"Failed to wait for shard %d tick after block %d", shardId, block.Number)
+	require.Eventually(t, func() bool {
+		block, err := client.GetBlock(t.Context(), shardId, 1, false)
+		require.NoError(t, err)
+		return block != nil
+	}, ShardTickWaitTimeout, ShardTickPollInterval)
 }
 
 func GetBalance(t *testing.T, client client.Client, address types.Address) types.Value {

--- a/nil/tests/sharded_suite.go
+++ b/nil/tests/sharded_suite.go
@@ -248,8 +248,7 @@ func (s *ShardedSuite) start(
 		s.connectToInstances(shard.nm)
 	}
 
-	s.waitZerostate()
-	s.waitShardsTick(cfg.NShards)
+	s.waitShardsTick()
 }
 
 func (s *ShardedSuite) Start(cfg *nilservice.Config, port int, options ...network.Option) {
@@ -465,7 +464,7 @@ func (s *ShardedSuite) checkNodeStart(nShards uint32, client client.Client) {
 	wg.Wait()
 }
 
-func (s *ShardedSuite) waitZerostate() {
+func (s *ShardedSuite) waitShardsTick() {
 	s.T().Helper()
 
 	var wg sync.WaitGroup
@@ -474,20 +473,12 @@ func (s *ShardedSuite) waitZerostate() {
 		go func() {
 			defer wg.Done()
 
-			for _, shard := range instance.Config.MyShards {
-				WaitZerostate(s.T(), instance.Client, types.ShardId(shard))
+			for shard := range instance.Config.NShards {
+				WaitShardTick(s.T(), instance.Client, types.ShardId(shard))
 			}
 		}()
 	}
 	wg.Wait()
-}
-
-func (s *ShardedSuite) waitShardsTick(nShards uint32) {
-	for _, instance := range s.Instances {
-		for shardId := range types.ShardId(nShards) {
-			WaitShardTick(s.T(), instance.Client, shardId)
-		}
-	}
 }
 
 func (s *ShardedSuite) LoadContract(path string, name string) (types.Code, abi.ABI) {


### PR DESCRIPTION
Some improvements made after testing archive nodes with relays.

- Archive nodes serve blocks over libp2p: call SetBlockRequestHandler in syncer.
- Update to syncer init: no bootstrap peers is fine; more explicit handling of the absence of peers with whom to check the version.

Part of https://github.com/NilFoundation/nil/issues/489

