### PR TITLE
feat(sc): handle CommitBatch errors, add simulation before tx submission

### DIFF
--- a/nil/services/synccommittee/core/batches/blob/builder.go
+++ b/nil/services/synccommittee/core/batches/blob/builder.go
@@ -20,7 +20,7 @@ type builderImpl struct{}
 
 var _ Builder = (*builderImpl)(nil)
 
-func NewBuilder() *builderImpl {
+func NewBuilder() Builder {
 	return &builderImpl{}
 }
 

--- a/nil/services/synccommittee/core/fetching/aggregator.go
+++ b/nil/services/synccommittee/core/fetching/aggregator.go
@@ -39,6 +39,7 @@ type AggregatorBlockStorage interface {
 	TryGetLatestBatchId(ctx context.Context) (*types.BatchId, error)
 	SetBlockBatch(ctx context.Context, batch *types.BlockBatch) error
 	GetFreeSpaceBatchCount(ctx context.Context) (uint32, error)
+	SetProvedStateRoot(ctx context.Context, stateRoot common.Hash) error
 }
 
 type AggregatorConfig struct {
@@ -65,7 +66,7 @@ type aggregator struct {
 	batchEncoder    encode.BatchEncoder
 	blobBuilder     blob.Builder
 	rollupContract  rollupcontract.Wrapper
-	resetter        *reset.StateResetter
+	resetter        *reset.StateResetLauncher
 	clock           clockwork.Clock
 	metrics         AggregatorMetrics
 	config          AggregatorConfig
@@ -77,7 +78,7 @@ func NewAggregator(
 	rpcClient RpcBlockFetcher,
 	blockStorage AggregatorBlockStorage,
 	taskStorage AggregatorTaskStorage,
-	resetter *reset.StateResetter,
+	resetter *reset.StateResetLauncher,
 	rollupContractWrapper rollupcontract.Wrapper,
 	clock clockwork.Clock,
 	logger logging.Logger,
@@ -110,7 +111,20 @@ func (agg *aggregator) Name() string {
 func (agg *aggregator) Run(ctx context.Context, started chan<- struct{}) error {
 	agg.logger.Info().Msg("Starting block fetching")
 
-	err := agg.workerAction.Run(ctx, started)
+	latestStateRoot, err := agg.blockStorage.TryGetProvedStateRoot(ctx)
+	if err != nil {
+		return err
+	}
+	if latestStateRoot == nil {
+		// root not initialized in current database
+		agg.logger.Warn().
+			Msg("L1 state root is not initialized, trying to use storage state root")
+		if err := agg.syncLatestFinalizedRoot(ctx); err != nil {
+			return fmt.Errorf("failed to set proved state root: %w", err)
+		}
+	}
+
+	err = agg.workerAction.Run(ctx, started)
 
 	if err == nil || errors.Is(err, context.Canceled) {
 		agg.logger.Info().Msg("Block fetching stopped")
@@ -168,13 +182,16 @@ func (agg *aggregator) handleProcessingErr(ctx context.Context, err error) error
 
 	case errors.Is(err, types.ErrBlockMismatch):
 		agg.logger.Warn().Err(err).Msg("Block mismatch detected, resetting state")
-		if err := agg.resetter.ResetProgressNotProved(ctx); err != nil {
+		if err := agg.resetter.LaunchResetToL1WithSuspension(ctx, agg); err != nil {
 			return fmt.Errorf("error resetting state: %w", err)
 		}
 		return nil
 
 	case errors.Is(err, storage.ErrStateRootNotInitialized):
-		agg.logger.Warn().Err(err).Msg("State root not initialized, skipping")
+		agg.logger.Warn().Err(err).Msg("State root not initialized, trying to fetch it from L1")
+		if err := agg.syncLatestFinalizedRoot(ctx); err != nil {
+			return fmt.Errorf("failed to set proved state root: %w", err)
+		}
 		return nil
 
 	case errors.Is(err, storage.ErrCapacityLimitReached):
@@ -372,7 +389,7 @@ func (agg *aggregator) handleBlockBatch(ctx context.Context, batch *types.BlockB
 	}
 
 	if err := agg.rollupContract.CommitBatch(ctx, sidecar, batch.Id.String()); err != nil {
-		return fmt.Errorf("error committing batch, latestMainHash=%s: %w", batch.LatestMainBlock().Hash, err)
+		return agg.handleCommitBatchError(ctx, batch, err)
 	}
 
 	if err := agg.createProofTasks(ctx, batch); err != nil {
@@ -380,6 +397,34 @@ func (agg *aggregator) handleBlockBatch(ctx context.Context, batch *types.BlockB
 	}
 
 	agg.metrics.RecordBatchCreated(ctx, batch)
+	return nil
+}
+
+func (agg *aggregator) handleCommitBatchError(ctx context.Context, batch *types.BlockBatch, err error) error {
+	switch {
+	case errors.Is(err, rollupcontract.ErrBatchAlreadyCommitted) ||
+		errors.Is(err, rollupcontract.ErrBatchAlreadyFinalized):
+		// for some reason, we attempted to prove a batch that has already been proved,
+		// sync the latest proved root with the L1 contract.
+		agg.logger.Warn().Stringer(logging.FieldBatchId, batch.Id).
+			Err(err).Msg("batch is already committed, resetting state with L1")
+		if err := agg.resetter.LaunchResetToL1WithSuspension(ctx, agg); err != nil {
+			return fmt.Errorf("error resetting state from L1, latestMainHash=%s: %w",
+				batch.LatestMainBlock().Hash, err)
+		}
+	case errors.Is(err, rollupcontract.ErrInvalidBatchIndex) ||
+		errors.Is(err, rollupcontract.ErrInvalidVersionedHash):
+		// data was corrupted or initially created in a wrong way
+		// NOTE: this shouldn't happen in prod setting
+		agg.logger.Warn().Stringer(logging.FieldBatchId, batch.Id).
+			Err(err).Msg("data was corrupted or initially created in a wrong way")
+		if err := agg.resetter.LaunchResetToL1WithSuspension(ctx, agg); err != nil {
+			return fmt.Errorf("error resetting state from L1, latestMainHash=%s: %w",
+				batch.LatestMainBlock().Hash, err)
+		}
+	default:
+		return err
+	}
 	return nil
 }
 
@@ -417,4 +462,42 @@ func (agg *aggregator) prepareForBatchCommit(
 	}
 
 	return agg.rollupContract.PrepareBlobs(ctx, blobs)
+}
+
+// getLatestFinalizedRootFromL1 attempts to retrieve the finalized root from the following sources,
+// in order of priority:
+// 1. L1 contract
+// 2. Genesis block (fallback)
+func (agg *aggregator) getLatestFinalizedRootFromL1(ctx context.Context) (common.Hash, error) {
+	agg.logger.Info().Msg("syncing state with L1")
+
+	latestStateRoot, err := agg.rollupContract.LatestFinalizedStateRoot(ctx)
+	if err != nil {
+		return common.EmptyHash, err
+	}
+	if latestStateRoot != common.EmptyHash {
+		return latestStateRoot, nil
+	}
+
+	agg.logger.Warn().
+		Msg("storage state root is not initialized, genesis state root will be used")
+	genesisBlock, err := agg.rpcClient.GetBlock(ctx, coreTypes.MainShardId, "earliest", false)
+	if err != nil {
+		return common.EmptyHash, err
+	}
+	latestStateRoot = genesisBlock.Hash
+
+	return latestStateRoot, nil
+}
+
+func (agg *aggregator) syncLatestFinalizedRoot(ctx context.Context) error {
+	latestStateRoot, err := agg.getLatestFinalizedRootFromL1(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get latest finalized state root: %w", err)
+	}
+	if err := agg.blockStorage.SetProvedStateRoot(ctx, latestStateRoot); err != nil {
+		return fmt.Errorf("failed to set proved state root: %w", err)
+	}
+	agg.logger.Warn().Msg("Proved state root set")
+	return nil
 }

--- a/nil/services/synccommittee/core/proposer_test.go
+++ b/nil/services/synccommittee/core/proposer_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/NilFoundation/nil/nil/common/logging"
 	"github.com/NilFoundation/nil/nil/internal/db"
 	"github.com/NilFoundation/nil/nil/internal/types"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/core/reset"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/core/rollupcontract"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/metrics"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/storage"
@@ -34,10 +35,10 @@ type ProposerTestSuite struct {
 	clock            clockwork.Clock
 	storage          *storage.BlockStorage
 	ethClient        *rollupcontract.EthClientMock
-	rpcClientMock    *client.ClientMock
 	proposer         *proposer
 	testData         *scTypes.ProposalData
 	callContractMock *testaide.CallContractMock
+	rpcClientMock    *client.ClientMock
 }
 
 func TestProposerSuite(t *testing.T) {
@@ -100,12 +101,24 @@ func (s *ProposerTestSuite) SetupSuite() {
 			return txInTest, false, nil
 		},
 	}
-	s.rpcClientMock = &client.ClientMock{}
 	contractWrapper, err := rollupcontract.NewWrapperWithEthClient(
 		s.ctx, rollupcontract.NewDefaultWrapperConfig(), s.ethClient, logger,
 	)
 	s.Require().NoError(err)
-	s.proposer, err = NewProposer(s.params, s.storage, contractWrapper, s.rpcClientMock, metricsHandler, logger)
+
+	stateResetter := reset.NewStateResetter(logger, s.storage, contractWrapper)
+	resetLauncher := reset.NewResetLauncher(stateResetter, nil, logger)
+
+	s.rpcClientMock = &client.ClientMock{}
+
+	s.proposer, err = NewProposer(
+		s.params,
+		s.storage,
+		contractWrapper,
+		resetLauncher,
+		metricsHandler,
+		logger,
+	)
 	s.Require().NoError(err)
 }
 
@@ -127,6 +140,7 @@ func (s *ProposerTestSuite) TestSendProofCommittedBatch() {
 	s.callContractMock.AddExpectedCall("isBatchCommitted", true)
 	s.callContractMock.AddExpectedCall("getLastFinalizedBatchIndex", "testingFinalizedBatchIndex")
 	s.callContractMock.AddExpectedCall("finalizedStateRoots", s.testData.OldProvedStateRoot)
+	s.callContractMock.AddExpectedCall("updateState", testaide.NoValue{})
 
 	err := s.proposer.updateState(s.ctx, s.testData)
 	s.Require().NoError(err, "failed to send proof")
@@ -168,6 +182,7 @@ func (s *ProposerTestSuite) TestStorageProposalDataRemoved() {
 	s.callContractMock.AddExpectedCall("isBatchCommitted", true)
 	s.callContractMock.AddExpectedCall("getLastFinalizedBatchIndex", "testingFinalizedBatchIndex")
 	s.callContractMock.AddExpectedCall("finalizedStateRoots", s.testData.OldProvedStateRoot)
+	s.callContractMock.AddExpectedCall("updateState", testaide.NoValue{})
 
 	subgraph, err := scTypes.NewSubgraph(
 		&scTypes.Block{
@@ -198,17 +213,45 @@ func (s *ProposerTestSuite) TestStorageProposalDataRemoved() {
 	s.Require().Len(s.ethClient.SendTransactionCalls(), 1)
 }
 
-// Test if storage proved state root is updated from L1
-func (s *ProposerTestSuite) TestStorageProvedRootUpdate() {
-	// Calls inside FinalizedBatchIndex
-	s.callContractMock.AddExpectedCall("finalizedStateRoots", s.testData.OldProvedStateRoot)
+// Test if proposal data is removed from the storage on success
+func (s *ProposerTestSuite) TestProposerResetToL1State() {
+	l1FinalizedStateRoot := common.HexToHash("0x3456")
+	// Calls inside UpdateState
+	s.callContractMock.AddExpectedCall("isBatchCommitted", true)
+	s.callContractMock.AddExpectedCall("isBatchFinalized", true)
 	s.callContractMock.AddExpectedCall("getLastFinalizedBatchIndex", "testingFinalizedBatchIndex")
-	err := s.proposer.updateStoredStateRootFromContract(s.ctx)
-	s.Require().NoError(err)
+	s.callContractMock.AddExpectedCall("finalizedStateRoots", l1FinalizedStateRoot)
 
-	storageProvedStateRoot, err := s.storage.TryGetProvedStateRoot(s.ctx)
+	subgraph, err := scTypes.NewSubgraph(
+		&scTypes.Block{
+			ShardId:    types.MainShardId,
+			Number:     123,
+			Hash:       common.HexToHash("123"),
+			ParentHash: s.testData.OldProvedStateRoot,
+		}, nil)
 	s.Require().NoError(err)
-	s.Require().Equal(s.testData.OldProvedStateRoot, *storageProvedStateRoot)
+	s.Require().NoError(s.storage.SetBlockBatch(
+		s.ctx,
+		&scTypes.BlockBatch{Id: s.testData.BatchId, Subgraphs: []scTypes.Subgraph{*subgraph}},
+	))
+	s.Require().NoError(s.storage.SetBatchAsProved(s.ctx, s.testData.BatchId))
+	s.Require().NoError(s.storage.SetProvedStateRoot(s.ctx, s.testData.OldProvedStateRoot))
+
+	data, err := s.storage.TryGetNextProposalData(s.ctx)
+	s.Require().NoError(err)
+	s.Require().NotNil(data)
+	s.Require().NoError(s.proposer.updateStateIfReady(s.ctx))
+
+	// after `SetBatchAsProposed` call inside `updateStateIfReady` there should be no new proposal data
+	data, err = s.storage.TryGetNextProposalData(s.ctx)
+	s.Require().NoError(err)
+	// no batches were inserted, thus, no new proposal data
+	s.Require().Nil(data)
+
+	provedStateRoot, err := s.storage.TryGetProvedStateRoot(s.ctx)
+	s.Require().NoError(err)
+	// latest proved state root should have been fetched from L1
+	s.Require().Equal(l1FinalizedStateRoot, *provedStateRoot)
 
 	s.Require().NoError(s.callContractMock.EverythingCalled())
 	s.Require().Empty(s.ethClient.SendTransactionCalls())

--- a/nil/services/synccommittee/core/reset/state_reset_launcher.go
+++ b/nil/services/synccommittee/core/reset/state_reset_launcher.go
@@ -2,7 +2,9 @@ package reset
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	"github.com/NilFoundation/nil/nil/common/logging"
@@ -10,51 +12,63 @@ import (
 )
 
 const (
-	fetchResumeDelay        = 10 * time.Minute
-	fetchResumeTimeout      = time.Minute
+	componentsResumeDelay   = 10 * time.Minute
+	componentsResumeTimeout = time.Minute
 	gracefulShutdownTimeout = 5 * time.Minute
 )
 
-type BlockFetcher interface {
+type PausableComponent interface {
 	Pause(ctx context.Context) error
 	Resume(ctx context.Context) error
+	Name() string
 }
 
 type Service interface {
 	Stop() (stopped <-chan struct{})
 }
 
-type stateResetLauncher struct {
-	blockFetcher BlockFetcher
-	resetter     *StateResetter
-	service      Service
-	logger       logging.Logger
+type StateResetLauncher struct {
+	pausableComponents []PausableComponent
+	resetter           *StateResetter
+	service            Service
+	logger             logging.Logger
+	isRunning          atomic.Bool
 }
 
 func NewResetLauncher(
-	blockFetcher BlockFetcher,
 	resetter *StateResetter,
 	service Service,
 	logger logging.Logger,
-) *stateResetLauncher {
-	return &stateResetLauncher{
-		blockFetcher: blockFetcher,
-		resetter:     resetter,
-		service:      service,
-		logger:       logger,
+) *StateResetLauncher {
+	return &StateResetLauncher{
+		resetter: resetter,
+		service:  service,
+		logger:   logger,
 	}
 }
 
-func (l *stateResetLauncher) LaunchPartialResetWithSuspension(
+func (l *StateResetLauncher) AddPausableComponent(pausableComponent ...PausableComponent) {
+	l.pausableComponents = append(l.pausableComponents, pausableComponent...)
+}
+
+func (l *StateResetLauncher) LaunchPartialResetWithSuspension(
+	ctx context.Context, failedBatchId scTypes.BatchId,
+) error {
+	return l.withExclusiveLock(func() error {
+		return l.unsafeLaunchPartialResetWithSuspension(ctx, failedBatchId)
+	})
+}
+
+func (l *StateResetLauncher) unsafeLaunchPartialResetWithSuspension(
 	ctx context.Context,
 	failedBatchId scTypes.BatchId,
 ) error {
 	l.logger.Info().
 		Stringer(logging.FieldBatchId, failedBatchId).
-		Msg("Launching state reset process")
+		Msg("Launching state partial reset process")
 
-	if err := l.blockFetcher.Pause(ctx); err != nil {
-		return fmt.Errorf("failed to pause block fetching: %w", err)
+	if err := l.pauseComponents(ctx, nil); err != nil {
+		return err
 	}
 
 	if err := l.resetter.ResetProgressPartial(ctx, failedBatchId); err != nil {
@@ -64,41 +78,112 @@ func (l *stateResetLauncher) LaunchPartialResetWithSuspension(
 
 	l.logger.Info().
 		Stringer(logging.FieldBatchId, failedBatchId).
-		Msgf("State reset completed, block fetching will be resumed after %s", fetchResumeDelay)
+		Msgf("State partial reset completed, block components will be resumed after %s", componentsResumeDelay)
 
-	time.AfterFunc(fetchResumeDelay, func() {
-		l.resumeBlockFetching(ctx)
+	time.AfterFunc(componentsResumeDelay, func() {
+		l.resumeComponents(ctx)
 	})
 	return nil
 }
 
-func (l *stateResetLauncher) onResetError(
+// LaunchResetToL1WithSuspension pauses all components, resets all batches by removing them from storage,
+// and calls `SetProvedStateRoot` using the root obtained from L1.
+// The `caller` argument is used to exclude the caller from being paused;
+// otherwise, `StateResetLauncher` will attempt to pause the caller as well, which will cause a `pauseComponents` error.
+func (l *StateResetLauncher) LaunchResetToL1WithSuspension(
+	ctx context.Context, caller PausableComponent,
+) error {
+	return l.withExclusiveLock(func() error {
+		return l.unsafeLaunchResetToL1WithSuspension(ctx, caller)
+	})
+}
+
+func (l *StateResetLauncher) unsafeLaunchResetToL1WithSuspension(
+	ctx context.Context, caller PausableComponent,
+) error {
+	l.logger.Info().
+		Msg("Launching state full reset process")
+
+	if err := l.pauseComponents(ctx, caller); err != nil {
+		l.logger.Error().Err(err).Msg("Pausing components failed")
+		return err
+	}
+
+	if err := l.resetter.ResetProgressToL1(ctx); err != nil {
+		l.logger.Error().Err(err).Msg("Failed to reset all progress")
+		l.resumeComponents(ctx)
+		return nil
+	}
+
+	l.logger.Info().
+		Msgf("State full reset completed, block components will be resumed after %s", componentsResumeDelay)
+
+	time.AfterFunc(componentsResumeDelay, func() {
+		l.resumeComponents(ctx)
+	})
+	return nil
+}
+
+func (l *StateResetLauncher) onResetError(
 	ctx context.Context, resetErr error, failedBatchId scTypes.BatchId,
 ) {
 	l.logger.Error().Err(resetErr).Stringer(logging.FieldBatchId, failedBatchId).Msg("Failed to reset progress")
-	l.resumeBlockFetching(ctx)
+	l.resumeComponents(ctx)
 }
 
-func (l *stateResetLauncher) resumeBlockFetching(ctx context.Context) {
+func (l *StateResetLauncher) pauseComponents(ctx context.Context, skipComponent PausableComponent) error {
+	l.logger.Info().Msg("Pausing components")
+	for _, component := range l.pausableComponents {
+		if component == skipComponent {
+			continue
+		}
+		if err := component.Pause(ctx); err != nil {
+			return fmt.Errorf("failed to pause component %s: %w", component.Name(), err)
+		}
+	}
+	return nil
+}
+
+func (l *StateResetLauncher) resumeComponents(ctx context.Context) {
+	l.logger.Info().Msg("Resuming components")
+
 	detachedCtx := context.WithoutCancel(ctx)
-	timeoutCtx, cancel := context.WithTimeout(detachedCtx, fetchResumeTimeout)
-	defer cancel()
+	var resumeErr error
+	for _, component := range l.pausableComponents {
+		timeoutCtx, cancel := context.WithTimeout(detachedCtx, componentsResumeTimeout)
 
-	l.logger.Info().Msg("Resuming block fetching")
-	err := l.blockFetcher.Resume(timeoutCtx)
+		err := component.Resume(timeoutCtx)
+		cancel()
 
-	if err == nil {
+		if err != nil {
+			resumeErr = fmt.Errorf("failed to resume component %s: %w", component.Name(), err)
+			break
+		}
+	}
+
+	if resumeErr == nil {
 		l.logger.Info().Msg("Block fetching successfully resumed")
 		return
 	}
 
-	l.logger.Error().Err(err).Msg("Failed to resume block fetching, service will be terminated")
+	l.logger.Error().Err(resumeErr).Msg("Failed to resume block fetching, service will be terminated")
 
 	stopped := l.service.Stop()
 
 	select {
 	case <-time.After(gracefulShutdownTimeout):
-		l.logger.Fatal().Err(err).Msgf("Service did not stop after %s, force termination", gracefulShutdownTimeout)
+		l.logger.Fatal().Err(resumeErr).
+			Msgf("Service did not stop after %s, force termination", gracefulShutdownTimeout)
 	case <-stopped:
 	}
+}
+
+func (l *StateResetLauncher) withExclusiveLock(f func() error) error {
+	if !l.isRunning.CompareAndSwap(false, true) {
+		l.logger.Warn().Msg("Reset already in progress, ignoring duplicate call")
+		return errors.New("reset already in progress")
+	}
+	defer l.isRunning.Store(false)
+
+	return f()
 }

--- a/nil/services/synccommittee/core/rollupcontract/errors.go
+++ b/nil/services/synccommittee/core/rollupcontract/errors.go
@@ -6,4 +6,6 @@ var (
 	ErrBatchAlreadyFinalized = errors.New("batch already finalized")
 	ErrBatchAlreadyCommitted = errors.New("batch already committed")
 	ErrBatchNotCommitted     = errors.New("batch has not been committed")
+	ErrInvalidBatchIndex     = errors.New("batch index is invalid")
+	ErrInvalidVersionedHash  = errors.New("versioned hash is invalid")
 )

--- a/nil/services/synccommittee/core/service_test.go
+++ b/nil/services/synccommittee/core/service_test.go
@@ -97,23 +97,8 @@ func (s *SyncCommitteeTestSuite) waitMainShardToProcess() {
 	)
 }
 
-func (s *SyncCommitteeTestSuite) TestProcessingLoop() {
-	// Run processing loop for a short time
-	ctx, cancel := context.WithTimeout(s.Context, 5*time.Second)
-	defer cancel()
-
-	errCh := make(chan error)
-	go func() {
-		errCh <- s.syncCommittee.Run(ctx)
-	}()
-
-	s.waitMainShardToProcess()
-
-	cancel()
-	s.Require().ErrorIs(<-errCh, context.Canceled)
-}
-
 func (s *SyncCommitteeTestSuite) TestRun() {
+	// Run processing loop for a short time
 	ctx, cancel := context.WithTimeout(s.Context, 5*time.Second)
 	defer cancel()
 

--- a/nil/services/synccommittee/internal/testaide/client_mock_block_setter.go
+++ b/nil/services/synccommittee/internal/testaide/client_mock_block_setter.go
@@ -54,12 +54,17 @@ func ClientMockSetBlocks(client *client.ClientMock, blocks iter.Seq[*scTypes.Blo
 	client.GetBlockFunc = func(
 		_ context.Context, shardId types.ShardId, blockId any, fullTx bool,
 	) (*scTypes.Block, error) {
-		if strId, ok := blockId.(string); ok && strId == "latest" {
+		if strId, ok := blockId.(string); ok {
 			shardSlice := shardsToBlocks[shardId]
 			if len(shardSlice) == 0 {
 				return nil, nil
 			}
-			return shardSlice[len(shardSlice)-1], nil
+			switch strId {
+			case "latest":
+				return shardSlice[len(shardSlice)-1], nil
+			case "earliest":
+				return shardSlice[0], nil
+			}
 		}
 
 		blockHash, ok := blockId.(common.Hash)


### PR DESCRIPTION
## Short Summary

Sync committee. Handle CommitBatch errors, add simulation before tx submission.

## What Changes Were Made
- Add simulation before submitting each transaction to L1 to catch errors early.
- If simulation fails, parse the RPC error; depending on its type, the `CommitBatch` method either panics or triggers a state resync from L1 (e.g., when multiple SC instances are running and local state is stale).
- Move L1 finalized state fetcher to a separate class for better modularity.
- Pass the fetcher into both aggregator and proposer components so they can detect outdated local state and initiate L1 synchronization.

## Checklist
- [x] I have read and followed the [Contributing Guide](https://github.com/NilFoundation/nil/blob/main/CONTRIBUTION-GUIDE.md)
- [x] I have tested the changes locally
- [x] I have added relevant tests (if applicable)
- [x] I have updated documentation/comments (if applicable)
