### PR TITLE
Sync Committee: Full Local Reset

### DIFF
--- a/nil/services/synccommittee/core/fetching/aggregator.go
+++ b/nil/services/synccommittee/core/fetching/aggregator.go
@@ -168,7 +168,7 @@ func (agg *aggregator) handleProcessingErr(ctx context.Context, err error) error
 
 	case errors.Is(err, types.ErrBlockMismatch):
 		agg.logger.Warn().Err(err).Msg("Block mismatch detected, resetting state")
-		if err := agg.resetter.ResetProgressNotProved(ctx); err != nil {
+		if err := agg.resetter.ResetProgressFull(ctx); err != nil {
 			return fmt.Errorf("error resetting state: %w", err)
 		}
 		return nil


### PR DESCRIPTION
### Sync Committee: Full Local Reset

`ErrBlockMismatch` error now triggers a full reset of the local state—discarding all batches, including those that have already been proved.

This may be necessary if an L2 rollback/reset occurs after a batch is proved, but before the corresponding state update is submitted to L1.

In such cases, the proved batch may contain mismatched block(s).
