### PR TITLE
relayer: fix log-level flag

### DIFF
--- a/nil/cmd/relayer/main.go
+++ b/nil/cmd/relayer/main.go
@@ -57,7 +57,7 @@ func execute() error {
 		Short: "Run nil L1<->L2 relayer",
 	}
 
-	logLevel := rootCmd.Flags().String("log-level", "info", "app log level")
+	logLevel := rootCmd.PersistentFlags().String("log-level", "info", "app log level")
 	rootCmd.PreRun = func(cmd *cobra.Command, args []string) {
 		logging.SetupGlobalLogger(*logLevel)
 	}


### PR DESCRIPTION
## Short Summary

This PR fixes invalid setup of the log level CLI flag (it was overwritten by subcommand flags instead of preserving)