### PR TITLE
[rpc] move common code into a function

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,6 +40,7 @@ linters:
     - musttag
     - nakedret
     - nilerr
+    - noctx
     - nolintlint
     - nosprintfhostport
     - paralleltest

--- a/nil/cmd/nil/common/args.go
+++ b/nil/cmd/nil/common/args.go
@@ -3,6 +3,7 @@ package common
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -147,12 +148,12 @@ func ReadAbiFromFile(abiPath string) (abi.ABI, error) {
 	return abi.JSON(bytes.NewReader(abiFile))
 }
 
-func FetchAbiFromCometa(addr types.Address) (abi.ABI, error) {
+func FetchAbiFromCometa(ctx context.Context, addr types.Address) (abi.ABI, error) {
 	client := GetCometaRpcClient()
 	if client == nil {
 		return abi.ABI{}, errors.New("cometa client is not initialized")
 	}
-	res, err := client.GetAbi(addr)
+	res, err := client.GetAbi(ctx, addr)
 	if err != nil {
 		return abi.ABI{}, fmt.Errorf("failed to fetch contract from cometa: %w", err)
 	}

--- a/nil/cmd/nil/internal/cometa/command.go
+++ b/nil/cmd/nil/internal/cometa/command.go
@@ -66,7 +66,7 @@ func GetInfoCommand() *cobra.Command {
 	return cmd
 }
 
-func runRegisterCommand(_ *cobra.Command, params *cometaParams) error {
+func runRegisterCommand(cmd *cobra.Command, params *cometaParams) error {
 	cometaClient := common.GetCometaRpcClient()
 
 	inputJsonData, err := os.ReadFile(params.inputJsonFile)
@@ -79,7 +79,7 @@ func runRegisterCommand(_ *cobra.Command, params *cometaParams) error {
 		return fmt.Errorf("failed to normalize the input JSON file: %w", err)
 	}
 
-	err = cometaClient.RegisterContract(inputJson, params.address)
+	err = cometaClient.RegisterContract(cmd.Context(), inputJson, params.address)
 	if err != nil {
 		return fmt.Errorf("failed to register the contract: %w", err)
 	}
@@ -104,10 +104,10 @@ func normalizeCompileInput(inputJson, inputJsonFile string) (string, error) {
 	return string(data), err
 }
 
-func runInfoCommand(_ *cobra.Command, params *cometaParams) error {
+func runInfoCommand(cmd *cobra.Command, params *cometaParams) error {
 	cometa := common.GetCometaRpcClient()
 
-	contract, err := cometa.GetContract(params.address)
+	contract, err := cometa.GetContract(cmd.Context(), params.address)
 	if err != nil {
 		return fmt.Errorf("failed to get the contract: %w", err)
 	}

--- a/nil/cmd/nil/internal/contract/call-readonly.go
+++ b/nil/cmd/nil/internal/contract/call-readonly.go
@@ -85,7 +85,7 @@ func runCallReadonly(cmd *cobra.Command, args []string, cfg *common.Config, para
 	if len(params.AbiPath) > 0 {
 		contractAbi, abiErr = common.ReadAbiFromFile(params.AbiPath)
 	} else {
-		contractAbi, abiErr = common.FetchAbiFromCometa(address)
+		contractAbi, abiErr = common.FetchAbiFromCometa(cmd.Context(), address)
 	}
 	if abiErr != nil {
 		return fmt.Errorf("failed to fetch ABI: %w", abiErr)

--- a/nil/cmd/nil/internal/smartaccount/call-readonly.go
+++ b/nil/cmd/nil/internal/smartaccount/call-readonly.go
@@ -87,7 +87,7 @@ func runCallReadonly(cmd *cobra.Command, args []string, cfg *common.Config, para
 	if len(params.AbiPath) > 0 {
 		contractAbi, abiErr = common.ReadAbiFromFile(params.AbiPath)
 	} else {
-		contractAbi, abiErr = common.FetchAbiFromCometa(address)
+		contractAbi, abiErr = common.FetchAbiFromCometa(cmd.Context(), address)
 	}
 	if abiErr != nil {
 		return fmt.Errorf("failed to fetch ABI: %w", abiErr)

--- a/nil/cmd/nil/internal/smartaccount/deploy.go
+++ b/nil/cmd/nil/internal/smartaccount/deploy.go
@@ -106,7 +106,7 @@ func runDeploy(cmd *cobra.Command, cmdArgs []string, cfg *common.Config, params 
 	var contractData *cometa.ContractData
 
 	if len(params.compileInput) != 0 {
-		contractData, err = cm.CompileContract(params.compileInput)
+		contractData, err = cm.CompileContract(cmd.Context(), params.compileInput)
 		if err != nil {
 			return fmt.Errorf("failed to compile the contract: %w", err)
 		}
@@ -168,7 +168,7 @@ https://ethereum.org/en/developers/tutorials/downsizing-contracts-to-fight-the-c
 	}
 
 	if len(params.compileInput) != 0 {
-		if err = cm.RegisterContractData(contractData, contractAddr); err != nil {
+		if err = cm.RegisterContractData(cmd.Context(), contractData, contractAddr); err != nil {
 			return fmt.Errorf("failed to register the contract: %w", err)
 		}
 	}

--- a/nil/services/cliservice/faucet.go
+++ b/nil/services/cliservice/faucet.go
@@ -139,7 +139,7 @@ func (s *Service) TopUpViaFaucet(faucetAddress, contractAddressTo types.Address,
 
 	var r *jsonrpc.RPCReceipt
 	for range 5 {
-		txnHash, err := s.faucetClient.TopUpViaFaucet(faucetAddress, contractAddressTo, amount)
+		txnHash, err := s.faucetClient.TopUpViaFaucet(s.ctx, faucetAddress, contractAddressTo, amount)
 		if err != nil {
 			return err
 		}

--- a/nil/services/rpc/internal/http/http_test.go
+++ b/nil/services/rpc/internal/http/http_test.go
@@ -95,7 +95,7 @@ func confirmHTTPRequestYieldsStatusCode(t *testing.T, method, contentType, body 
 	ts := httptest.NewServer(NewServer(s, plantTextContentType, []string{plantTextContentType}))
 	defer ts.Close()
 
-	request, err := http.NewRequest(method, ts.URL+"?dummy", strings.NewReader(body))
+	request, err := http.NewRequestWithContext(t.Context(), method, ts.URL+"?dummy", strings.NewReader(body))
 	require.NoError(t, err, "failed to create a valid HTTP request")
 	if len(contentType) > 0 {
 		request.Header.Set("Content-Type", contentType)
@@ -124,7 +124,7 @@ func TestHTTPRespBodyUnlimited(t *testing.T) {
 	ts := httptest.NewServer(NewServer(s, plantTextContentType, []string{plantTextContentType}))
 	defer ts.Close()
 
-	request, err := http.NewRequest(http.MethodGet, ts.URL+"?dummy", strings.NewReader(""))
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodGet, ts.URL+"?dummy", strings.NewReader(""))
 	require.NoError(t, err, "failed to create a valid HTTP request")
 	request.Header.Set("Content-Type", plantTextContentType)
 	resp, err := http.DefaultClient.Do(request)

--- a/nil/services/rpc/internal/http/testaide.go
+++ b/nil/services/rpc/internal/http/testaide.go
@@ -110,7 +110,7 @@ func rpcRequest(t *testing.T, url string, extraHeaders ...string) *http.Response
 
 	// Create the request.
 	body := bytes.NewReader([]byte(`{"jsonrpc":"2.0","id":1,"method":"rpc_modules","params":[]}`))
-	req, err := http.NewRequest(http.MethodPost, url, body)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, url, body)
 	if err != nil {
 		t.Fatal("could not create http request:", err)
 	}

--- a/nil/services/stresser/core/helper.go
+++ b/nil/services/stresser/core/helper.go
@@ -231,7 +231,7 @@ func (h *Helper) CallAndWait(
 }
 
 func (h *Helper) TopUp(addr types.Address, value types.Value) error {
-	tx, err := h.faucet.TopUpViaFaucet(types.FaucetAddress, addr, value)
+	tx, err := h.faucet.TopUpViaFaucet(h.ctx, types.FaucetAddress, addr, value)
 	if err != nil {
 		return fmt.Errorf("failed to top up via faucet: %w", err)
 	}

--- a/nil/tests/faucet/faucet_test.go
+++ b/nil/tests/faucet/faucet_test.go
@@ -90,7 +90,7 @@ func (s *SuiteFaucet) TestDeployContractViaFaucet() {
 
 	code := types.BuildDeployPayload(smartAccountCode, common.EmptyHash)
 	smartAccountAddr := types.CreateAddress(types.FaucetAddress.ShardId(), code)
-	txnHash, err := s.faucetClient.TopUpViaFaucet(types.FaucetAddress, smartAccountAddr, value)
+	txnHash, err := s.faucetClient.TopUpViaFaucet(s.Context, types.FaucetAddress, smartAccountAddr, value)
 	s.Require().NoError(err)
 	receipt := s.WaitIncludedInMain(txnHash)
 	s.Require().True(receipt.AllSuccess())
@@ -132,7 +132,8 @@ func (s *SuiteFaucet) TestTopUpViaFaucet() {
 		s.Require().NoError(err)
 		s.Require().NotEmpty(code)
 
-		mshHash, err := s.faucetClient.TopUpViaFaucet(types.FaucetAddress, address, types.NewValueFromUint64(value))
+		mshHash, err := s.faucetClient.TopUpViaFaucet(
+			s.Context, types.FaucetAddress, address, types.NewValueFromUint64(value))
 		s.Require().NoError(err)
 		receipt = s.WaitIncludedInMain(mshHash)
 		s.Require().NotNil(receipt)
@@ -186,7 +187,7 @@ func (s *SuiteFaucet) TestTopUpTokenViaFaucet() {
 		types.UsdcFaucetAddress,
 	}
 	for _, faucet := range faucetsAddr {
-		mshHash, err := s.faucetClient.TopUpViaFaucet(faucet, address, value)
+		mshHash, err := s.faucetClient.TopUpViaFaucet(s.Context, faucet, address, value)
 		s.Require().NoError(err)
 		receipt = s.WaitIncludedInMain(mshHash)
 		s.Require().NotNil(receipt)

--- a/nil/tests/faucet_service/faucet_service_test.go
+++ b/nil/tests/faucet_service/faucet_service_test.go
@@ -41,7 +41,7 @@ func (s *FaucetRpc) TearDownSuite() {
 func (s *FaucetRpc) topUpAndWait(faucetAddr, addr types.Address, amount types.Value) {
 	s.T().Helper()
 
-	hash, err := s.faucetClient.TopUpViaFaucet(faucetAddr, addr, amount)
+	hash, err := s.faucetClient.TopUpViaFaucet(s.Context, faucetAddr, addr, amount)
 	s.Require().NoError(err)
 
 	receipt := s.WaitForReceipt(hash)
@@ -53,7 +53,7 @@ func (s *FaucetRpc) TestDefaultToken() {
 		faucets := types.GetTokens()
 		s.Require().Equal(types.FaucetAddress, faucets["NIL"])
 
-		res, err := s.faucetClient.GetFaucets()
+		res, err := s.faucetClient.GetFaucets(s.Context)
 		s.Require().NoError(err)
 		s.Require().Equal(faucets, res)
 	})
@@ -76,7 +76,7 @@ func (s *FaucetRpc) TestDefaultToken() {
 	if !s.builtinFaucet {
 		s.Run("TopUpViaFaucet from another service", func() {
 			otherClient := faucet.NewClient(s.Config.HttpUrl)
-			viaFaucet, err := otherClient.TopUpViaFaucet(types.FaucetAddress,
+			viaFaucet, err := otherClient.TopUpViaFaucet(s.Context, types.FaucetAddress,
 				types.GenerateRandomAddress(types.BaseShardId), types.NewValueFromUint64(100))
 			s.Require().NoError(err)
 

--- a/nil/tests/nil_load_generator_service/nil_load_generator_test.go
+++ b/nil/tests/nil_load_generator_service/nil_load_generator_test.go
@@ -81,7 +81,7 @@ func (s *NilLoadGeneratorRpc) TestSmartAccountBalanceModification() {
 	smartAccountsBalance := make([]types.Value, len(shardIdList))
 
 	s.Require().Eventually(func() bool {
-		resSmartAccounts, err = client.GetSmartAccountsAddr()
+		resSmartAccounts, err = client.GetSmartAccountsAddr(s.Context)
 		s.Require().NoError(err)
 		for i, addr := range resSmartAccounts {
 			smartAccountsBalance[i], err = s.Client.GetBalance(s.Context, addr, "latest")
@@ -100,7 +100,7 @@ func (s *NilLoadGeneratorRpc) TestSmartAccountBalanceModification() {
 		case <-testTimeout:
 			return
 		case <-ticker.C:
-			res, err := client.GetHealthCheck()
+			res, err := client.GetHealthCheck(s.Context)
 			s.Require().NoError(err)
 			s.Require().True(res)
 		case err := <-s.runErrCh:


### PR DESCRIPTION
There was some code duplication in different rpc clients: for cometa, faucet, loadgen. This patch reduces it. Here we will use a common method that performs HTTP JSONRPC request.
