### PR TITLE
Update publish_npm.yml

### DIFF
--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -19,6 +19,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
+          version: "10"
           run_install: |
             - recursive: true
               args: [--frozen-lockfile, --strict-peer-dependencies]


### PR DESCRIPTION
## Short Summary

This diff fixes the error with publishing NPM packages via GitHub Actions. Currently, the action fails as no PNPM version is specified.

## What Changes Were Made

- Added PNPM version fo the GitHub Actions configuration for NPM package publishing.

## Checklist

_Please mark each item with an `x` inside the brackets (e.g., [x]) once completed._

- [x] I have read and followed the [Contributing Guide](https://github.com/NilFoundation/nil/blob/main/CONTRIBUTION-GUIDE.md)
- [x] I have tested the changes locally
- [x] I have added relevant tests (if applicable)
- [x] I have updated documentation/comments (if applicable)
