### PR TITLE
[GH-#] dev.js/run.js fix

### DIFF
--- a/clijs/src/commands/smart-account/call-readonly.ts
+++ b/clijs/src/commands/smart-account/call-readonly.ts
@@ -2,8 +2,8 @@ import type { CallRes, Hex } from "@nilfoundation/niljs";
 import { Args, Flags } from "@oclif/core";
 import type { Abi } from "abitype";
 import { BaseCommand } from "../../base.js";
-import { readJsonFile } from "../../common/utils";
-import { hexArg } from "../../types";
+import { readJsonFile } from "../../common/utils.js";
+import { hexArg } from "../../types.js";
 
 export default class SmartAccountCallReadOnly extends BaseCommand {
   static override summary = "Call view method of field of a smart account";

--- a/clijs/src/commands/smart-account/deploy.ts
+++ b/clijs/src/commands/smart-account/deploy.ts
@@ -5,8 +5,8 @@ import { addHexPrefix } from "@nilfoundation/niljs";
 import { Args, Flags } from "@oclif/core";
 import type { Abi } from "abitype";
 import { BaseCommand } from "../../base.js";
-import { readJsonFile } from "../../common/utils";
-import { bigintFlag } from "../../types";
+import { readJsonFile } from "../../common/utils.js";
+import { bigintFlag } from "../../types.js";
 
 export default class SmartAccountDeploy extends BaseCommand {
   static override summary = "Deploy a smart contract";

--- a/clijs/src/commands/smart-account/estimate-fee.ts
+++ b/clijs/src/commands/smart-account/estimate-fee.ts
@@ -2,8 +2,8 @@ import type { EstimateFeeResult, Hex } from "@nilfoundation/niljs";
 import { Args, Flags } from "@oclif/core";
 import type { Abi } from "abitype";
 import { BaseCommand } from "../../base.js";
-import { readJsonFile } from "../../common/utils";
-import { bigintFlag, hexArg } from "../../types";
+import { readJsonFile } from "../../common/utils.js";
+import { bigintFlag, hexArg } from "../../types.js";
 
 export default class SmartAccountEstimateFee extends BaseCommand {
   static override summary = "Get the recommended fees";

--- a/clijs/src/commands/smart-account/new.ts
+++ b/clijs/src/commands/smart-account/new.ts
@@ -3,7 +3,7 @@ import { Flags } from "@oclif/core";
 import { BaseCommand } from "../../base.js";
 import { ConfigKeys } from "../../common/config.js";
 import { logger } from "../../logger.js";
-import { bigintFlag } from "../../types";
+import { bigintFlag } from "../../types.js";
 
 export const DefualtNewSmartAccountAmount = 1_000_000_000_000_000n;
 

--- a/clijs/src/commands/smart-account/send-tokens.ts
+++ b/clijs/src/commands/smart-account/send-tokens.ts
@@ -1,7 +1,7 @@
 import type { Hex } from "@nilfoundation/niljs";
 import { Flags } from "@oclif/core";
 import { BaseCommand } from "../../base.js";
-import { bigintFlag, hexArg, tokenFlag } from "../../types";
+import { bigintFlag, hexArg, tokenFlag } from "../../types.js";
 
 export default class SmartAccountSendToken extends BaseCommand {
   static override summary = "Transfer tokens to a specific address";

--- a/clijs/src/commands/smart-account/send-transaction.ts
+++ b/clijs/src/commands/smart-account/send-transaction.ts
@@ -3,8 +3,8 @@ import type { Transaction } from "@nilfoundation/niljs";
 import { Args, Flags } from "@oclif/core";
 import type { Abi } from "abitype";
 import { BaseCommand } from "../../base.js";
-import { readJsonFile } from "../../common/utils";
-import { bigintFlag, hexArg, tokenFlag } from "../../types";
+import { readJsonFile } from "../../common/utils.js";
+import { bigintFlag, hexArg, tokenFlag } from "../../types.js";
 
 export default class SmartAccountSendTransaction extends BaseCommand {
   static override summary = "Send a transaction to a smart contract via the smart account";

--- a/clijs/src/commands/smart-account/top-up.ts
+++ b/clijs/src/commands/smart-account/top-up.ts
@@ -1,6 +1,6 @@
 import { Args } from "@oclif/core";
 import { BaseCommand } from "../../base.js";
-import { bigintArg } from "../../types";
+import { bigintArg } from "../../types.js";
 
 export default class SmartAccountTopup extends BaseCommand {
   static override summary = "Top-up address with token";


### PR DESCRIPTION
If I run `clijs` without bundling through `dev.js` or `run.js`, I get a ton of errors:
<details>
<summary>Log</summary>

```
$ ./bin/dev.js 
(node:3343624) [DEP0180] DeprecationWarning: fs.Stats constructor is deprecated.
(Use `node --trace-deprecation ...` to show where the warning was created)
(node:3343624) Warning: Error
module: @oclif/core@4.2.10
task: findCommand (smart-account:call-readonly)
plugin: @nilfoundation/clijs
root: /home/un1or/projects/nil/nil-public/clijs
message: Cannot find module '/home/un1or/projects/nil/nil-public/clijs/dist/src/common/utils' imported from /home/un1or/projects/nil/nil-public/clijs/dist/src/commands/smart-account/call-readonly.js
See more details with DEBUG=*
(Use `node --trace-warnings ...` to show where the warning was created)
Warning: Error
    at Plugin.warn (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/plugin.js:371:17)
    at /home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/plugin.js:273:30
    at async Promise.all (index 17)
    at async Plugin._manifest (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/plugin.js:254:24)
    at async Plugin.load (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/plugin.js:205:25)
    at async PluginLoader.loadRoot (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/plugin-loader.js:43:13)
    at async Config.load (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/config.js:312:27)
    at async Config.load (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/config.js:178:9)
    at async run (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/main.js:55:20)
    at async file:///home/un1or/projects/nil/nil-public/clijs/bin/dev.js:6:1
module: @oclif/core@4.2.10
task: findCommand (smart-account:call-readonly)
plugin: @nilfoundation/clijs
root: /home/un1or/projects/nil/nil-public/clijs
message: Cannot find module '/home/un1or/projects/nil/nil-public/clijs/dist/src/common/utils' imported from /home/un1or/projects/nil/nil-public/clijs/dist/src/commands/smart-account/call-readonly.js
See more details with DEBUG=*
(node:3343624) Warning: Error
module: @oclif/core@4.2.10
task: findCommand (smart-account:deploy)
plugin: @nilfoundation/clijs
root: /home/un1or/projects/nil/nil-public/clijs
message: Cannot find module '/home/un1or/projects/nil/nil-public/clijs/dist/src/common/utils' imported from /home/un1or/projects/nil/nil-public/clijs/dist/src/commands/smart-account/deploy.js
See more details with DEBUG=*
Warning: Error
    at Plugin.warn (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/plugin.js:371:17)
    at /home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/plugin.js:273:30
    at async Promise.all (index 18)
    at async Plugin._manifest (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/plugin.js:254:24)
    at async Plugin.load (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/plugin.js:205:25)
    at async PluginLoader.loadRoot (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/plugin-loader.js:43:13)
    at async Config.load (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/config.js:312:27)
    at async Config.load (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/config.js:178:9)
    at async run (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/main.js:55:20)
    at async file:///home/un1or/projects/nil/nil-public/clijs/bin/dev.js:6:1
module: @oclif/core@4.2.10
task: findCommand (smart-account:deploy)
plugin: @nilfoundation/clijs
root: /home/un1or/projects/nil/nil-public/clijs
message: Cannot find module '/home/un1or/projects/nil/nil-public/clijs/dist/src/common/utils' imported from /home/un1or/projects/nil/nil-public/clijs/dist/src/commands/smart-account/deploy.js
See more details with DEBUG=*
(node:3343624) Warning: Error
module: @oclif/core@4.2.10
task: findCommand (smart-account:estimate-fee)
plugin: @nilfoundation/clijs
root: /home/un1or/projects/nil/nil-public/clijs
message: Cannot find module '/home/un1or/projects/nil/nil-public/clijs/dist/src/common/utils' imported from /home/un1or/projects/nil/nil-public/clijs/dist/src/commands/smart-account/estimate-fee.js
See more details with DEBUG=*
Warning: Error
    at Plugin.warn (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/plugin.js:371:17)
    at /home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/plugin.js:273:30
    at async Promise.all (index 19)
    at async Plugin._manifest (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/plugin.js:254:24)
    at async Plugin.load (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/plugin.js:205:25)
    at async PluginLoader.loadRoot (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/plugin-loader.js:43:13)
    at async Config.load (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/config.js:312:27)
    at async Config.load (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/config.js:178:9)
    at async run (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/main.js:55:20)
    at async file:///home/un1or/projects/nil/nil-public/clijs/bin/dev.js:6:1
module: @oclif/core@4.2.10
task: findCommand (smart-account:estimate-fee)
plugin: @nilfoundation/clijs
root: /home/un1or/projects/nil/nil-public/clijs
message: Cannot find module '/home/un1or/projects/nil/nil-public/clijs/dist/src/common/utils' imported from /home/un1or/projects/nil/nil-public/clijs/dist/src/commands/smart-account/estimate-fee.js
See more details with DEBUG=*
(node:3343624) Warning: Error
module: @oclif/core@4.2.10
task: findCommand (smart-account:new)
plugin: @nilfoundation/clijs
root: /home/un1or/projects/nil/nil-public/clijs
message: Cannot find module '/home/un1or/projects/nil/nil-public/clijs/dist/src/types' imported from /home/un1or/projects/nil/nil-public/clijs/dist/src/commands/smart-account/new.js
See more details with DEBUG=*
Warning: Error
    at Plugin.warn (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/plugin.js:371:17)
    at /home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/plugin.js:273:30
    at async Promise.all (index 22)
    at async Plugin._manifest (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/plugin.js:254:24)
    at async Plugin.load (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/plugin.js:205:25)
    at async PluginLoader.loadRoot (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/plugin-loader.js:43:13)
    at async Config.load (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/config.js:312:27)
    at async Config.load (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/config.js:178:9)
    at async run (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/main.js:55:20)
    at async file:///home/un1or/projects/nil/nil-public/clijs/bin/dev.js:6:1
module: @oclif/core@4.2.10
task: findCommand (smart-account:new)
plugin: @nilfoundation/clijs
root: /home/un1or/projects/nil/nil-public/clijs
message: Cannot find module '/home/un1or/projects/nil/nil-public/clijs/dist/src/types' imported from /home/un1or/projects/nil/nil-public/clijs/dist/src/commands/smart-account/new.js
See more details with DEBUG=*
(node:3343624) Warning: Error
module: @oclif/core@4.2.10
task: findCommand (smart-account:send-tokens)
plugin: @nilfoundation/clijs
root: /home/un1or/projects/nil/nil-public/clijs
message: Cannot find module '/home/un1or/projects/nil/nil-public/clijs/dist/src/types' imported from /home/un1or/projects/nil/nil-public/clijs/dist/src/commands/smart-account/send-tokens.js
See more details with DEBUG=*
Warning: Error
    at Plugin.warn (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/plugin.js:371:17)
    at /home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/plugin.js:273:30
    at async Promise.all (index 23)
    at async Plugin._manifest (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/plugin.js:254:24)
    at async Plugin.load (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/plugin.js:205:25)
    at async PluginLoader.loadRoot (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/plugin-loader.js:43:13)
    at async Config.load (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/config.js:312:27)
    at async Config.load (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/config.js:178:9)
    at async run (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/main.js:55:20)
    at async file:///home/un1or/projects/nil/nil-public/clijs/bin/dev.js:6:1
module: @oclif/core@4.2.10
task: findCommand (smart-account:send-tokens)
plugin: @nilfoundation/clijs
root: /home/un1or/projects/nil/nil-public/clijs
message: Cannot find module '/home/un1or/projects/nil/nil-public/clijs/dist/src/types' imported from /home/un1or/projects/nil/nil-public/clijs/dist/src/commands/smart-account/send-tokens.js
See more details with DEBUG=*
(node:3343624) Warning: Error
module: @oclif/core@4.2.10
task: findCommand (smart-account:send-transaction)
plugin: @nilfoundation/clijs
root: /home/un1or/projects/nil/nil-public/clijs
message: Cannot find module '/home/un1or/projects/nil/nil-public/clijs/dist/src/common/utils' imported from /home/un1or/projects/nil/nil-public/clijs/dist/src/commands/smart-account/send-transaction.js
See more details with DEBUG=*
Warning: Error
    at Plugin.warn (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/plugin.js:371:17)
    at /home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/plugin.js:273:30
    at async Promise.all (index 24)
    at async Plugin._manifest (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/plugin.js:254:24)
    at async Plugin.load (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/plugin.js:205:25)
    at async PluginLoader.loadRoot (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/plugin-loader.js:43:13)
    at async Config.load (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/config.js:312:27)
    at async Config.load (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/config.js:178:9)
    at async run (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/main.js:55:20)
    at async file:///home/un1or/projects/nil/nil-public/clijs/bin/dev.js:6:1
module: @oclif/core@4.2.10
task: findCommand (smart-account:send-transaction)
plugin: @nilfoundation/clijs
root: /home/un1or/projects/nil/nil-public/clijs
message: Cannot find module '/home/un1or/projects/nil/nil-public/clijs/dist/src/common/utils' imported from /home/un1or/projects/nil/nil-public/clijs/dist/src/commands/smart-account/send-transaction.js
See more details with DEBUG=*
(node:3343624) Warning: Error
module: @oclif/core@4.2.10
task: findCommand (smart-account:top-up)
plugin: @nilfoundation/clijs
root: /home/un1or/projects/nil/nil-public/clijs
message: Cannot find module '/home/un1or/projects/nil/nil-public/clijs/dist/src/types' imported from /home/un1or/projects/nil/nil-public/clijs/dist/src/commands/smart-account/top-up.js
See more details with DEBUG=*
Warning: Error
    at Plugin.warn (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/plugin.js:371:17)
    at /home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/plugin.js:273:30
    at async Promise.all (index 26)
    at async Plugin._manifest (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/plugin.js:254:24)
    at async Plugin.load (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/plugin.js:205:25)
    at async PluginLoader.loadRoot (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/plugin-loader.js:43:13)
    at async Config.load (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/config.js:312:27)
    at async Config.load (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/config/config.js:178:9)
    at async run (/home/un1or/projects/nil/nil-public/node_modules/.pnpm/@oclif+core@4.2.10/node_modules/@oclif/core/lib/main.js:55:20)
    at async file:///home/un1or/projects/nil/nil-public/clijs/bin/dev.js:6:1
module: @oclif/core@4.2.10
task: findCommand (smart-account:top-up)
plugin: @nilfoundation/clijs
root: /home/un1or/projects/nil/nil-public/clijs
message: Cannot find module '/home/un1or/projects/nil/nil-public/clijs/dist/src/types' imported from /home/un1or/projects/nil/nil-public/clijs/dist/src/commands/smart-account/top-up.js
See more details with DEBUG=*
The CLI tool for interacting with the =nil; cluster

VERSION
  @nilfoundation/clijs/0.2.1 linux-x64 node-v22.14.0

USAGE
  $ clijs [COMMAND]

TOPICS
  abi            Encode or decode a contract call using the provided ABI
  config         Manage the =nil; CLI config
  keygen         Generate a new key or generate a key from the provided hex private key
  smart-account  Interact with the smart account set in the config file
  system         Get system information

COMMANDS
  abi            Encode or decode a contract call using the provided ABI
  block          Retrieve a block from the cluster
  config         Manage the =nil; CLI config
  keygen         Generate a new key or generate a key from the provided hex private key
  smart-account  Interact with the smart account set in the config file
  system         Get system information
```
</details>
Apparently they don't show up in the bundled version, but they break the convenient development environment.

These edits eliminate them. 