### PR TITLE
sync committee: fix state root divergence

### DIFF
--- a/nil/services/synccommittee/core/config.go
+++ b/nil/services/synccommittee/core/config.go
@@ -20,7 +20,7 @@ type Config struct {
 }
 
 func NewDefaultConfig() *Config {
-	return &Config{
+	cfg := Config{
 		RpcEndpoint:             "tcp://127.0.0.1:8529",
 		TaskListenerRpcEndpoint: DefaultTaskRpcEndpoint,
 		AggregatorConfig:        fetching.NewDefaultAggregatorConfig(),
@@ -30,4 +30,8 @@ func NewDefaultConfig() *Config {
 			ServiceName: "sync_committee",
 		},
 	}
+
+	cfg.ProposerParams.DisableL1 = &cfg.ContractWrapperConfig.DisableL1
+
+	return &cfg
 }


### PR DESCRIPTION
## Short Summary

In case of disabled L1 fetcher it is invalid to fetch new state root via RPC if some non-empty is already stored in local database

## What Changes Were Made

<!-- List the changes introduced in this PR -->

- DisableL1 flag is forwarded to the proposer config (false by default)
- ProposerStorage is extended with new method of getting current state root
- In case of L1 is disabled and storage contains some non-empty state root value - it is used instead of the "fetched" one

## Checklist

- [x] I have read and followed the [Contributing Guide](https://github.com/NilFoundation/nil/blob/main/CONTRIBUTION-GUIDE.md)
- [x] I have tested the changes locally
- [ ] I have added relevant tests (if applicable)
- [ ] I have updated documentation/comments (if applicable)
