### PR TITLE
Sync Committee: Batch Constraints

### DIFF
--- a/nil/services/synccommittee/Makefile.inc
+++ b/nil/services/synccommittee/Makefile.inc
@@ -18,6 +18,7 @@ $(root_sc)/core/rollupcontract/rollupcontract_abi_generated.go: \
 
 .PHONY: sync_committee_types_stringer
 sync_committee_types_stringer: \
+	$(root_sc)/core/batches/constraints/checkresult_string.go \
 	$(root_sc)/internal/types/tasktype_string.go \
 	$(root_sc)/internal/types/proverresulttype_string.go \
 	$(root_sc)/internal/types/taskstatus_string.go \
@@ -25,6 +26,8 @@ sync_committee_types_stringer: \
 	$(root_sc)/internal/types/taskerrtype_string.go \
 	$(root_sc)/public/taskdebugorder_string.go
 
+$(root_sc)/core/batches/constraints/checkresult_string.go: $(root_sc)/core/batches/constraints/result.go
+	go generate -run="CheckResult" $(root_sc)/core/batches/constraints/result.go
 $(root_sc)/internal/types/tasktype_string.go: $(root_sc)/internal/types/task_type.go
 	go generate -run="TaskType" $(root_sc)/internal/types/generate.go
 $(root_sc)/internal/types/proverresulttype_string.go: $(root_sc)/internal/types/task_result.go

--- a/nil/services/synccommittee/core/batches/constraints/checker.go
+++ b/nil/services/synccommittee/core/batches/constraints/checker.go
@@ -49,7 +49,7 @@ func (c *checker) CheckConstraints(ctx context.Context, batch *types.BlockBatch)
 		if err != nil {
 			return nil, fmt.Errorf("failed to run batch constraint %s: %w", constraint.Name(), err)
 		}
-		batchResult = batchResult.Join(result)
+		batchResult.JoinWith(result)
 	}
 
 	if batchResult.Type == CheckResultTypeCanBeExtended {

--- a/nil/services/synccommittee/core/batches/constraints/checker.go
+++ b/nil/services/synccommittee/core/batches/constraints/checker.go
@@ -1,0 +1,64 @@
+package constraints
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/NilFoundation/nil/nil/common/logging"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
+	"github.com/jonboulle/clockwork"
+)
+
+type batchConstraintRunner interface {
+	Name() string
+	Run(ctx context.Context, batch *types.BlockBatch) (*CheckResult, error)
+}
+
+type checker struct {
+	constraints BatchConstraints
+	runners     []batchConstraintRunner
+	logger      logging.Logger
+}
+
+func NewChecker(
+	constraints BatchConstraints,
+	clock clockwork.Clock,
+	logger logging.Logger,
+) *checker {
+	return &checker{
+		constraints: constraints,
+		runners: []batchConstraintRunner{
+			newTimeoutConstraint(constraints, clock),
+			newSizeConstraint(constraints),
+		},
+		logger: logger,
+	}
+}
+
+func (c *checker) Constraints() BatchConstraints {
+	return c.constraints
+}
+
+func (c *checker) CheckConstraints(ctx context.Context, batch *types.BlockBatch) (*CheckResult, error) {
+	c.logger.Debug().Stringer(logging.FieldBatchId, batch.Id).Msg("Checking batch constraints")
+
+	batchResult := canBeExtended()
+
+	for _, constraint := range c.runners {
+		result, err := constraint.Run(ctx, batch)
+		if err != nil {
+			return nil, fmt.Errorf("failed to run batch constraint %s: %w", constraint.Name(), err)
+		}
+		batchResult = batchResult.Join(result)
+	}
+
+	if batchResult.Type == CheckResultTypeCanBeExtended {
+		c.logger.Debug().Stringer(logging.FieldBatchId, batch.Id).Msg("All batch constraints are satisfied")
+	} else {
+		c.logger.Info().
+			Stringer(logging.FieldBatchId, batch.Id).
+			Msgf("Batch constraint(s) are violated, result: %s", batchResult)
+	}
+
+	return batchResult, nil
+}

--- a/nil/services/synccommittee/core/batches/constraints/constraint_size.go
+++ b/nil/services/synccommittee/core/batches/constraints/constraint_size.go
@@ -21,14 +21,14 @@ func (c *sizeConstraint) Name() string {
 }
 
 func (c *sizeConstraint) Run(_ context.Context, batch *types.BlockBatch) (*CheckResult, error) {
-	blocksCount := batch.Blocks.BlocksCount()
+	blocksCount := uint32(batch.Blocks.BlocksCount())
 	maxBlockCount := c.constraints.MaxBlocksCount
 
 	switch {
 	case blocksCount > maxBlockCount:
 		return shouldBeDiscarded("batch size exceeded MaxBlocksCount (%d > %d)", blocksCount, maxBlockCount), nil
 
-	case blocksCount == c.constraints.MaxBlocksCount:
+	case blocksCount == maxBlockCount:
 		return shouldBeSealed("batch size is equal to MaxBlocksCount value (%d)", blocksCount), nil
 
 	default:

--- a/nil/services/synccommittee/core/batches/constraints/constraint_size.go
+++ b/nil/services/synccommittee/core/batches/constraints/constraint_size.go
@@ -1,0 +1,37 @@
+package constraints
+
+import (
+	"context"
+
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
+)
+
+type sizeConstraint struct {
+	constraints BatchConstraints
+}
+
+func newSizeConstraint(constraints BatchConstraints) batchConstraintRunner {
+	return &sizeConstraint{
+		constraints: constraints,
+	}
+}
+
+func (c *sizeConstraint) Name() string {
+	return "size"
+}
+
+func (c *sizeConstraint) Run(_ context.Context, batch *types.BlockBatch) (*CheckResult, error) {
+	blocksCount := batch.Blocks.BlocksCount()
+	maxBlockCount := c.constraints.MaxBlocksCount
+
+	switch {
+	case blocksCount > maxBlockCount:
+		return shouldBeDiscarded("batch size exceeded MaxBlocksCount (%d > %d)", blocksCount, maxBlockCount), nil
+
+	case blocksCount == c.constraints.MaxBlocksCount:
+		return shouldBeSealed("batch size is equal to MaxBlocksCount value (%d)", blocksCount), nil
+
+	default:
+		return canBeExtended(), nil
+	}
+}

--- a/nil/services/synccommittee/core/batches/constraints/constraint_timeout.go
+++ b/nil/services/synccommittee/core/batches/constraints/constraint_timeout.go
@@ -1,0 +1,40 @@
+package constraints
+
+import (
+	"context"
+
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
+	"github.com/jonboulle/clockwork"
+)
+
+type timeoutConstraint struct {
+	constraint BatchConstraints
+	clock      clockwork.Clock
+}
+
+func newTimeoutConstraint(constraint BatchConstraints, clock clockwork.Clock) batchConstraintRunner {
+	return &timeoutConstraint{
+		constraint: constraint,
+		clock:      clock,
+	}
+}
+
+func (c *timeoutConstraint) Name() string {
+	return "timeout"
+}
+
+func (c *timeoutConstraint) Run(_ context.Context, batch *types.BlockBatch) (*CheckResult, error) {
+	if batch.IsEmpty() {
+		return canBeExtended(), nil
+	}
+
+	now := c.clock.Now()
+	currentDuration := now.Sub(batch.CreatedAt)
+	sealingTimeout := c.constraint.SealingTimeout
+
+	if currentDuration < sealingTimeout {
+		return canBeExtended(), nil
+	} else {
+		return shouldBeSealed("sealing timeout is reached (%s >= %s)", sealingTimeout, currentDuration), nil
+	}
+}

--- a/nil/services/synccommittee/core/batches/constraints/constraint_timeout.go
+++ b/nil/services/synccommittee/core/batches/constraints/constraint_timeout.go
@@ -32,9 +32,9 @@ func (c *timeoutConstraint) Run(_ context.Context, batch *types.BlockBatch) (*Ch
 	currentDuration := now.Sub(batch.CreatedAt)
 	sealingTimeout := c.constraint.SealingTimeout
 
-	if currentDuration < sealingTimeout {
-		return canBeExtended(), nil
-	} else {
-		return shouldBeSealed("sealing timeout is reached (%s >= %s)", sealingTimeout, currentDuration), nil
+	if currentDuration >= sealingTimeout {
+		return shouldBeSealed("sealing timeout is reached (%s >= %s)", currentDuration, sealingTimeout), nil
 	}
+
+	return canBeExtended(), nil
 }

--- a/nil/services/synccommittee/core/batches/constraints/constraints.go
+++ b/nil/services/synccommittee/core/batches/constraints/constraints.go
@@ -1,0 +1,20 @@
+package constraints
+
+import "time"
+
+type BatchConstraints struct {
+	// SealingTimeout defines the max allowed interval between batch creation
+	// and batch sealing (when batch is considered complete).
+	SealingTimeout time.Duration
+
+	// MaxBlocksCount specifies the maximum number of blocks allowed
+	// to be included into a single batch.
+	MaxBlocksCount uint32
+}
+
+func DefaultBatchConstraints() BatchConstraints {
+	return BatchConstraints{
+		SealingTimeout: 10 * time.Minute,
+		MaxBlocksCount: 1000,
+	}
+}

--- a/nil/services/synccommittee/core/batches/constraints/constraints.go
+++ b/nil/services/synccommittee/core/batches/constraints/constraints.go
@@ -8,13 +8,22 @@ type BatchConstraints struct {
 	SealingTimeout time.Duration
 
 	// MaxBlocksCount specifies the maximum number of blocks allowed
-	// to be included into a single batch.
+	// to be included in a single batch.
 	MaxBlocksCount uint32
 }
 
-func DefaultBatchConstraints() BatchConstraints {
+func NewBatchConstraints(
+	sealingTimeout time.Duration,
+	maxBlocksCount uint32,
+) BatchConstraints {
 	return BatchConstraints{
-		SealingTimeout: 10 * time.Minute,
-		MaxBlocksCount: 1000,
+		SealingTimeout: sealingTimeout,
+		MaxBlocksCount: maxBlocksCount,
 	}
+}
+
+func DefaultBatchConstraints() BatchConstraints {
+	const defaultSealingTimeout = 12 * time.Second
+	const defaultMaxBlocksCount = 100
+	return NewBatchConstraints(defaultSealingTimeout, defaultMaxBlocksCount)
 }

--- a/nil/services/synccommittee/core/batches/constraints/result.go
+++ b/nil/services/synccommittee/core/batches/constraints/result.go
@@ -1,0 +1,83 @@
+package constraints
+
+import (
+	"fmt"
+)
+
+//go:generate stringer -type=CheckResultType -trimprefix=CheckResultType
+
+type CheckResultType uint8
+
+const (
+	_ CheckResultType = iota
+
+	// CheckResultTypeCanBeExtended indicates that the batch can be further extended with additional blocks.
+	CheckResultTypeCanBeExtended
+
+	// CheckResultTypeShouldBeSealed indicates that the batch should be finalized and cannot be further extended.
+	CheckResultTypeShouldBeSealed
+
+	// CheckResultTypeShouldBeDiscarded indicates that the batch is not valid for processing and should be discarded.
+	CheckResultTypeShouldBeDiscarded
+)
+
+var severity = map[CheckResultType]uint8{
+	CheckResultTypeCanBeExtended:     1,
+	CheckResultTypeShouldBeSealed:    2,
+	CheckResultTypeShouldBeDiscarded: 3,
+}
+
+type CheckResult struct {
+	Type    CheckResultType
+	Details string
+}
+
+func (r *CheckResult) String() string {
+	return fmt.Sprintf("%s: %s", r.Type, r.Details)
+}
+
+func (r *CheckResult) Join(other *CheckResult) *CheckResult {
+	var joinedType CheckResultType
+	if severity[r.Type] >= severity[other.Type] {
+		joinedType = r.Type
+	} else {
+		joinedType = other.Type
+	}
+
+	var joinedDetails string
+	switch {
+	case r.Details == "":
+		joinedDetails = other.Details
+	case other.Details == "":
+		joinedDetails = r.Details
+	default:
+		joinedDetails = r.Details + "; " + other.Details
+	}
+
+	return &CheckResult{
+		Type:    joinedType,
+		Details: joinedDetails,
+	}
+}
+
+func newCheckResult(resultType CheckResultType, format string, args ...interface{}) CheckResult {
+	return CheckResult{
+		Type:    resultType,
+		Details: fmt.Sprintf(format, args...),
+	}
+}
+
+func canBeExtended() *CheckResult {
+	result := newCheckResult(CheckResultTypeCanBeExtended, "")
+	return &result
+}
+
+func shouldBeSealed(format string, args ...interface{}) *CheckResult {
+	result := newCheckResult(CheckResultTypeShouldBeSealed, format, args...)
+	return &result
+}
+
+func shouldBeDiscarded(format string, args ...interface{}) *CheckResult {
+	result := newCheckResult(CheckResultTypeShouldBeDiscarded, format, args...)
+	return &result
+}

--- a/nil/services/synccommittee/core/batches/constraints/result.go
+++ b/nil/services/synccommittee/core/batches/constraints/result.go
@@ -36,12 +36,9 @@ func (r *CheckResult) String() string {
 	return fmt.Sprintf("%s: %s", r.Type, r.Details)
 }
 
-func (r *CheckResult) Join(other *CheckResult) *CheckResult {
-	var joinedType CheckResultType
-	if severity[r.Type] >= severity[other.Type] {
-		joinedType = r.Type
-	} else {
-		joinedType = other.Type
+func (r *CheckResult) JoinWith(other *CheckResult) {
+	if severity[other.Type] > severity[r.Type] {
+		r.Type = other.Type
 	}
 
 	var joinedDetails string
@@ -54,13 +51,10 @@ func (r *CheckResult) Join(other *CheckResult) *CheckResult {
 		joinedDetails = r.Details + "; " + other.Details
 	}
 
-	return &CheckResult{
-		Type:    joinedType,
-		Details: joinedDetails,
-	}
+	r.Details = joinedDetails
 }
 
-func newCheckResult(resultType CheckResultType, format string, args ...interface{}) CheckResult {
+func newCheckResult(resultType CheckResultType, format string, args ...any) CheckResult {
 	return CheckResult{
 		Type:    resultType,
 		Details: fmt.Sprintf(format, args...),
@@ -72,12 +66,12 @@ func canBeExtended() *CheckResult {
 	return &result
 }
 
-func shouldBeSealed(format string, args ...interface{}) *CheckResult {
+func shouldBeSealed(format string, args ...any) *CheckResult {
 	result := newCheckResult(CheckResultTypeShouldBeSealed, format, args...)
 	return &result
 }
 
-func shouldBeDiscarded(format string, args ...interface{}) *CheckResult {
+func shouldBeDiscarded(format string, args ...any) *CheckResult {
 	result := newCheckResult(CheckResultTypeShouldBeDiscarded, format, args...)
 	return &result
 }

--- a/nil/services/synccommittee/core/block_batch_test.go
+++ b/nil/services/synccommittee/core/block_batch_test.go
@@ -21,7 +21,7 @@ func TestBlockBatchTestSuite(t *testing.T) {
 
 func (s *BlockBatchTestSuite) Test_Valid_Batch_Single_ChainSegments() {
 	blocks := testaide.NewChainSegments(testaide.ShardsCount)
-	batch, err := types.NewBlockBatch(nil).WithAddedBlocks(blocks)
+	batch, err := types.NewBlockBatch(nil, testaide.Now).WithAddedBlocks(blocks, testaide.Now)
 	s.Require().NoError(err)
 	s.Require().NotNil(batch)
 	s.Require().Equal(blocks, batch.Blocks)
@@ -30,11 +30,11 @@ func (s *BlockBatchTestSuite) Test_Valid_Batch_Single_ChainSegments() {
 func (s *BlockBatchTestSuite) Test_Valid_Batch_Multiple_ChainSegments() {
 	segments := testaide.NewSegmentsSequence(2)
 
-	batch, err := types.NewBlockBatch(nil).WithAddedBlocks(segments[0])
+	batch, err := types.NewBlockBatch(nil, testaide.Now).WithAddedBlocks(segments[0], testaide.Now)
 	s.Require().NoError(err)
 	s.Require().NotNil(batch)
 
-	updatedBatch, err := batch.WithAddedBlocks(segments[1])
+	updatedBatch, err := batch.WithAddedBlocks(segments[1], testaide.Now)
 	s.Require().NoError(err)
 	s.Require().NotNil(updatedBatch)
 
@@ -46,14 +46,14 @@ func (s *BlockBatchTestSuite) Test_Valid_Batch_Multiple_ChainSegments() {
 func (s *BlockBatchTestSuite) Test_Invalid_Sequencing() {
 	segments := testaide.NewChainSegments(testaide.ShardsCount)
 
-	batch, err := types.NewBlockBatch(nil).WithAddedBlocks(segments)
+	batch, err := types.NewBlockBatch(nil, testaide.Now).WithAddedBlocks(segments, testaide.Now)
 	s.Require().NoError(err)
 	s.Require().NotNil(batch)
 
 	// nextSegments has no connection with the first segments
 	nextSegments := testaide.NewChainSegments(testaide.ShardsCount)
 
-	updatedBatch, err := batch.WithAddedBlocks(nextSegments)
+	updatedBatch, err := batch.WithAddedBlocks(nextSegments, testaide.Now)
 	s.Require().ErrorIs(err, types.ErrBlockMismatch)
 	s.Require().Nil(updatedBatch)
 }

--- a/nil/services/synccommittee/core/block_tasks_integration_test.go
+++ b/nil/services/synccommittee/core/block_tasks_integration_test.go
@@ -74,7 +74,7 @@ func (s *BlockTasksIntegrationTestSuite) Test_Provide_Tasks_And_Handle_Success_R
 	err := s.blockStorage.SetProvedStateRoot(s.ctx, batch.EarliestMainBlock().ParentHash)
 	s.Require().NoError(err)
 
-	err = s.blockStorage.SetBlockBatch(s.ctx, batch)
+	err = s.blockStorage.PutBlockBatch(s.ctx, batch)
 	s.Require().NoError(err)
 
 	proofTask, err := batch.CreateProofTask(s.clock.Now())
@@ -114,7 +114,7 @@ func (s *BlockTasksIntegrationTestSuite) Test_Provide_Tasks_And_Handle_Failure_R
 	err := s.blockStorage.SetProvedStateRoot(s.ctx, batch.EarliestMainBlock().ParentHash)
 	s.Require().NoError(err)
 
-	err = s.blockStorage.SetBlockBatch(s.ctx, batch)
+	err = s.blockStorage.PutBlockBatch(s.ctx, batch)
 	s.Require().NoError(err)
 
 	proofTask, err := batch.CreateProofTask(s.clock.Now())

--- a/nil/services/synccommittee/core/fetching/aggregator.go
+++ b/nil/services/synccommittee/core/fetching/aggregator.go
@@ -37,7 +37,7 @@ type AggregatorBlockStorage interface {
 	GetLatestFetched(ctx context.Context) (types.BlockRefs, error)
 	TryGetProvedStateRoot(ctx context.Context) (*common.Hash, error)
 	TryGetLatestBatch(ctx context.Context) (*types.BlockBatch, error)
-	SetBlockBatch(ctx context.Context, batch *types.BlockBatch) error
+	PutBlockBatch(ctx context.Context, batch *types.BlockBatch) error
 	GetFreeSpaceBatchCount(ctx context.Context) (uint32, error)
 	SetProvedStateRoot(ctx context.Context, stateRoot common.Hash) error
 }
@@ -374,7 +374,8 @@ func (agg *aggregator) handleBlockBatch(ctx context.Context, batch *types.BlockB
 	}
 
 	mainRef := latestFetched.TryGetMain()
-	if err := mainRef.ValidateNext(batch.EarliestMainBlock()); err != nil {
+	batchEarliestMain := batch.EarliestMainBlock()
+	if err := mainRef.ValidateNext(batchEarliestMain); err != nil {
 		return err
 	}
 
@@ -384,7 +385,7 @@ func (agg *aggregator) handleBlockBatch(ctx context.Context, batch *types.BlockB
 	}
 	batch = batch.WithDataProofs(dataProofs)
 
-	if err := agg.blockStorage.SetBlockBatch(ctx, batch); err != nil {
+	if err := agg.blockStorage.PutBlockBatch(ctx, batch); err != nil {
 		return fmt.Errorf("error storing block batch, latestMainHash=%s: %w", batch.LatestMainBlock().Hash, err)
 	}
 

--- a/nil/services/synccommittee/core/fetching/aggregator_test.go
+++ b/nil/services/synccommittee/core/fetching/aggregator_test.go
@@ -104,7 +104,7 @@ func (s *AggregatorTestSuite) TearDownSuite() {
 
 func (s *AggregatorTestSuite) Test_No_New_Blocks_To_Fetch() {
 	batch := testaide.NewBlockBatch(testaide.ShardsCount)
-	err := s.blockStorage.SetBlockBatch(s.ctx, batch)
+	err := s.blockStorage.PutBlockBatch(s.ctx, batch)
 	s.Require().NoError(err)
 
 	testaide.ClientMockSetBatches(s.rpcClientMock, []*scTypes.BlockBatch{batch})
@@ -129,7 +129,7 @@ func (s *AggregatorTestSuite) Test_Main_Parent_Hash_Mismatch() {
 
 	// Set first 2 batches as proved
 	for _, provedBatch := range batches[:2] {
-		err := s.blockStorage.SetBlockBatch(s.ctx, provedBatch)
+		err := s.blockStorage.PutBlockBatch(s.ctx, provedBatch)
 		s.Require().NoError(err)
 		err = s.blockStorage.SetBatchAsProved(s.ctx, provedBatch.Id)
 		s.Require().NoError(err)
@@ -176,7 +176,7 @@ func (s *AggregatorTestSuite) Test_Fetch_At_Zero_State() {
 
 func (s *AggregatorTestSuite) Test_Fetch_Next_Valid() {
 	batches := testaide.NewBatchesSequence(2)
-	err := s.blockStorage.SetBlockBatch(s.ctx, batches[0])
+	err := s.blockStorage.PutBlockBatch(s.ctx, batches[0])
 	s.Require().NoError(err)
 	nextMainBlock := batches[1].LatestMainBlock()
 
@@ -195,7 +195,7 @@ func (s *AggregatorTestSuite) Test_Block_Storage_Capacity_Exceeded() {
 	batches := testaide.NewBatchesSequence(2)
 	testaide.ClientMockSetBatches(s.rpcClientMock, batches)
 
-	err := blockStorage.SetBlockBatch(s.ctx, batches[0])
+	err := blockStorage.PutBlockBatch(s.ctx, batches[0])
 	s.Require().NoError(err)
 
 	agg := s.newTestAggregator(blockStorage)

--- a/nil/services/synccommittee/core/fetching/block_range_fetcher.go
+++ b/nil/services/synccommittee/core/fetching/block_range_fetcher.go
@@ -1,0 +1,98 @@
+package fetching
+
+import (
+	"context"
+	"fmt"
+	"iter"
+
+	"github.com/NilFoundation/nil/nil/common"
+	"github.com/NilFoundation/nil/nil/common/logging"
+	coreTypes "github.com/NilFoundation/nil/nil/internal/types"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
+)
+
+const blockRangeBatchSize = 20
+
+type fetcher struct {
+	rpcClient RpcBlockFetcher
+	logger    logging.Logger
+}
+
+func newFetcher(rpcClient RpcBlockFetcher, logger logging.Logger) *fetcher {
+	return &fetcher{
+		rpcClient: rpcClient,
+		logger:    logger,
+	}
+}
+
+func (bf *fetcher) GetBlockRef(
+	ctx context.Context,
+	shardId coreTypes.ShardId,
+	hash common.Hash,
+) (*types.BlockRef, error) {
+	block, err := bf.rpcClient.GetBlock(ctx, shardId, hash, true)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching block from shard %d: %w", shardId, err)
+	}
+	if block == nil {
+		return nil, fmt.Errorf("block not found in shard %d: %s", shardId, hash)
+	}
+	blockRef := types.BlockToRef(block)
+	return &blockRef, nil
+}
+
+func (bf *fetcher) GetLatestBlockRef(
+	ctx context.Context,
+	shardId coreTypes.ShardId,
+) (*types.BlockRef, error) {
+	block, err := bf.rpcClient.GetBlock(ctx, shardId, "latest", false)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching latest block, shardId=%d: %w", shardId, err)
+	}
+	if block == nil {
+		return nil, fmt.Errorf("%w: latest block not found in chain, shardId=%d", types.ErrBlockNotFound, shardId)
+	}
+	blockRef := types.BlockToRef(block)
+	return &blockRef, nil
+}
+
+func (bf *fetcher) FetchBlocksSeq(
+	ctx context.Context,
+	shardId coreTypes.ShardId,
+	blocksRange types.BlocksRange,
+) iter.Seq2[*types.Block, error] {
+	return func(yield func(*types.Block, error) bool) {
+		chunks := blocksRange.SplitToChunks(blockRangeBatchSize)
+
+		for _, chunk := range chunks {
+			blocks, err := bf.fetchChunk(ctx, shardId, chunk)
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+			for _, block := range blocks {
+				if !yield(block, nil) {
+					return
+				}
+			}
+		}
+	}
+}
+
+func (bf *fetcher) fetchChunk(
+	ctx context.Context,
+	shardId coreTypes.ShardId,
+	blocksRange types.BlocksRange,
+) ([]*types.Block, error) {
+	blocks, err := bf.rpcClient.GetBlocksRange(
+		ctx, shardId, blocksRange.Start, blocksRange.End+1, true, blockRangeBatchSize,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"error fetching blocks from shard %d in range [%d, %d]: %w",
+			shardId, blocksRange.Start, blocksRange.End, err,
+		)
+	}
+
+	return blocks, nil
+}

--- a/nil/services/synccommittee/core/fetching/block_range_fetcher.go
+++ b/nil/services/synccommittee/core/fetching/block_range_fetcher.go
@@ -35,22 +35,41 @@ func (bf *fetcher) GetBlockRef(
 		return nil, fmt.Errorf("error fetching block from shard %d: %w", shardId, err)
 	}
 	if block == nil {
-		return nil, fmt.Errorf("block not found in shard %d: %s", shardId, hash)
+		return nil, fmt.Errorf("%w: block not found in shard %d: %s", types.ErrBlockMismatch, shardId, hash)
 	}
 	blockRef := types.BlockToRef(block)
 	return &blockRef, nil
+}
+
+func (bf *fetcher) GetEarliestBlockRef(
+	ctx context.Context,
+	shardId coreTypes.ShardId,
+) (*types.BlockRef, error) {
+	return bf.getBlockRefByStrId(ctx, shardId, "earliest")
 }
 
 func (bf *fetcher) GetLatestBlockRef(
 	ctx context.Context,
 	shardId coreTypes.ShardId,
 ) (*types.BlockRef, error) {
-	block, err := bf.rpcClient.GetBlock(ctx, shardId, "latest", false)
+	return bf.getBlockRefByStrId(ctx, shardId, "latest")
+}
+
+func (bf *fetcher) getBlockRefByStrId(
+	ctx context.Context,
+	shardId coreTypes.ShardId,
+	strId string,
+) (*types.BlockRef, error) {
+	block, err := bf.rpcClient.GetBlock(ctx, shardId, strId, false)
 	if err != nil {
-		return nil, fmt.Errorf("error fetching latest block, shardId=%d: %w", shardId, err)
+		return nil, fmt.Errorf(
+			"error fetching block, shardId=%d, id=%s: %w", shardId, strId, err,
+		)
 	}
 	if block == nil {
-		return nil, fmt.Errorf("%w: latest block not found in chain, shardId=%d", types.ErrBlockNotFound, shardId)
+		return nil, fmt.Errorf(
+			"%w: block not found in chain, shardId=%d, id=%s", types.ErrBlockNotFound, shardId, strId,
+		)
 	}
 	blockRef := types.BlockToRef(block)
 	return &blockRef, nil

--- a/nil/services/synccommittee/core/fetching/lag_tracker_test.go
+++ b/nil/services/synccommittee/core/fetching/lag_tracker_test.go
@@ -80,7 +80,7 @@ func (s *LagTrackerTestSuite) Test_GetLagForAllShards_No_Lag() {
 	testaide.ClientMockSetBatches(s.rpcClientMock, batches)
 
 	for _, batch := range batches {
-		err := s.blockStorage.SetBlockBatch(s.ctx, batch)
+		err := s.blockStorage.PutBlockBatch(s.ctx, batch)
 		s.Require().NoError(err)
 	}
 
@@ -103,7 +103,7 @@ func (s *LagTrackerTestSuite) Test_GetLagForAllShards_Lagging_Behind() {
 	pending := batches[3:]
 
 	for _, batch := range alreadyFetched {
-		err := s.blockStorage.SetBlockBatch(s.ctx, batch)
+		err := s.blockStorage.PutBlockBatch(s.ctx, batch)
 		s.Require().NoError(err)
 	}
 
@@ -120,7 +120,7 @@ func (s *LagTrackerTestSuite) Test_GetLagForAllShards_Being_Ahead() {
 	testaide.ClientMockSetBatches(s.rpcClientMock, stateOnL2)
 
 	for _, batch := range batches {
-		err := s.blockStorage.SetBlockBatch(s.ctx, batch)
+		err := s.blockStorage.PutBlockBatch(s.ctx, batch)
 		s.Require().NoError(err)
 	}
 

--- a/nil/services/synccommittee/core/proposer_test.go
+++ b/nil/services/synccommittee/core/proposer_test.go
@@ -182,7 +182,8 @@ func (s *ProposerTestSuite) TestStorageProposalDataRemoved() {
 	s.callContractMock.AddExpectedCall("getLastFinalizedBatchIndex", "testingFinalizedBatchIndex")
 	s.callContractMock.AddExpectedCall("finalizedStateRoots", s.testData.OldProvedStateRoot)
 
-	batch := testaide.NewBlockBatch(testaide.ShardsCount).WithDataProofs(scTypes.DataProofs{[]byte{}})
+	batch, err := testaide.NewBlockBatch(testaide.ShardsCount).Seal(scTypes.DataProofs{[]byte{}}, testaide.Now)
+	s.Require().NoError(err)
 	batch.Id = s.testData.BatchId
 	mainBlock := batch.Blocks[types.MainShardId].Latest()
 	mainBlock.ParentHash = s.testData.OldProvedStateRoot
@@ -214,11 +215,12 @@ func (s *ProposerTestSuite) TestProposerResetToL1State() {
 	s.callContractMock.AddExpectedCall("getLastFinalizedBatchIndex", "testingFinalizedBatchIndex")
 	s.callContractMock.AddExpectedCall("finalizedStateRoots", l1FinalizedStateRoot)
 
-	batch := testaide.NewBlockBatch(testaide.ShardsCount).WithDataProofs(scTypes.DataProofs{[]byte{}})
+	batch, err := testaide.NewBlockBatch(testaide.ShardsCount).Seal(scTypes.DataProofs{[]byte{}}, testaide.Now)
+	s.Require().NoError(err)
 	batch.Blocks[types.MainShardId].Earliest().ParentHash = s.testData.OldProvedStateRoot
 	batch.Id = s.testData.BatchId
 
-	err := s.storage.SetBlockBatch(s.ctx, batch)
+	err = s.storage.PutBlockBatch(s.ctx, batch)
 	s.Require().NoError(err)
 	s.Require().NoError(s.storage.SetBatchAsProved(s.ctx, s.testData.BatchId))
 	s.Require().NoError(s.storage.SetProvedStateRoot(s.ctx, s.testData.OldProvedStateRoot))

--- a/nil/services/synccommittee/core/proposer_test.go
+++ b/nil/services/synccommittee/core/proposer_test.go
@@ -187,7 +187,7 @@ func (s *ProposerTestSuite) TestStorageProposalDataRemoved() {
 	mainBlock := batch.Blocks[types.MainShardId].Latest()
 	mainBlock.ParentHash = s.testData.OldProvedStateRoot
 
-	s.Require().NoError(s.storage.SetBlockBatch(s.ctx, batch))
+	s.Require().NoError(s.storage.PutBlockBatch(s.ctx, batch))
 	s.Require().NoError(s.storage.SetBatchAsProved(s.ctx, s.testData.BatchId))
 	s.Require().NoError(s.storage.SetProvedStateRoot(s.ctx, s.testData.OldProvedStateRoot))
 

--- a/nil/services/synccommittee/core/reset/state_reset_launcher.go
+++ b/nil/services/synccommittee/core/reset/state_reset_launcher.go
@@ -52,22 +52,25 @@ func (l *StateResetLauncher) AddPausableComponent(pausableComponent ...PausableC
 }
 
 func (l *StateResetLauncher) LaunchPartialResetWithSuspension(
-	ctx context.Context, failedBatchId scTypes.BatchId,
+	ctx context.Context,
+	caller PausableComponent,
+	failedBatchId scTypes.BatchId,
 ) error {
 	return l.withExclusiveLock(func() error {
-		return l.unsafeLaunchPartialResetWithSuspension(ctx, failedBatchId)
+		return l.unsafeLaunchPartialResetWithSuspension(ctx, caller, failedBatchId)
 	})
 }
 
 func (l *StateResetLauncher) unsafeLaunchPartialResetWithSuspension(
 	ctx context.Context,
+	caller PausableComponent,
 	failedBatchId scTypes.BatchId,
 ) error {
 	l.logger.Info().
 		Stringer(logging.FieldBatchId, failedBatchId).
 		Msg("Launching state partial reset process")
 
-	if err := l.pauseComponents(ctx, nil); err != nil {
+	if err := l.pauseComponents(ctx, caller); err != nil {
 		return err
 	}
 

--- a/nil/services/synccommittee/core/service.go
+++ b/nil/services/synccommittee/core/service.go
@@ -7,6 +7,7 @@ import (
 	"github.com/NilFoundation/nil/nil/common/logging"
 	"github.com/NilFoundation/nil/nil/internal/db"
 	"github.com/NilFoundation/nil/nil/internal/telemetry"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/core/batches/constraints"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/core/fetching"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/core/reset"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/core/rollupcontract"
@@ -58,8 +59,15 @@ func New(ctx context.Context, cfg *Config, database db.DB) (*SyncCommittee, erro
 	syncCommittee := &SyncCommittee{}
 	resetLauncher := reset.NewResetLauncher(stateResetter, syncCommittee, logger)
 
+	batchChecker := constraints.NewChecker(
+		constraints.DefaultBatchConstraints(),
+		clock,
+		logger,
+	)
+
 	agg := fetching.NewAggregator(
 		client,
+		batchChecker,
 		blockStorage,
 		taskStorage,
 		resetLauncher,

--- a/nil/services/synccommittee/core/task_state_change_handler.go
+++ b/nil/services/synccommittee/core/task_state_change_handler.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/NilFoundation/nil/nil/common/logging"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/core/reset"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/api"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/log"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
@@ -20,7 +21,9 @@ type ProvedBatchSetter interface {
 //go:generate bash ../internal/scripts/generate_mock.sh StateResetLauncher
 
 type StateResetLauncher interface {
-	LaunchPartialResetWithSuspension(ctx context.Context, failedBatchId types.BatchId) error
+	LaunchPartialResetWithSuspension(
+		ctx context.Context, caller reset.PausableComponent, failedBatchId types.BatchId,
+	) error
 }
 
 type taskStateChangeHandler struct {
@@ -75,7 +78,7 @@ func (h *taskStateChangeHandler) resetState(ctx context.Context, task *types.Tas
 	log.NewTaskResultEvent(h.logger, zerolog.WarnLevel, result).
 		Msg("task execution failed with critical error, state will be reset")
 
-	err := h.stateResetLauncher.LaunchPartialResetWithSuspension(ctx, task.BatchId)
+	err := h.stateResetLauncher.LaunchPartialResetWithSuspension(ctx, nil, task.BatchId)
 
 	switch {
 	case err == nil:

--- a/nil/services/synccommittee/core/task_state_change_handler_test.go
+++ b/nil/services/synccommittee/core/task_state_change_handler_test.go
@@ -112,7 +112,7 @@ func (s *TaskStateChangeHandlerTestSuite) batchTaskSetUp() (*types.Task, *types.
 	err := s.blockStorage.SetProvedStateRoot(s.ctx, batch.EarliestMainBlock().ParentHash)
 	s.Require().NoError(err)
 
-	err = s.blockStorage.SetBlockBatch(s.ctx, batch)
+	err = s.blockStorage.PutBlockBatch(s.ctx, batch)
 	s.Require().NoError(err)
 
 	task := testaide.NewTaskOfType(types.ProofBatch)

--- a/nil/services/synccommittee/internal/storage/block_storage_op_block.go
+++ b/nil/services/synccommittee/internal/storage/block_storage_op_block.go
@@ -40,6 +40,15 @@ func (bs blockOp) getBlock(tx db.RoTx, id scTypes.BlockId, required bool) (*bloc
 	return bs.getBlockBytesId(tx, id.Bytes(), required)
 }
 
+func (blockOp) blockExists(tx db.RoTx, id scTypes.BlockId) (bool, error) {
+	key := id.Bytes()
+	exists, err := tx.Exists(blocksTable, key)
+	if err != nil {
+		return false, fmt.Errorf("failed to check if block with id=%s exists: %w", id, err)
+	}
+	return exists, nil
+}
+
 func (blockOp) getBlockBytesId(tx db.RoTx, idBytes []byte, required bool) (*blockEntry, error) {
 	value, err := tx.Get(blocksTable, idBytes)
 

--- a/nil/services/synccommittee/internal/testaide/blocks.go
+++ b/nil/services/synccommittee/internal/testaide/blocks.go
@@ -83,7 +83,7 @@ func NewBatchesSequence(batchesCount int) []*scTypes.BlockBatch {
 
 	var parentId *scTypes.BatchId
 	for _, segments := range NewSegmentsSequence(batchesCount) {
-		batch, err := scTypes.NewBlockBatch(parentId).WithAddedBlocks(segments)
+		batch, err := scTypes.NewBlockBatch(parentId, Now).WithAddedBlocks(segments, Now)
 		check.PanicIfErr(err)
 		batches = append(batches, batch)
 		parentId = &batch.Id
@@ -124,7 +124,7 @@ func NewSegmentsSequence(count int) []scTypes.ChainSegments {
 
 func NewBlockBatch(shardCount int) *scTypes.BlockBatch {
 	segments := NewChainSegments(shardCount)
-	batch, err := scTypes.NewBlockBatch(nil).WithAddedBlocks(segments)
+	batch, err := scTypes.NewBlockBatch(nil, Now).WithAddedBlocks(segments, Now)
 	check.PanicIfErr(err)
 	return batch
 }
@@ -187,6 +187,12 @@ func NewProposalData(currentTime time.Time) *scTypes.ProposalData {
 		RandomHash(),
 		currentTime.Add(-time.Hour),
 	)
+}
+
+func NewDataProofs() scTypes.DataProofs {
+	return scTypes.DataProofs{
+		[]byte{10, 20, 30, 40}, []byte{11, 22, 33, 44}, []byte{12, 23, 34, 45}, []byte{13, 24, 35, 46},
+	}
 }
 
 func newRpcInTransactions(count int) []*jsonrpc.RPCInTransaction {

--- a/nil/services/synccommittee/internal/types/block_batch.go
+++ b/nil/services/synccommittee/internal/types/block_batch.go
@@ -136,15 +136,25 @@ func (b *BlockBatch) ParentRefs() map[types.ShardId]*BlockRef {
 	return refs
 }
 
+// EarliestBlocks returns the earliest block for each shard in the batch
+func (b *BlockBatch) EarliestBlocks() map[types.ShardId]*Block {
+	return b.Blocks.getEdgeBlocks(false)
+}
+
+// LatestBlocks returns the latest block for each shard in the batch
+func (b *BlockBatch) LatestBlocks() map[types.ShardId]*Block {
+	return b.Blocks.getEdgeBlocks(false)
+}
+
 // EarliestRefs returns refs to the earliest blocks for each shard in the batch
 func (b *BlockBatch) EarliestRefs() BlockRefs {
-	earliestBlocks := b.Blocks.getEdgeBlocks(false)
-	return BlocksToRefs(earliestBlocks)
+	latestBlocks := b.LatestBlocks()
+	return BlocksToRefs(latestBlocks)
 }
 
 // LatestRefs returns refs to the latest blocks for each shard in the batch
 func (b *BlockBatch) LatestRefs() BlockRefs {
-	latestBlocks := b.Blocks.getEdgeBlocks(true)
+	latestBlocks := b.LatestBlocks()
 	return BlocksToRefs(latestBlocks)
 }
 

--- a/nil/services/synccommittee/internal/types/block_batch.go
+++ b/nil/services/synccommittee/internal/types/block_batch.go
@@ -54,13 +54,18 @@ type BlockBatch struct {
 	ParentId   *BatchId      `json:"parentId"`
 	Blocks     ChainSegments `json:"blocks"`
 	DataProofs DataProofs    `json:"dataProofs"`
+	IsSealed   bool          `json:"isSealed"`
+	CreatedAt  time.Time     `json:"createdAt"`
+	UpdatedAt  time.Time     `json:"updatedAt"`
 }
 
-func NewBlockBatch(parentId *BatchId) *BlockBatch {
+func NewBlockBatch(parentId *BatchId, currentTime time.Time) *BlockBatch {
 	return &BlockBatch{
-		Id:       NewBatchId(),
-		ParentId: parentId,
-		Blocks:   make(ChainSegments),
+		Id:        NewBatchId(),
+		ParentId:  parentId,
+		Blocks:    make(ChainSegments),
+		CreatedAt: currentTime,
+		UpdatedAt: currentTime,
 	}
 }
 
@@ -69,28 +74,50 @@ func ReconstructExistingBlockBatch(
 	parentId *BatchId,
 	blocks ChainSegments,
 	dataProofs DataProofs,
+	isSealed bool,
+	createdAt time.Time,
+	updatedAt time.Time,
 ) *BlockBatch {
 	return &BlockBatch{
 		Id:         id,
 		ParentId:   parentId,
 		Blocks:     blocks,
 		DataProofs: dataProofs,
+		IsSealed:   isSealed,
+		CreatedAt:  createdAt,
+		UpdatedAt:  updatedAt,
 	}
 }
 
-func (b BlockBatch) WithAddedBlocks(segments ChainSegments) (*BlockBatch, error) {
+func (b BlockBatch) WithAddedBlocks(segments ChainSegments, currentTime time.Time) (*BlockBatch, error) {
+	if b.IsSealed {
+		return nil, fmt.Errorf("cannot add blocks to sealed batch with id=%s", b.Id)
+	}
+
 	newSegments, err := b.Blocks.Concat(segments)
 	if err != nil {
 		return nil, fmt.Errorf("failed to add blocks to batch with id=%s: %w", b.Id, err)
 	}
 
 	b.Blocks = newSegments
+	b.UpdatedAt = currentTime
 	return &b, nil
 }
 
-func (b BlockBatch) WithDataProofs(dataProofs DataProofs) *BlockBatch {
+func (b BlockBatch) Seal(dataProofs DataProofs, currentTime time.Time) (*BlockBatch, error) {
+	if b.IsSealed {
+		return nil, fmt.Errorf("batch with id=%s is already sealed", b.Id)
+	}
+
 	b.DataProofs = dataProofs
-	return &b
+	b.UpdatedAt = currentTime
+	b.IsSealed = true
+
+	return &b, nil
+}
+
+func (b *BlockBatch) IsEmpty() bool {
+	return b.Blocks.BlocksCount() == 0
 }
 
 func (b *BlockBatch) BlockIds() []BlockId {
@@ -143,12 +170,12 @@ func (b *BlockBatch) EarliestBlocks() map[types.ShardId]*Block {
 
 // LatestBlocks returns the latest block for each shard in the batch
 func (b *BlockBatch) LatestBlocks() map[types.ShardId]*Block {
-	return b.Blocks.getEdgeBlocks(false)
+	return b.Blocks.getEdgeBlocks(true)
 }
 
 // EarliestRefs returns refs to the earliest blocks for each shard in the batch
 func (b *BlockBatch) EarliestRefs() BlockRefs {
-	latestBlocks := b.LatestBlocks()
+	latestBlocks := b.EarliestBlocks()
 	return BlocksToRefs(latestBlocks)
 }
 

--- a/nil/services/synccommittee/internal/types/blocks.go
+++ b/nil/services/synccommittee/internal/types/blocks.go
@@ -36,6 +36,10 @@ func BlockToRef(block *Block) BlockRef {
 	return NewBlockRef(block.ShardId, block.Hash, block.Number)
 }
 
+func (br *BlockRef) AsId() BlockId {
+	return NewBlockId(br.ShardId, br.Hash)
+}
+
 func (br *BlockRef) String() string {
 	return fmt.Sprintf("BlockRef{shardId=%s, number=%d, hash=%s}", br.ShardId, br.Number, br.Hash)
 }
@@ -143,10 +147,6 @@ func (br *BlockRef) ValidateDescendant(descendant BlockRef) error {
 
 // ValidateNext ensures that the given child block is a valid subsequent block of the current BlockRef.
 func (br *BlockRef) ValidateNext(child *Block) error {
-	if child == nil {
-		return errors.New("child block cannot be nil")
-	}
-
 	childRef := BlockToRef(child)
 	if err := br.ValidateDescendant(childRef); err != nil {
 		return err

--- a/nil/services/synccommittee/internal/types/blocks.go
+++ b/nil/services/synccommittee/internal/types/blocks.go
@@ -71,6 +71,11 @@ type BlocksRange struct {
 	End   types.BlockNumber
 }
 
+func NewBlocksRange(start types.BlockNumber, end types.BlockNumber) BlocksRange {
+	check.PanicIff(start > end, "start cannot be greater than end")
+	return BlocksRange{start, end}
+}
+
 // GetBlocksFetchingRange determines the range of blocks to fetch between the latest handled block
 // and the actual latest block.
 // latestHandled can be equal to:
@@ -112,6 +117,25 @@ func GetBlocksFetchingRange(
 	}
 
 	return &BlocksRange{blocksRange.Start, blocksRange.Start + types.BlockNumber(maxNumBlocks-1)}, nil
+}
+
+func (r *BlocksRange) SplitToChunks(chunkSize uint32) []BlocksRange {
+	check.PanicIff(chunkSize == 0, "chunkSize cannot be 0")
+
+	if r == nil {
+		return nil
+	}
+
+	var chunks []BlocksRange
+	for start := r.Start; start <= r.End; start += types.BlockNumber(chunkSize) {
+		end := start + types.BlockNumber(chunkSize) - 1
+		if end > r.End {
+			end = r.End
+		}
+		chunks = append(chunks, BlocksRange{Start: start, End: end})
+	}
+
+	return chunks
 }
 
 func (br *BlockRef) Equals(other *BlockRef) bool {

--- a/nil/services/synccommittee/internal/types/blocks_test.go
+++ b/nil/services/synccommittee/internal/types/blocks_test.go
@@ -1,0 +1,84 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type BlocksRangeTestSuite struct {
+	suite.Suite
+}
+
+func TestBlocksRange(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(BlocksRangeTestSuite))
+}
+
+func (s *BlocksRangeTestSuite) Test_SplitToChunks_Nil_Range() {
+	var blocksRange *BlocksRange
+	chunks := blocksRange.SplitToChunks(10)
+	s.Require().Empty(chunks)
+}
+
+func (s *BlocksRangeTestSuite) Test_SplitToChunks() {
+	testCases := []struct {
+		name           string
+		input          BlocksRange
+		chunkSize      uint32
+		expectedChunks []BlocksRange
+	}{
+		{
+			name:      "Chunk_Size_Is_Equal_To_Range_Size",
+			input:     NewBlocksRange(1, 10),
+			chunkSize: 10,
+			expectedChunks: []BlocksRange{
+				NewBlocksRange(1, 10),
+			},
+		},
+		{
+			name:      "Split_Into_Equal_Chunks",
+			input:     NewBlocksRange(1, 20),
+			chunkSize: 5,
+			expectedChunks: []BlocksRange{
+				NewBlocksRange(1, 5),
+				NewBlocksRange(6, 10),
+				NewBlocksRange(11, 15),
+				NewBlocksRange(16, 20),
+			},
+		},
+		{
+			name:      "Last_Chunk_Is_Smaller",
+			input:     NewBlocksRange(1, 23),
+			chunkSize: 10,
+			expectedChunks: []BlocksRange{
+				NewBlocksRange(1, 10),
+				NewBlocksRange(11, 20),
+				NewBlocksRange(21, 23),
+			},
+		},
+		{
+			name:      "Chunk_Size_Is_Larger_Than_Range",
+			input:     NewBlocksRange(1, 7),
+			chunkSize: 10,
+			expectedChunks: []BlocksRange{
+				NewBlocksRange(1, 7),
+			},
+		},
+		{
+			name:      "Single_Element_Range",
+			input:     NewBlocksRange(5, 5),
+			chunkSize: 2,
+			expectedChunks: []BlocksRange{
+				NewBlocksRange(5, 5),
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		s.Run(testCase.name, func() {
+			actualChunks := testCase.input.SplitToChunks(testCase.chunkSize)
+			s.Require().Equal(testCase.expectedChunks, actualChunks)
+		})
+	}
+}

--- a/nil/services/synccommittee/internal/types/prover_tasks.go
+++ b/nil/services/synccommittee/internal/types/prover_tasks.go
@@ -259,7 +259,7 @@ func (t *TaskEntry) HasHigherPriorityThan(other *TaskEntry) bool {
 		return true
 	}
 
-	if t.Created != other.Created {
+	if !t.Created.Equal(other.Created) {
 		return t.Created.Before(other.Created)
 	}
 	return t.Task.TaskType < other.Task.TaskType
@@ -282,7 +282,7 @@ func NewBatchProofTaskEntry(
 	batchId BatchId, blockIds []BlockId, currentTime time.Time,
 ) (*TaskEntry, error) {
 	if len(blockIds) == 0 {
-		return nil, errors.New("no blocks for create proof batch task")
+		return nil, fmt.Errorf("batch with id=%s is empty, cannot create proof task", batchId)
 	}
 
 	task := Task{


### PR DESCRIPTION
### Batch Constraints in Aggregator

Refactor `aggregator` logic for batch processing and validation.
Now, instead of creating a separate batch for each individual subgraph, a batch is constructed from an arbitrary number of blocks based on constraints.

* Integrated `BatchConstraintChecker` and `fetcher` into `Aggregator`;
* Rewrote the `aggregator.processBlockRange` method;
* Adjusted the `BlockBatch` structure to support explicit sealing;
* Modified all existing `Aggregator` tests;


### Lazy Block Fetching

Introduced a mechanism to lazily fetch block range from a specific shard

* Introduced `fetcher` type (will be used by `aggregator`);
* Implemented `BlocksRange.SplitToChunks()` method;


### Constraints Package

* Introduced `checker` type to manage batch constraints implementing `batchConstraintRunner` interface;
* Implemented `sizeConstraint` and `timeoutConstraint`;


### Batch Construction

Add support for multi-stage batch construction.

Now, a `BlockBatch` can be created, populated with blocks, persisted to storage, then later reconstructed, extended with new blocks, and saved back to storage.

* Replaced the `BlockStorage.SetBlockBatch(...)` method with `PutBlockBatch(...)`, which implements an "insert or update" mechanism;
* Adjusted how `LatestFetched` is tracked and updated to align with the new logic;
* Modified batch sequencing checks;