### PR TITLE
relayer: add forgotten pk config flag

### DIFF
--- a/nil/cmd/relayer/main.go
+++ b/nil/cmd/relayer/main.go
@@ -134,6 +134,13 @@ func addRunCommandFlags(runCmd *cobra.Command, cfg *Config) error {
 	)
 
 	runCmd.Flags().StringVar(
+		&cfg.L2ContractConfig.PrivateKeyPath,
+		"l2-private-key-path",
+		cfg.L2ContractConfig.PrivateKeyPath,
+		"Path to private key file for L2 smart account",
+	)
+
+	runCmd.Flags().StringVar(
 		&cfg.L2ContractConfig.Endpoint, "l2-endpoint", "", "URL for nil L2 client",
 	)
 	runCmd.Flags().StringVar(


### PR DESCRIPTION
## Short Summary

Adding forgotten config flag for setting private key file for the relayer. It is needed for customizing deployment of the service to different environments
