### PR TITLE
[niljs] remove nil from default nix package inputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
             solc = solc;
             rollup-bridge-contracts = rollup-bridge-contracts;
           });
-          niljs = (pkgs.callPackage ./nix/niljs.nix { solc = solc; nil = nil; });
+          niljs = (pkgs.callPackage ./nix/niljs.nix { solc = solc; });
           clijs = (pkgs.callPackage ./nix/clijs.nix { nil = nil; });
           nilhardhat = (pkgs.callPackage ./nix/nilhardhat.nix { solc = solc; });
           nildocs = (pkgs.callPackage ./nix/nildocs.nix {


### PR DESCRIPTION
Passing nil as a default input causes rebuild of niljs on every cluster code change. 