### PR TITLE
[nild] Argument --chain adds test/main-net defaults

### DIFF
--- a/nil/cmd/nild/main.go
+++ b/nil/cmd/nild/main.go
@@ -66,8 +66,13 @@ func main() {
 }
 
 func loadConfig() (*nildconfig.Config, error) {
+	c, err := nilservice.DefaultConfig(cobrax.GetChainFromArgs())
+	if err != nil {
+		return nil, err
+	}
+
 	cfg := &nildconfig.Config{
-		Config: nilservice.NewDefaultConfig(),
+		Config: c,
 		DB:     db.NewDefaultBadgerDBOptions(),
 		ReadThrough: &nildconfig.ReadThroughOptions{
 			ForkMainAtBlock: transport.LatestBlockNumber,
@@ -112,6 +117,7 @@ func parseArgs() *nildconfig.Config {
 	}
 
 	cobrax.AddConfigFlag(rootCmd.PersistentFlags())
+	cobrax.AddChainFlag(rootCmd.PersistentFlags())
 
 	var logLevel, libp2pLogLevel string
 	cobrax.AddLogLevelFlag(rootCmd.PersistentFlags(), &logLevel)

--- a/nil/internal/cobrax/config.go
+++ b/nil/internal/cobrax/config.go
@@ -14,11 +14,29 @@ func AddConfigFlag(fset *pflag.FlagSet) {
 	fset.StringP("config", "c", "", "config file")
 }
 
+// AddChainFlag adds a flag to the flag set to specify a chain name.
+// It doesn't attach the flag to any variable because normally GetChainFromArgs is used.
+func AddChainFlag(fset *pflag.FlagSet) {
+	fset.String("chain", "",
+		"use defaults for the specified chain name; possible values: \"devnet\", empty")
+}
+
 // GetConfigNameFromArgs searches for a config file name in the command line arguments.
 // Generally, it should be called before argument parsing because the latter depends on the config (default values).
 func GetConfigNameFromArgs() string {
 	for i, f := range os.Args[:len(os.Args)-1] {
 		if f == "--config" || f == "-c" {
+			return os.Args[i+1]
+		}
+	}
+	return ""
+}
+
+// GetChainFromArgs searches for a chain name in the command line arguments.
+// Generally, it should be called before argument parsing because the latter depends on the chain name (default values).
+func GetChainFromArgs() string {
+	for i, f := range os.Args[:len(os.Args)-1] {
+		if f == "--chain" {
 			return os.Args[i+1]
 		}
 	}

--- a/nil/internal/collate/syncer.go
+++ b/nil/internal/collate/syncer.go
@@ -126,6 +126,10 @@ type NodeVersion struct {
 	GenesisBlockHash common.Hash
 }
 
+func (v NodeVersion) String() string {
+	return fmt.Sprintf("[%s, %s]", v.ProtocolVersion, v.GenesisBlockHash)
+}
+
 func (s *Syncer) fetchRemoteVersion(ctx context.Context) (NodeVersion, error) {
 	var err error
 	for _, peer := range s.config.BootstrapPeers {

--- a/nil/internal/network/addr_info.go
+++ b/nil/internal/network/addr_info.go
@@ -46,6 +46,16 @@ func (a *AddrInfo) UnmarshalText(text []byte) error {
 
 type AddrInfoSlice = common.PValueSlice[*AddrInfo, AddrInfo]
 
+func AddrInfoSliceFromStrings(s []string) (AddrInfoSlice, error) {
+	res := make(AddrInfoSlice, len(s))
+	for i, str := range s {
+		if err := res[i].Set(str); err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
 func ToLibP2pAddrInfoSlice(s AddrInfoSlice) []peer.AddrInfo {
 	res := make([]peer.AddrInfo, len(s))
 	for i, a := range s {

--- a/nil/services/nilservice/defaults.go
+++ b/nil/services/nilservice/defaults.go
@@ -1,0 +1,83 @@
+package nilservice
+
+import (
+	"fmt"
+
+	"github.com/NilFoundation/nil/nil/common/check"
+	"github.com/NilFoundation/nil/nil/internal/network"
+)
+
+const (
+	ChainNameDevnet = "devnet"
+
+	ChainNameTest = "test" // todo: remove after tests
+)
+
+type ChainDefaults struct {
+	RelayAddresses     []string
+	BootstrapAddresses []string
+
+	Relays         network.AddrInfoSlice
+	BootstrapPeers network.AddrInfoSlice
+}
+
+var (
+	TestDefaults = newChainDefaults(
+		[]string{
+			"/ip4/100.100.35.125/tcp/3149/p2p/16Uiu2HAmFhv4FVhp3syxJ7uQCXm86Rbiu9Y6Cox7zBD757mBNNdK",
+		},
+		[]string{
+			"/ip4/100.100.35.125/tcp/3149/p2p/16Uiu2HAmFhv4FVhp3syxJ7uQCXm86Rbiu9Y6Cox7zBD757mBNNdK/p2p-circuit/" +
+				"p2p/16Uiu2HAmErDZcwxP6KQ6x1oPn8bY1Kkg9o39LvACcKjzJNTYpDNd",
+		},
+	)
+
+	DevnetDefaults = newChainDefaults(
+		nil,
+		nil,
+	)
+
+	// DefaultsByChainName is a map of chain names to their default configurations (hard-coded).
+	// Users may assume them to be valid.
+	DefaultsByChainName = map[string]*ChainDefaults{
+		ChainNameDevnet: DevnetDefaults,
+
+		ChainNameTest: TestDefaults,
+	}
+)
+
+func newChainDefaults(relayAddresses, bootstrapAddresses []string) *ChainDefaults {
+	relays, err := network.AddrInfoSliceFromStrings(relayAddresses)
+	check.PanicIfErr(err)
+	bootstrapPeers, err := network.AddrInfoSliceFromStrings(bootstrapAddresses)
+	check.PanicIfErr(err)
+
+	return &ChainDefaults{
+		RelayAddresses:     relayAddresses,
+		BootstrapAddresses: bootstrapAddresses,
+
+		Relays:         relays,
+		BootstrapPeers: bootstrapPeers,
+	}
+}
+
+func DefaultConfig(chainName string) (*Config, error) {
+	if chainName == "" {
+		return NewDefaultConfig(), nil
+	}
+
+	defaults, ok := DefaultsByChainName[chainName]
+	if !ok {
+		return nil, fmt.Errorf("unknown chain name: %s", chainName)
+	}
+
+	config := NewDefaultConfig()
+
+	config.BootstrapPeers = defaults.BootstrapPeers
+
+	config.Network.TcpPort = 3000
+	config.Network.DHTEnabled = true
+	config.Network.DHTBootstrapPeers = config.BootstrapPeers
+
+	return config, nil
+}

--- a/nil/services/nilservice/defaults_test.go
+++ b/nil/services/nilservice/defaults_test.go
@@ -1,0 +1,35 @@
+package nilservice
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChainDefaults(t *testing.T) {
+	t.Parallel()
+
+	for chain, defaults := range DefaultsByChainName {
+		t.Run(chain, func(t *testing.T) {
+			t.Parallel()
+
+			testChainDefaults(t, defaults)
+		})
+	}
+}
+
+func testChainDefaults(t *testing.T, defaults *ChainDefaults) {
+	t.Helper()
+
+	for _, p := range defaults.BootstrapAddresses {
+		found := false
+		for _, r := range defaults.RelayAddresses {
+			if strings.HasPrefix(p, r) {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "bootstrap peer %s is not prefixed with any relay address", p)
+	}
+}


### PR DESCRIPTION
## Short Summary

An archive node outside of the cluster will be run simply with `nild archive --chain devnet`.

*The PR is a draft until the relay is up.*

## What Changes Were Made

- Argument `--chain` in `nild` and default config depending on it.
- Defaults for the actual network: relay and bootstrap addresses. *WIP*: now on test cluster `--chain test`.
- Validation of cluster spec against the defaults in `nild gen-configs` with `--chain`. E.g., each bootstrap identity and each relay from the defaults must be present in the cluster configs.

## Related Issue

Fixes https://github.com/NilFoundation/nil/issues/786

## Future Tasks

More defaults, including zero state.
