### PR TITLE
[relay] Overwrite existing config

### DIFF
--- a/nil/cmd/relay/main.go
+++ b/nil/cmd/relay/main.go
@@ -100,12 +100,6 @@ func genConfig(cfg *config, fileName string) error {
 		fileName = defaultConfigFileName
 	}
 
-	if _, err := os.Stat(fileName); err == nil {
-		return fmt.Errorf("config file %s already exists", fileName)
-	} else if !os.IsNotExist(err) {
-		return fmt.Errorf("error checking config file %s: %w", fileName, err)
-	}
-
 	if _, err := network.LoadOrGenerateKeys(cfg.Network.KeysPath); err != nil {
 		return fmt.Errorf("failed to ensure keys file %s existence: %w", cfg.Network.KeysPath, err)
 	}


### PR DESCRIPTION
`relay gen-config` overwrites existing config. (This is the way `nild gen-configs` acts.)

Required to deploy relay in the cluster.
