### PR TITLE
[relay] Rename cmd to nil-relay

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ GOBUILD = GOPRIVATE="$(GOPRIVATE)" $(GO) build $(GO_FLAGS) -tags $(TAGS)
 GOTEST = GOPRIVATE="$(GOPRIVATE)" GODEBUG=cgocheck=0 $(GO) test -tags $(BUILD_TAGS),debug,assert,test,goexperiment.synctest $(GO_FLAGS) ./... -p 2
 
 SC_COMMANDS = sync_committee sync_committee_cli proof_provider prover nil_block_generator relayer
-COMMANDS += nild nil nil-load-generator indexer cometa faucet journald_forwarder relay stresser $(SC_COMMANDS)
+COMMANDS += nild nil nil-load-generator indexer cometa faucet journald_forwarder nil-relay stresser $(SC_COMMANDS)
 
 BINARY_NAMES := cometa=nil-cometa indexer=nil-indexer
 get_bin_name = $(if $(filter $(1)=%,$(BINARY_NAMES)),$(patsubst $(1)=%,%,$(filter $(1)=%,$(BINARY_NAMES))),$(1))

--- a/nil/cmd/nil-relay/main.go
+++ b/nil/cmd/nil-relay/main.go
@@ -25,7 +25,7 @@ const (
 
 	filePermissions = 0o644
 
-	defaultConfigFileName = "relay.yaml"
+	defaultConfigFileName = "nil-relay.yaml"
 )
 
 var logger = logging.NewLogger("relay")
@@ -54,7 +54,7 @@ func runCommand() error {
 	}
 
 	rootCmd := &cobra.Command{
-		Use:           "relay [flags]",
+		Use:           "nil-relay [flags]",
 		Short:         "relay for nild cluster network",
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -86,7 +86,7 @@ func runCommand() error {
 	genConfigCmd.Flags().StringVarP(outputFile, "output", "o", "", "Output config file name")
 	rootCmd.AddCommand(genConfigCmd)
 
-	rootCmd.AddCommand(cobrax.VersionCmd("relay"))
+	rootCmd.AddCommand(cobrax.VersionCmd("nil-relay"))
 
 	return rootCmd.Execute()
 }


### PR DESCRIPTION
`nil-relay` is more clear and safe than `relay`.