### PR TITLE
Sync Committee: Heartbeat + Worker Metrics

### DIFF
--- a/nil/common/logging/fields.go
+++ b/nil/common/logging/fields.go
@@ -40,6 +40,7 @@ const (
 	FieldTaskParentId   = "taskParentId"
 	FieldTaskType       = "taskType"
 	FieldTaskExecutorId = "taskExecutorId"
+	FieldWorkerName     = "workerName"
 
 	FieldTokenId = "TokenId"
 

--- a/nil/services/synccommittee/core/proposer.go
+++ b/nil/services/synccommittee/core/proposer.go
@@ -30,10 +30,11 @@ type ProposerMetrics interface {
 }
 
 type proposer struct {
+	concurrent.Suspendable
+
 	storage               ProposerStorage
 	resetter              *reset.StateResetLauncher
 	rollupContractWrapper rollupcontract.Wrapper
-	workerAction          *concurrent.Suspendable
 	metrics               ProposerMetrics
 	logger                logging.Logger
 }
@@ -66,7 +67,8 @@ func NewProposer(
 		metrics:               metrics,
 	}
 
-	p.workerAction = concurrent.NewSuspendable(p.runIteration, config.ProposingInterval)
+	iteration := srv.NewWorkerIteration(logger, metrics, p.Name(), p.updateStateIfReady)
+	p.Suspendable = concurrent.NewSuspendable(iteration.Run, config.ProposingInterval)
 	p.logger = srv.WorkerLogger(logger, p)
 
 	return p, nil
@@ -74,57 +76,6 @@ func NewProposer(
 
 func (*proposer) Name() string {
 	return "proposer"
-}
-
-func (p *proposer) Run(ctx context.Context, started chan<- struct{}) error {
-	p.logger.Info().Msg("starting proposer")
-
-	err := p.workerAction.Run(ctx, started)
-
-	if err == nil || errors.Is(err, context.Canceled) {
-		p.logger.Info().Msg("proposer stopped")
-	} else {
-		p.logger.Error().Err(err).Msg("error running proposer, stopped")
-	}
-
-	return err
-}
-
-func (p *proposer) Pause(ctx context.Context) error {
-	paused, err := p.workerAction.Pause(ctx)
-	if err != nil {
-		return err
-	}
-	if paused {
-		p.logger.Info().Msg("Proposer paused")
-	} else {
-		p.logger.Warn().Msg("Trying to pause proposer, but it's already paused")
-	}
-	return nil
-}
-
-func (p *proposer) Resume(ctx context.Context) error {
-	resumed, err := p.workerAction.Resume(ctx)
-	if err != nil {
-		return err
-	}
-	if resumed {
-		p.logger.Info().Msg("Proposer resumed")
-	} else {
-		p.logger.Warn().Msg("Trying to resume proposer, but it's already resumed")
-	}
-	return nil
-}
-
-func (p *proposer) runIteration(ctx context.Context) {
-	err := p.updateStateIfReady(ctx)
-
-	if err == nil || errors.Is(err, context.Canceled) {
-		return
-	}
-
-	p.logger.Error().Err(err).Msg("Error during proved batches proposing (updateStateIfReady)")
-	p.metrics.RecordError(ctx, p.Name())
 }
 
 // updateStateIfReady checks if there is new proved state root is ready to be submitted to L1 and

--- a/nil/services/synccommittee/core/service.go
+++ b/nil/services/synccommittee/core/service.go
@@ -117,7 +117,8 @@ func New(ctx context.Context, cfg *Config, database db.DB) (*SyncCommittee, erro
 		logger,
 	)
 
-	syncCommittee.Service = srv.NewService(
+	syncCommittee.Service = srv.NewServiceWithHeartbeat(
+		metricsHandler,
 		logger,
 		syncRunner, proposer, agg, lagTracker, taskScheduler, taskListener,
 	)

--- a/nil/services/synccommittee/internal/executor/task_executor_test.go
+++ b/nil/services/synccommittee/internal/executor/task_executor_test.go
@@ -17,7 +17,7 @@ type TestSuite struct {
 	suite.Suite
 	context        context.Context
 	cancellation   context.CancelFunc
-	taskExecutor   TaskExecutor
+	taskExecutor   *taskExecutor
 	requestHandler *api.TaskRequestHandlerMock
 	taskHandler    *api.TaskHandlerMock
 }

--- a/nil/services/synccommittee/internal/metrics/basic_metrics.go
+++ b/nil/services/synccommittee/internal/metrics/basic_metrics.go
@@ -9,14 +9,11 @@ import (
 	"go.opentelemetry.io/otel/metric"
 )
 
-type BasicMetrics interface {
-	RecordError(ctx context.Context, origin string)
-}
-
 type basicMetricsHandler struct {
 	attributes metric.MeasurementOption
 
 	totalErrorsEncountered telemetry.Counter
+	heartbeat              telemetry.Counter
 }
 
 func (h *basicMetricsHandler) init(attributes metric.MeasurementOption, meter telemetry.Meter) error {
@@ -24,6 +21,10 @@ func (h *basicMetricsHandler) init(attributes metric.MeasurementOption, meter te
 	var err error
 
 	if h.totalErrorsEncountered, err = meter.Int64Counter(namespace + "total_errors_encountered"); err != nil {
+		return err
+	}
+
+	if h.heartbeat, err = meter.Int64Counter(namespace + "heartbeat"); err != nil {
 		return err
 	}
 
@@ -36,4 +37,8 @@ func (h *basicMetricsHandler) RecordError(ctx context.Context, origin string) {
 	)
 
 	h.totalErrorsEncountered.Add(ctx, 1, h.attributes, errorAttributes)
+}
+
+func (h *basicMetricsHandler) Heartbeat(ctx context.Context) {
+	h.heartbeat.Add(ctx, 1, h.attributes)
 }

--- a/nil/services/synccommittee/internal/scheduler/task_cancel_checker_test.go
+++ b/nil/services/synccommittee/internal/scheduler/task_cancel_checker_test.go
@@ -140,17 +140,11 @@ func (s *TaskCancelCheckerSuite) Test_Check_Dead_Task() {
 
 func (s *TaskCancelCheckerSuite) newTestTaskCancelChecker(handler api.TaskRequestHandler) *TaskCancelChecker {
 	s.T().Helper()
-	checker := &TaskCancelChecker{
-		requestHandler: handler,
-		taskSource:     s.taskStorage,
-		config:         MakeDefaultCheckerConfig(),
-	}
-
-	checker.WorkerLoop = srv.NewWorkerLoop(
-		"task_cancel_checker_test",
-		checker.config.UpdateInterval,
-		checker.runIteration,
+	return NewTaskCancelChecker(
+		handler,
+		s.taskStorage,
+		testaide.RandomExecutorId(),
+		srv.NewNoopWorkerMetrics(),
+		s.logger,
 	)
-	checker.logger = srv.WorkerLogger(s.logger, checker)
-	return checker
 }

--- a/nil/services/synccommittee/internal/scheduler/task_result_sender_test.go
+++ b/nil/services/synccommittee/internal/scheduler/task_result_sender_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/NilFoundation/nil/nil/common/logging"
 	"github.com/NilFoundation/nil/nil/internal/db"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/api"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/srv"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/storage"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/testaide"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
@@ -109,5 +110,5 @@ func (s *TaskResultSenderSuite) Test_Send_And_Delete_Result() {
 
 func (s *TaskResultSenderSuite) newTestTaskResultSender(handler api.TaskRequestHandler) *TaskResultSender {
 	s.T().Helper()
-	return NewTaskResultSender(handler, s.resultStorage, s.logger)
+	return NewTaskResultSender(handler, s.resultStorage, srv.NewNoopWorkerMetrics(), s.logger)
 }

--- a/nil/services/synccommittee/internal/srv/heartbeat_sender.go
+++ b/nil/services/synccommittee/internal/srv/heartbeat_sender.go
@@ -1,0 +1,40 @@
+package srv
+
+import (
+	"context"
+	"time"
+
+	"github.com/NilFoundation/nil/nil/common/logging"
+)
+
+type HeartbeatSenderMetrics interface {
+	WorkerMetrics
+	Heartbeat(ctx context.Context)
+}
+
+type HeartbeatSenderConfig struct {
+	Interval time.Duration
+}
+
+func DefaultHeartbeatSenderConfig() HeartbeatSenderConfig {
+	return HeartbeatSenderConfig{
+		Interval: 5 * time.Second,
+	}
+}
+
+func NewHeartbeatSender(
+	metrics HeartbeatSenderMetrics,
+	config HeartbeatSenderConfig,
+	logger logging.Logger,
+) Worker {
+	loopConfig := NewWorkerLoopConfig(
+		"heartbeat_sender",
+		config.Interval,
+		func(ctx context.Context) error {
+			metrics.Heartbeat(ctx)
+			return nil
+		})
+
+	workerLoop := NewWorkerLoop(loopConfig, metrics, logger)
+	return &workerLoop
+}

--- a/nil/services/synccommittee/internal/srv/log.go
+++ b/nil/services/synccommittee/internal/srv/log.go
@@ -3,5 +3,5 @@ package srv
 import "github.com/NilFoundation/nil/nil/common/logging"
 
 func WorkerLogger(logger logging.Logger, worker Worker) logging.Logger {
-	return logger.With().Str("worker", worker.Name()).Logger()
+	return logger.With().Str(logging.FieldWorkerName, worker.Name()).Logger()
 }

--- a/nil/services/synccommittee/internal/srv/noop_worker_metrics.go
+++ b/nil/services/synccommittee/internal/srv/noop_worker_metrics.go
@@ -1,0 +1,15 @@
+//go:build test
+
+package srv
+
+import "context"
+
+type noopMetrics struct{}
+
+func NewNoopWorkerMetrics() WorkerMetrics {
+	return &noopMetrics{}
+}
+
+func (m *noopMetrics) Heartbeat(_ context.Context) {}
+
+func (m *noopMetrics) RecordError(_ context.Context, _ string) {}

--- a/nil/services/synccommittee/internal/srv/service.go
+++ b/nil/services/synccommittee/internal/srv/service.go
@@ -35,6 +35,17 @@ func NewService(logger logging.Logger, workers ...Worker) Service {
 	}
 }
 
+func NewServiceWithHeartbeat(
+	metrics HeartbeatSenderMetrics,
+	logger logging.Logger,
+	workers ...Worker,
+) Service {
+	return NewService(
+		logger,
+		append(workers, NewHeartbeatSender(metrics, DefaultHeartbeatSenderConfig(), logger))...,
+	)
+}
+
 type workerControl struct {
 	cancel  context.CancelFunc
 	started chan struct{}

--- a/nil/services/synccommittee/internal/srv/service_test.go
+++ b/nil/services/synccommittee/internal/srv/service_test.go
@@ -145,7 +145,7 @@ func (s *ServiceTestSuite) Test_Cancel_Worker_With_Long_Startup() {
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
-			// Emulating long-running startup
+			// Emulating a long-running startup
 			case <-time.After(time.Minute):
 			}
 
@@ -382,6 +382,8 @@ func (s *ServiceTestSuite) Test_Stop_Service() {
 }
 
 func (s *ServiceTestSuite) runInBackground(ctx context.Context, workers ...Worker) <-chan error {
+	s.T().Helper()
+
 	service := NewService(s.logger, workers...)
 	errorCh := make(chan error, 1)
 	go func() {

--- a/nil/services/synccommittee/internal/srv/worker.go
+++ b/nil/services/synccommittee/internal/srv/worker.go
@@ -1,9 +1,6 @@
 package srv
 
-import (
-	"context"
-	"time"
-)
+import "context"
 
 //go:generate bash ../scripts/generate_mock.sh Worker
 
@@ -13,38 +10,4 @@ type Worker interface {
 
 	// Run starts the worker, signaling its initialization through the started channel.
 	Run(ctx context.Context, started chan<- struct{}) error
-}
-
-type WorkerLoop struct {
-	name     string
-	interval time.Duration
-	action   func(ctx context.Context)
-}
-
-func NewWorkerLoop(name string, interval time.Duration, action func(ctx context.Context)) WorkerLoop {
-	return WorkerLoop{
-		name:     name,
-		interval: interval,
-		action:   action,
-	}
-}
-
-func (w *WorkerLoop) Name() string {
-	return w.name
-}
-
-func (w *WorkerLoop) Run(ctx context.Context, started chan<- struct{}) error {
-	ticker := time.NewTicker(w.interval)
-	defer ticker.Stop()
-
-	close(started)
-
-	for {
-		select {
-		case <-ticker.C:
-			w.action(ctx)
-		case <-ctx.Done():
-			return ctx.Err()
-		}
-	}
 }

--- a/nil/services/synccommittee/internal/srv/worker_iteration.go
+++ b/nil/services/synccommittee/internal/srv/worker_iteration.go
@@ -1,0 +1,43 @@
+package srv
+
+import (
+	"context"
+	"errors"
+
+	"github.com/NilFoundation/nil/nil/common/logging"
+)
+
+type workerIteration struct {
+	logger  logging.Logger
+	metrics WorkerMetrics
+	name    string
+	action  func(context.Context) error
+}
+
+func NewWorkerIteration(
+	logger logging.Logger,
+	metrics WorkerMetrics,
+	name string,
+	action WorkerLoopAction,
+) workerIteration {
+	return workerIteration{
+		logger:  logger,
+		metrics: metrics,
+		name:    name,
+		action:  action,
+	}
+}
+
+func (i *workerIteration) Run(ctx context.Context) error {
+	err := i.action(ctx)
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, context.Canceled):
+		return err
+	default:
+		i.logger.Error().Err(err).Str(logging.FieldWorkerName, i.name).Msgf("Worker %s produced an error", i.name)
+		i.metrics.RecordError(ctx, i.name)
+		return nil
+	}
+}

--- a/nil/services/synccommittee/internal/srv/worker_loop.go
+++ b/nil/services/synccommittee/internal/srv/worker_loop.go
@@ -1,0 +1,90 @@
+package srv
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/NilFoundation/nil/nil/common/logging"
+)
+
+type WorkerLoopAction = func(ctx context.Context) error
+
+type WorkerLoopConfig struct {
+	Name     string
+	Interval time.Duration
+	Action   WorkerLoopAction
+}
+
+func NewWorkerLoopConfig(name string, interval time.Duration, action WorkerLoopAction) WorkerLoopConfig {
+	return WorkerLoopConfig{
+		Name:     name,
+		Interval: interval,
+		Action:   action,
+	}
+}
+
+type WorkerMetrics interface {
+	RecordError(ctx context.Context, workerName string)
+}
+
+type WorkerLoop struct {
+	config  WorkerLoopConfig
+	metrics WorkerMetrics
+	Logger  logging.Logger
+}
+
+func NewWorkerLoop(
+	config WorkerLoopConfig,
+	metrics WorkerMetrics,
+	logger logging.Logger,
+) WorkerLoop {
+	loop := WorkerLoop{
+		config:  config,
+		metrics: metrics,
+	}
+
+	loop.Logger = WorkerLogger(logger, &loop)
+	return loop
+}
+
+func (w *WorkerLoop) Name() string {
+	return w.config.Name
+}
+
+func (w *WorkerLoop) Run(ctx context.Context, started chan<- struct{}) error {
+	close(started)
+
+	if err := w.runIteration(ctx); err != nil {
+		return err
+	}
+
+	ticker := time.NewTicker(w.config.Interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			if err := w.runIteration(ctx); err != nil {
+				return err
+			}
+
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+func (w *WorkerLoop) runIteration(ctx context.Context) error {
+	err := w.config.Action(ctx)
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, context.Canceled):
+		return err
+	default:
+		w.Logger.Error().Err(err).Msgf("Worker %s produced an error", w.config.Name)
+		w.metrics.RecordError(ctx, w.config.Name)
+		return nil
+	}
+}

--- a/nil/services/synccommittee/proofprovider/service.go
+++ b/nil/services/synccommittee/proofprovider/service.go
@@ -56,7 +56,7 @@ func New(config *Config, database db.DB) (*ProofProvider, error) {
 
 	taskRpcClient := rpc.NewTaskRequestRpcClient(config.SyncCommitteeRpcEndpoint, logger)
 	taskResultStorage := storage.NewTaskResultStorage(database, logger)
-	taskResultSender := scheduler.NewTaskResultSender(taskRpcClient, taskResultStorage, logger)
+	taskResultSender := scheduler.NewTaskResultSender(taskRpcClient, taskResultStorage, metricsHandler, logger)
 
 	taskStorage := storage.NewTaskStorage(database, clock, metricsHandler, logger)
 
@@ -86,11 +86,13 @@ func New(config *Config, database db.DB) (*ProofProvider, error) {
 		taskRpcClient,
 		taskStorage,
 		taskExecutor.Id(),
+		metricsHandler,
 		logger,
 	)
 
 	return &ProofProvider{
-		Service: srv.NewService(
+		Service: srv.NewServiceWithHeartbeat(
+			metricsHandler,
 			logger,
 			taskExecutor, taskScheduler, taskListener, taskCancelChecker, taskResultSender,
 		),

--- a/nil/services/synccommittee/prover/service.go
+++ b/nil/services/synccommittee/prover/service.go
@@ -51,7 +51,7 @@ func New(config Config, database db.DB) (*Prover, error) {
 
 	taskRpcClient := rpc.NewTaskRequestRpcClient(config.ProofProviderRpcEndpoint, logger)
 	taskResultStorage := storage.NewTaskResultStorage(database, logger)
-	taskResultSender := scheduler.NewTaskResultSender(taskRpcClient, taskResultStorage, logger)
+	taskResultSender := scheduler.NewTaskResultSender(taskRpcClient, taskResultStorage, metricsHandler, logger)
 
 	handler := newTaskHandler(
 		taskResultStorage,
@@ -72,7 +72,8 @@ func New(config Config, database db.DB) (*Prover, error) {
 	}
 
 	return &Prover{
-		Service: srv.NewService(
+		Service: srv.NewServiceWithHeartbeat(
+			metricsHandler,
 			logger,
 			taskExecutor, taskResultSender,
 		),


### PR DESCRIPTION
### Sync Committee: Heartbeat + Worker Metrics

Refactor `Worker`'s initialization and logging, introduce `HeartbeatSender`

* Implemented a new `HeartbeatSender` worker updating the new heartbeat counter metric with a static interval;
* Integrated logger and basic metrics into `srv.WorkerLoop` to mandatorily log unhandled errors and publish error-related metrics;

Other changes:

* Increased the default task polling interval from `1 sec` to `10 sec` to reduce the number of requests between nodes;
* Removed unused interfaces, renamed a couple of types;