### PR TITLE
[GH-846] Added `--bootstrap-url` parameter for simple initialization of archive node

### DIFF
--- a/nil/client/client.go
+++ b/nil/client/client.go
@@ -14,6 +14,7 @@ import (
 	"github.com/NilFoundation/nil/nil/internal/contracts"
 	"github.com/NilFoundation/nil/nil/internal/types"
 	"github.com/NilFoundation/nil/nil/services/rpc/jsonrpc"
+	rpctypes "github.com/NilFoundation/nil/nil/services/rpc/types"
 	"github.com/NilFoundation/nil/nil/services/txnpool"
 )
 
@@ -132,6 +133,8 @@ type Client interface {
 
 	// GetDebugContract retrieves smart contract with its data, such as code, storage and proof
 	GetDebugContract(ctx context.Context, contractAddr types.Address, blockId any) (*jsonrpc.DebugRPCContract, error)
+
+	GetBootstrapConfig(ctx context.Context) (*rpctypes.BootstrapConfig, error)
 }
 
 func EstimateFeeExternal(

--- a/nil/client/direct_client.go
+++ b/nil/client/direct_client.go
@@ -15,6 +15,7 @@ import (
 	"github.com/NilFoundation/nil/nil/services/rpc/jsonrpc"
 	"github.com/NilFoundation/nil/nil/services/rpc/rawapi"
 	"github.com/NilFoundation/nil/nil/services/rpc/transport"
+	rpctypes "github.com/NilFoundation/nil/nil/services/rpc/types"
 )
 
 // DirectClient is a client that interacts with the end api directly, without using the rpc server.
@@ -437,4 +438,8 @@ func (c *DirectClient) GetTxpoolStatus(ctx context.Context, shardId types.ShardI
 
 func (c *DirectClient) GetTxpoolContent(ctx context.Context, shardId types.ShardId) (jsonrpc.TxPoolContent, error) {
 	return c.txPoolApi.GetTxpoolContent(ctx, shardId)
+}
+
+func (c *DirectClient) GetBootstrapConfig(ctx context.Context) (*rpctypes.BootstrapConfig, error) {
+	return c.debugApi.GetBootstrapConfig(ctx)
 }

--- a/nil/client/rpc/client.go
+++ b/nil/client/rpc/client.go
@@ -25,6 +25,7 @@ import (
 	"github.com/NilFoundation/nil/nil/internal/types"
 	"github.com/NilFoundation/nil/nil/services/rpc/jsonrpc"
 	"github.com/NilFoundation/nil/nil/services/rpc/transport"
+	rpctypes "github.com/NilFoundation/nil/nil/services/rpc/types"
 )
 
 // CallError represents an error that occurs during a remote procedure call,
@@ -79,6 +80,7 @@ const (
 	Debug_getBlockByHash                 = "debug_getBlockByHash"
 	Debug_getBlockByNumber               = "debug_getBlockByNumber"
 	Debug_getContract                    = "debug_getContract"
+	Debug_getBootstrapConfig             = "debug_getBootstrapConfig"
 	Web3_clientVersion                   = "web3_clientVersion"
 	Dev_doPanicOnShard                   = "dev_doPanicOnShard"
 	Txpool_getTxpoolStatus               = "txpool_getTxpoolStatus"
@@ -951,6 +953,18 @@ func (c *Client) DoPanicOnShard(ctx context.Context, shardId types.ShardId) (uin
 	return 0, err
 }
 
+func (c *Client) GetTxpoolStatus(ctx context.Context, shardId types.ShardId) (jsonrpc.TxPoolStatus, error) {
+	return simpleCall[jsonrpc.TxPoolStatus](ctx, c, Txpool_getTxpoolStatus, shardId)
+}
+
+func (c *Client) GetTxpoolContent(ctx context.Context, shardId types.ShardId) (jsonrpc.TxPoolContent, error) {
+	return simpleCall[jsonrpc.TxPoolContent](ctx, c, Txpool_getTxpoolContent, shardId)
+}
+
+func (c *Client) GetBootstrapConfig(ctx context.Context) (*rpctypes.BootstrapConfig, error) {
+	return simpleCall[*rpctypes.BootstrapConfig](ctx, c, Debug_getBootstrapConfig)
+}
+
 func simpleCall[ReturnType any](ctx context.Context, c *Client, method string, params ...any) (ReturnType, error) {
 	res, err := c.call(ctx, method, params...)
 	var result ReturnType
@@ -976,12 +990,4 @@ func simpleCallUint64[ReturnType ~uint64](
 		return 0, err
 	}
 	return ReturnType(result), err
-}
-
-func (c *Client) GetTxpoolStatus(ctx context.Context, shardId types.ShardId) (jsonrpc.TxPoolStatus, error) {
-	return simpleCall[jsonrpc.TxPoolStatus](ctx, c, Txpool_getTxpoolStatus, shardId)
-}
-
-func (c *Client) GetTxpoolContent(ctx context.Context, shardId types.ShardId) (jsonrpc.TxPoolContent, error) {
-	return simpleCall[jsonrpc.TxPoolContent](ctx, c, Txpool_getTxpoolContent, shardId)
 }

--- a/nil/cmd/nild/devnet.go
+++ b/nil/cmd/nild/devnet.go
@@ -32,31 +32,33 @@ type nodeSpec struct {
 }
 
 type clusterSpec struct {
-	NilServerName          string   `yaml:"nil_server_name"`
-	NilCertEmail           string   `yaml:"nil_cert_email"`
-	NildConfigDir          string   `yaml:"nild_config_dir"`
-	NildCredentialsDir     string   `yaml:"nild_credentials_dir"`
-	NildPromBasePort       int      `yaml:"nild_prom_base_port"`
-	NildP2PBaseTCPPort     int      `yaml:"nild_p2p_base_tcp_port"`
-	PprofBaseTCPPort       int      `yaml:"pprof_base_tcp_port"`
-	NilWipeOnUpdate        bool     `yaml:"nil_wipe_on_update"`
-	NShards                uint32   `yaml:"nShards"`
-	NilRPCHost             string   `yaml:"nil_rpc_host"`
-	NilRPCPort             int      `yaml:"nil_rpc_port"`
-	EnableRPCOnValidators  bool     `yaml:"nil_rpc_enable_on_validators"`
-	ClickhouseHost         string   `yaml:"clickhouse_host"`
-	ClickhousePort         int      `yaml:"clickhouse_port"`
-	ClickhouseLogin        string   `yaml:"clickhouse_login"`
-	ClickhouseDatabase     string   `yaml:"clickhouse_database"`
-	CometaRPCHost          string   `yaml:"cometa_rpc_host"`
-	CometaPort             int      `yaml:"cometa_port"`
-	FaucetRPCHost          string   `yaml:"faucet_rpc_host"`
-	FaucetPort             int      `yaml:"faucet_port"`
-	NilLoadgenHost         string   `yaml:"nil_loadgen_host"`
-	NilLoadgenPort         int      `yaml:"nil_loadgen_port"`
-	NilUpdateRetryInterval int      `yaml:"nil_update_retry_interval_sec"`
-	InstanceEnv            string   `yaml:"instance_env"`
-	SignozJournaldLogs     []string `yaml:"signoz_journald_logs"`
+	NilServerName          string                `yaml:"nil_server_name"`
+	NilCertEmail           string                `yaml:"nil_cert_email"`
+	NildConfigDir          string                `yaml:"nild_config_dir"`
+	NildCredentialsDir     string                `yaml:"nild_credentials_dir"`
+	NildPromBasePort       int                   `yaml:"nild_prom_base_port"`
+	NildP2PBaseTCPPort     int                   `yaml:"nild_p2p_base_tcp_port"`
+	PprofBaseTCPPort       int                   `yaml:"pprof_base_tcp_port"`
+	NilWipeOnUpdate        bool                  `yaml:"nil_wipe_on_update"`
+	NShards                uint32                `yaml:"nShards"`
+	NilRPCHost             string                `yaml:"nil_rpc_host"`
+	NilRPCPort             int                   `yaml:"nil_rpc_port"`
+	EnableRPCOnValidators  bool                  `yaml:"nil_rpc_enable_on_validators"`
+	Relays                 network.AddrInfoSlice `yaml:"nil_relays"`
+	RelayPublicAddress     network.AddrInfo      `yaml:"nil_relay_public_address"`
+	ClickhouseHost         string                `yaml:"clickhouse_host"`
+	ClickhousePort         int                   `yaml:"clickhouse_port"`
+	ClickhouseLogin        string                `yaml:"clickhouse_login"`
+	ClickhouseDatabase     string                `yaml:"clickhouse_database"`
+	CometaRPCHost          string                `yaml:"cometa_rpc_host"`
+	CometaPort             int                   `yaml:"cometa_port"`
+	FaucetRPCHost          string                `yaml:"faucet_rpc_host"`
+	FaucetPort             int                   `yaml:"faucet_port"`
+	NilLoadgenHost         string                `yaml:"nil_loadgen_host"`
+	NilLoadgenPort         int                   `yaml:"nil_loadgen_port"`
+	NilUpdateRetryInterval int                   `yaml:"nil_update_retry_interval_sec"`
+	InstanceEnv            string                `yaml:"instance_env"`
+	SignozJournaldLogs     []string              `yaml:"signoz_journald_logs"`
 
 	NilConfig        []nodeSpec `yaml:"nil_config"`
 	NilArchiveConfig []nodeSpec `yaml:"nil_archive_config"`
@@ -66,18 +68,20 @@ type clusterSpec struct {
 }
 
 type server struct {
-	service         string
-	name            string
-	identity        string
-	p2pPort         int
-	promPort        int
-	pprofPort       int
-	rpcPort         int
-	credsDir        string
-	workDir         string
-	nodeSpec        nodeSpec
-	logClientEvents bool
-	vkm             *keys.ValidatorKeysManager
+	service            string
+	name               string
+	identity           string
+	relays             network.AddrInfoSlice
+	relayPublicAddress network.AddrInfo
+	p2pPort            int
+	promPort           int
+	pprofPort          int
+	rpcPort            int
+	credsDir           string
+	workDir            string
+	nodeSpec           nodeSpec
+	logClientEvents    bool
+	vkm                *keys.ValidatorKeysManager
 }
 
 type cluster struct {
@@ -194,9 +198,17 @@ func genDevnet(cmd *cobra.Command, args []string) error {
 	if spec.EnableRPCOnValidators {
 		validatorRPCBasePort = spec.NilRPCPort + len(spec.NilRPCConfig)
 	}
-	validators, err := spec.makeServers(spec.NilConfig,
-		spec.NildP2PBaseTCPPort, spec.NildPromBasePort, spec.PprofBaseTCPPort, validatorRPCBasePort,
-		"nil", baseDir, false)
+	validators, err := spec.makeServers(
+		spec.NilConfig,
+		spec.NildP2PBaseTCPPort,
+		spec.NildPromBasePort,
+		spec.PprofBaseTCPPort,
+		validatorRPCBasePort,
+		spec.Relays,
+		spec.RelayPublicAddress,
+		"nil",
+		baseDir,
+		false)
 	if err != nil {
 		return fmt.Errorf("failed to setup validator nodes: %w", err)
 	}
@@ -216,18 +228,34 @@ func genDevnet(cmd *cobra.Command, args []string) error {
 		archiveBasePprof = spec.PprofBaseTCPPort + len(validators)
 	}
 
-	c.archivers, err = spec.makeServers(spec.NilArchiveConfig,
-		archiveBaseP2P, archiveBaseProm, archiveBasePprof, 0,
-		"nil-archive", baseDir, false)
+	c.archivers, err = spec.makeServers(
+		spec.NilArchiveConfig,
+		archiveBaseP2P,
+		archiveBaseProm,
+		archiveBasePprof,
+		0,
+		spec.Relays,
+		spec.RelayPublicAddress,
+		"nil-archive",
+		baseDir,
+		false)
 	if err != nil {
 		return fmt.Errorf("failed to setup archive nodes: %w", err)
 	}
 
 	rpcBasePprof := spec.PprofBaseTCPPort + len(validators) + len(c.archivers)
 
-	c.rpcNodes, err = spec.makeServers(spec.NilRPCConfig,
-		0, 0, rpcBasePprof, spec.NilRPCPort,
-		"nil-rpc", baseDir, true)
+	c.rpcNodes, err = spec.makeServers(
+		spec.NilRPCConfig,
+		0,
+		0,
+		rpcBasePprof,
+		spec.NilRPCPort,
+		nil,
+		network.AddrInfo{},
+		"nil-rpc",
+		baseDir,
+		true)
 	if err != nil {
 		return fmt.Errorf("failed to setup rpc nodes: %w", err)
 	}
@@ -277,6 +305,8 @@ func (spec *clusterSpec) makeServers(
 	basePromPort int,
 	basePprofPort int,
 	baseHTTPPort int,
+	relays network.AddrInfoSlice,
+	relayPublicAddress network.AddrInfo,
 	service string,
 	baseDir string,
 	logClientEvents bool,
@@ -286,6 +316,8 @@ func (spec *clusterSpec) makeServers(
 		servers[i].service = service
 		servers[i].name = fmt.Sprintf("%s-%d", service, i)
 		servers[i].nodeSpec = nodeSpec
+		servers[i].relays = relays
+		servers[i].relayPublicAddress = relayPublicAddress
 		servers[i].logClientEvents = logClientEvents
 		if baseP2pPort != 0 {
 			servers[i].p2pPort = baseP2pPort + i
@@ -333,7 +365,10 @@ func (spec *clusterSpec) EnsureIdentity(srv server) (string, error) {
 		return "", fmt.Errorf("failed to load or generate keys: %w", err)
 	}
 	_, _, identity, err := network.SerializeKeys(privKey)
-	return identity.String(), err
+	if err != nil {
+		return "", fmt.Errorf("failed to serialize keys: %w", err)
+	}
+	return identity.String(), nil
 }
 
 func (c *cluster) writeServerConfig(instanceId int, srv server, only string) error {
@@ -363,8 +398,10 @@ func (c *cluster) writeServerConfig(instanceId int, srv server, only string) err
 			Network: &network.Config{
 				TcpPort: srv.p2pPort,
 
-				DHTEnabled:        true,
-				DHTBootstrapPeers: getPeers(c.validators, inst.DHTBootstrapPeersIdx),
+				DHTEnabled:         true,
+				DHTBootstrapPeers:  getPeers(c.validators, inst.DHTBootstrapPeersIdx),
+				Relays:             srv.relays,
+				RelayPublicAddress: srv.relayPublicAddress,
 			},
 			Telemetry: &telemetry.Config{
 				ExportMetrics:  true,

--- a/nil/internal/cobrax/cmdflags/network.go
+++ b/nil/internal/cobrax/cmdflags/network.go
@@ -15,6 +15,7 @@ func AddNetwork(fset *pflag.FlagSet, cfg *network.Config) {
 
 	fset.BoolVar(&cfg.ServeRelay, "serve-relay", cfg.ServeRelay, "enable relay")
 	fset.Var(&cfg.Relays, "relays", "relay peers")
+	fset.Var(&cfg.RelayPublicAddress, "relay-public-address", "public address of relay")
 
 	fset.BoolVar(&cfg.DHTEnabled, "with-discovery", cfg.DHTEnabled, "enable discovery (with Kademlia DHT)")
 	fset.Var(&cfg.DHTBootstrapPeers, "discovery-bootstrap-peers", "bootstrap peers for discovery")

--- a/nil/internal/execution/zerostate.go
+++ b/nil/internal/execution/zerostate.go
@@ -16,12 +16,12 @@ import (
 )
 
 type ContractDescr struct {
-	Name     string        `yaml:"name"`
-	Address  types.Address `yaml:"address,omitempty"`
-	Value    types.Value   `yaml:"value"`
-	Shard    types.ShardId `yaml:"shard,omitempty"`
-	Contract string        `yaml:"contract"`
-	CtorArgs []any         `yaml:"ctorArgs,omitempty"`
+	Name     string        `yaml:"name" json:"name"`
+	Address  types.Address `yaml:"address,omitempty" json:"address,omitempty"`
+	Value    types.Value   `yaml:"value" json:"value"`
+	Shard    types.ShardId `yaml:"shard,omitempty" json:"shard,omitempty"`
+	Contract string        `yaml:"contract" json:"contract"`
+	CtorArgs []any         `yaml:"ctorArgs,omitempty" json:"ctorArgs,omitempty"`
 }
 
 type MainKeys struct {
@@ -30,13 +30,13 @@ type MainKeys struct {
 }
 
 type ConfigParams struct {
-	Validators config.ParamValidators `yaml:"validators,omitempty"`
-	GasPrice   config.ParamGasPrice   `yaml:"gasPrice"`
+	Validators config.ParamValidators `yaml:"validators,omitempty" json:"validators,omitempty"`
+	GasPrice   config.ParamGasPrice   `yaml:"gasPrice" json:"gasPrice"`
 }
 
 type ZeroStateConfig struct {
-	ConfigParams ConfigParams     `yaml:"config,omitempty"`
-	Contracts    []*ContractDescr `yaml:"contracts"`
+	ConfigParams ConfigParams     `yaml:"config,omitempty" json:"config,omitempty"`
+	Contracts    []*ContractDescr `yaml:"contracts" json:"contracts"`
 }
 
 func CreateDefaultZeroStateConfig(mainPublicKey []byte) (*ZeroStateConfig, error) {

--- a/nil/internal/network/addr_info.go
+++ b/nil/internal/network/addr_info.go
@@ -1,11 +1,18 @@
 package network
 
 import (
+	"errors"
+
 	"github.com/NilFoundation/nil/nil/common"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"gopkg.in/yaml.v3"
 )
 
 type AddrInfo peer.AddrInfo
+
+func (a AddrInfo) Empty() bool {
+	return errors.Is(a.ID.Validate(), peer.ErrEmptyPeerID)
+}
 
 func (a *AddrInfo) Set(value string) error {
 	addr, err := peer.AddrInfoFromString(value)
@@ -42,6 +49,14 @@ func (a AddrInfo) MarshalText() ([]byte, error) {
 
 func (a *AddrInfo) UnmarshalText(text []byte) error {
 	return a.Set(string(text))
+}
+
+func (a *AddrInfo) MarshalYAML() (any, error) {
+	return a.MarshalText()
+}
+
+func (a *AddrInfo) UnmarshalYAML(value *yaml.Node) error {
+	return a.UnmarshalText([]byte(value.Value))
 }
 
 type AddrInfoSlice = common.PValueSlice[*AddrInfo, AddrInfo]

--- a/nil/internal/network/addr_info_test.go
+++ b/nil/internal/network/addr_info_test.go
@@ -25,14 +25,17 @@ func TestConfigYamlSerialization(t *testing.T) {
 			addrInfo1,
 			addrInfo2,
 		},
+		RelayPublicAddress: addrInfo1,
 	}
 
 	data, err := yaml.Marshal(config)
 	require.NoError(t, err)
 
-	expectedYaml := `dhtBootstrapPeers:
-- /ip4/127.0.0.1/tcp/1500/p2p/16Uiu2HAmQctkUi9y7WfUtYa9rPon1m5TRBtXSvUwi2VtpbWZj4yf
-- /ip4/192.168.1.1/tcp/4002/p2p/16Uiu2HAmQctkUi9y7WfUtYa9rPon1m5TRBtXSvUwi2VtpbWZj4yg
+	expectedYaml := `---
+dhtBootstrapPeers:
+  - /ip4/127.0.0.1/tcp/1500/p2p/16Uiu2HAmQctkUi9y7WfUtYa9rPon1m5TRBtXSvUwi2VtpbWZj4yf
+  - /ip4/192.168.1.1/tcp/4002/p2p/16Uiu2HAmQctkUi9y7WfUtYa9rPon1m5TRBtXSvUwi2VtpbWZj4yg
+relayPublicAddress: /ip4/127.0.0.1/tcp/1500/p2p/16Uiu2HAmQctkUi9y7WfUtYa9rPon1m5TRBtXSvUwi2VtpbWZj4yf
 `
 	require.YAMLEq(t, expectedYaml, string(data))
 
@@ -53,15 +56,14 @@ func TestAddrInfoStringRepresentation(t *testing.T) {
 		"/ip4/192.168.0.10/tcp/4002/p2p/16Uiu2HAmQctkUi9y7WfUtYa9rPon1m5TRBtXSvUwi2VtpbWZj4yf")
 	require.NoError(t, err)
 
-	_, id := peer.SplitAddr(addr1)
+	transport1, id := peer.SplitAddr(addr1)
+	transport2, _ := peer.SplitAddr(addr2)
 	addrInfo := AddrInfo{
 		ID:    id,
-		Addrs: []ma.Multiaddr{addr1, addr2},
+		Addrs: []ma.Multiaddr{transport1, transport2},
 	}
 
-	expectedString := "/ip4/127.0.0.1/tcp/1500/p2p/16Uiu2HAmQctkUi9y7WfUtYa9rPon1m5TRBtXSvUwi2VtpbWZj4yf" +
-		"/p2p/16Uiu2HAmQctkUi9y7WfUtYa9rPon1m5TRBtXSvUwi2VtpbWZj4yf," +
-		"/ip4/192.168.0.10/tcp/4002/p2p/16Uiu2HAmQctkUi9y7WfUtYa9rPon1m5TRBtXSvUwi2VtpbWZj4yf" +
-		"/p2p/16Uiu2HAmQctkUi9y7WfUtYa9rPon1m5TRBtXSvUwi2VtpbWZj4yf"
+	expectedString := "/ip4/127.0.0.1/tcp/1500/p2p/16Uiu2HAmQctkUi9y7WfUtYa9rPon1m5TRBtXSvUwi2VtpbWZj4yf," +
+		"/ip4/192.168.0.10/tcp/4002/p2p/16Uiu2HAmQctkUi9y7WfUtYa9rPon1m5TRBtXSvUwi2VtpbWZj4yf"
 	require.Equal(t, expectedString, addrInfo.String())
 }

--- a/nil/internal/network/config.go
+++ b/nil/internal/network/config.go
@@ -23,6 +23,8 @@ type Config struct {
 
 	ServeRelay bool          `yaml:"serveRelay,omitempty"`
 	Relays     AddrInfoSlice `yaml:"relays,omitempty"`
+	// RelayPublicAddress is the public relay address used to wrap the node's own address in BootstrapConfig if set.
+	RelayPublicAddress AddrInfo `yaml:"relayPublicAddress,omitempty"`
 
 	DHTEnabled        bool          `yaml:"dhtEnabled,omitempty"`
 	DHTBootstrapPeers AddrInfoSlice `yaml:"dhtBootstrapPeers,omitempty"`

--- a/nil/internal/network/host.go
+++ b/nil/internal/network/host.go
@@ -14,6 +14,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/p2p/net/connmgr"
+	"github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/relay"
 	"github.com/libp2p/go-libp2p/p2p/security/noise"
 	quic "github.com/libp2p/go-libp2p/p2p/transport/quic"
 	"github.com/libp2p/go-libp2p/p2p/transport/tcp"
@@ -88,7 +89,11 @@ func newHost(ctx context.Context, conf *Config) (Host, logging.Logger, error) {
 	}
 
 	if conf.ServeRelay {
-		options = append(options, libp2p.EnableRelayService())
+		options = append(options, libp2p.EnableRelayService(
+			// We temporarily disable the limitation because proxying traffic through a relay is the simplest
+			// way to make the whole system work. Later we should study EnableAutoNATv2 and
+			// EnableHolePunching more carefully to move to direct peer-to-peer connections.
+			relay.WithInfiniteLimits()))
 
 		// todo: remove it after relay is tested
 		// this is to make sure that the relay is not disabled

--- a/nil/internal/network/relay_test.go
+++ b/nil/internal/network/relay_test.go
@@ -1,10 +1,10 @@
 package network
 
 import (
+	"context"
 	"testing"
 
 	"github.com/libp2p/go-libp2p/core/network"
-	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -29,6 +29,9 @@ func (s *RelayTestSuite) TestRelay() {
 		Relays:       []AddrInfo{CalcAddress(relay)},
 		Reachability: network.ReachabilityPrivate,
 	})
+	private.SetRequestHandler(s.context, "/hello", func(context.Context, []byte) ([]byte, error) {
+		return []byte("world"), nil
+	})
 	defer private.Close()
 
 	// Connect the private node to the relay (avoiding discovery)
@@ -38,12 +41,15 @@ func (s *RelayTestSuite) TestRelay() {
 	client := s.newManager()
 	defer client.Close()
 
-	relayedAddr, err := peer.AddrInfoFromString(hostAddress(relay) + "/p2p-circuit/p2p/" + private.host.ID().String())
-	s.Require().NoError(err)
-
-	id, err := client.Connect(s.context, AddrInfo(*relayedAddr))
+	relayedAddr := RelayedAddress(private.host.ID(), CalcAddress(relay))
+	id, err := client.Connect(s.context, relayedAddr)
 	s.Require().NoError(err)
 	s.Require().Equal(private.host.ID(), id)
+
+	resp, err := client.SendRequestAndGetResponse(
+		network.WithAllowLimitedConn(s.context, "relay"), id, "/hello", []byte("hello"))
+	s.Require().NoError(err)
+	s.Require().Equal("world", string(resp))
 }
 
 func TestRelay(t *testing.T) {

--- a/nil/internal/network/testaide.go
+++ b/nil/internal/network/testaide.go
@@ -11,28 +11,14 @@ import (
 	"time"
 
 	"github.com/NilFoundation/nil/nil/common"
-	"github.com/NilFoundation/nil/nil/common/check"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/require"
 )
-
-func CalcAddress(m Manager) AddrInfo {
-	addr, err := peer.AddrInfoFromString(hostAddress(m))
-	check.PanicIfErr(err)
-	return AddrInfo(*addr)
-}
-
-func hostAddress(m Manager) string {
-	return m.getHost().Addrs()[0].String() + "/p2p/" + m.getHost().ID().String()
-}
 
 func NewTestManagerWithBaseConfig(ctx context.Context, t *testing.T, conf *Config) *BasicManager {
 	t.Helper()
 
 	conf = common.CopyPtr(conf)
-	if conf.IPV4Address == "" {
-		conf.IPV4Address = "127.0.0.1"
-	}
 	if conf.PrivateKey == nil {
 		privateKey, err := GeneratePrivateKey()
 		require.NoError(t, err)

--- a/nil/internal/network/utils.go
+++ b/nil/internal/network/utils.go
@@ -1,0 +1,28 @@
+package network
+
+import (
+	"github.com/NilFoundation/nil/nil/common/check"
+	ma "github.com/multiformats/go-multiaddr"
+)
+
+func CalcAddress(m Manager) AddrInfo {
+	return AddrInfo{m.getHost().ID(), m.getHost().Addrs()}
+}
+
+func RelayedAddress(p PeerID, relayAddrInfo AddrInfo) AddrInfo {
+	addrInfo := AddrInfo{
+		ID:    p,
+		Addrs: make([]ma.Multiaddr, len(relayAddrInfo.Addrs)),
+	}
+	for i, relayAddr := range relayAddrInfo.Addrs {
+		var addr ma.Multiaddr
+		relay, err := ma.NewComponent("p2p", relayAddrInfo.ID.String())
+		check.PanicIfErr(err)
+		addr = addr.AppendComponent(relay)
+		circuit, err := ma.NewComponent("p2p-circuit", "")
+		check.PanicIfErr(err)
+		addr = addr.AppendComponent(circuit)
+		addrInfo.Addrs[i] = relayAddr.Encapsulate(addr)
+	}
+	return addrInfo
+}

--- a/nil/services/rpc/jsonrpc/debug_api.go
+++ b/nil/services/rpc/jsonrpc/debug_api.go
@@ -11,6 +11,7 @@ import (
 	"github.com/NilFoundation/nil/nil/services/rpc/rawapi"
 	rawapitypes "github.com/NilFoundation/nil/nil/services/rpc/rawapi/types"
 	"github.com/NilFoundation/nil/nil/services/rpc/transport"
+	rpctypes "github.com/NilFoundation/nil/nil/services/rpc/types"
 )
 
 type DebugAPI interface {
@@ -26,6 +27,7 @@ type DebugAPI interface {
 		contractAddr types.Address,
 		blockNrOrHash transport.BlockNumberOrHash,
 	) (*DebugRPCContract, error)
+	GetBootstrapConfig(ctx context.Context) (*rpctypes.BootstrapConfig, error)
 }
 
 type DebugAPIImpl struct {
@@ -120,4 +122,8 @@ func (api *DebugAPIImpl) GetContract(
 		Tokens:       contract.Tokens,
 		AsyncContext: contract.AsyncContext,
 	}, nil
+}
+
+func (api *DebugAPIImpl) GetBootstrapConfig(ctx context.Context) (*rpctypes.BootstrapConfig, error) {
+	return api.rawApi.GetBootstrapConfig(ctx)
 }

--- a/nil/services/rpc/jsonrpc/debug_api_test.go
+++ b/nil/services/rpc/jsonrpc/debug_api_test.go
@@ -77,7 +77,7 @@ func TestDebugGetBlock(t *testing.T) {
 
 	api := NewDebugAPI(
 		rawapi.NodeApiBuilder(database, nil).
-			WithLocalShardApiRo(types.MainShardId).
+			WithLocalShardApiRo(types.MainShardId, nil).
 			BuildAndReset(),
 		logging.GlobalLogger)
 
@@ -157,7 +157,7 @@ func (suite *SuiteDbgContracts) SetupSuite() {
 
 	suite.debugApi = NewDebugAPI(
 		rawapi.NodeApiBuilder(suite.db, nil).
-			WithLocalShardApiRo(shardId).
+			WithLocalShardApiRo(shardId, nil).
 			BuildAndReset(),
 		logging.NewLogger("Test"))
 	suite.Require().NoError(err)

--- a/nil/services/rpc/jsonrpc/eth_api_test.go
+++ b/nil/services/rpc/jsonrpc/eth_api_test.go
@@ -33,7 +33,7 @@ func NewTestEthAPI(ctx context.Context, t *testing.T, db db.DB, nShards int) *AP
 	nodeApiBuilder := rawapi.NodeApiBuilder(db, nil)
 	for shardId := range types.ShardId(nShards) {
 		nodeApiBuilder.
-			WithLocalShardApiRo(shardId).
+			WithLocalShardApiRo(shardId, nil).
 			WithLocalShardApiRw(shardId, pools[shardId])
 	}
 	return NewEthAPI(ctx, nodeApiBuilder.BuildAndReset(), db, true, false)

--- a/nil/services/rpc/rawapi/internal/client_ro.go
+++ b/nil/services/rpc/rawapi/internal/client_ro.go
@@ -126,3 +126,7 @@ func (api *shardApiClientRo) GetNumShards(ctx context.Context) (uint64, error) {
 func (api *shardApiClientRo) ClientVersion(ctx context.Context) (string, error) {
 	return sendRequestAndGetResponseWithCallerMethodName[string](ctx, api, "ClientVersion")
 }
+
+func (api *shardApiClientRo) GetBootstrapConfig(ctx context.Context) (*rpctypes.BootstrapConfig, error) {
+	return sendRequestAndGetResponseWithCallerMethodName[*rpctypes.BootstrapConfig](ctx, api, "GetBootstrapConfig")
+}

--- a/nil/services/rpc/rawapi/internal/local_api_ro.go
+++ b/nil/services/rpc/rawapi/internal/local_api_ro.go
@@ -9,6 +9,7 @@ import (
 	"github.com/NilFoundation/nil/nil/internal/execution"
 	"github.com/NilFoundation/nil/nil/internal/network"
 	"github.com/NilFoundation/nil/nil/internal/types"
+	rpctypes "github.com/NilFoundation/nil/nil/services/rpc/types"
 )
 
 type localShardApiRo struct {
@@ -16,19 +17,26 @@ type localShardApiRo struct {
 	accessor *execution.StateAccessor
 	shard    types.ShardId
 
+	bootstrapConfig *rpctypes.BootstrapConfig
+
 	nodeApi NodeApi
 	logger  logging.Logger
 }
 
 var _ shardApiRo = (*localShardApiRo)(nil)
 
-func newLocalShardApiRo(shardId types.ShardId, db db.ReadOnlyDB) *localShardApiRo {
+func newLocalShardApiRo(
+	shardId types.ShardId,
+	db db.ReadOnlyDB,
+	bootstrapConfig *rpctypes.BootstrapConfig,
+) *localShardApiRo {
 	stateAccessor := execution.NewStateAccessor()
 	return &localShardApiRo{
-		db:       db,
-		accessor: stateAccessor,
-		shard:    shardId,
-		logger:   logging.NewLogger("local_api"),
+		bootstrapConfig: bootstrapConfig,
+		db:              db,
+		accessor:        stateAccessor,
+		shard:           shardId,
+		logger:          logging.NewLogger("local_api"),
 	}
 }
 

--- a/nil/services/rpc/rawapi/internal/local_bootstrap_config.go
+++ b/nil/services/rpc/rawapi/internal/local_bootstrap_config.go
@@ -1,0 +1,11 @@
+package internal
+
+import (
+	"context"
+
+	rpctypes "github.com/NilFoundation/nil/nil/services/rpc/types"
+)
+
+func (api *localShardApiRo) GetBootstrapConfig(ctx context.Context) (*rpctypes.BootstrapConfig, error) {
+	return api.bootstrapConfig, nil
+}

--- a/nil/services/rpc/rawapi/internal/node.go
+++ b/nil/services/rpc/rawapi/internal/node.go
@@ -302,6 +302,20 @@ func (api *nodeApiOverShardApis) SendTransaction(
 	return result, nil
 }
 
+func (api *nodeApiOverShardApis) GetBootstrapConfig(ctx context.Context) (*rpctypes.BootstrapConfig, error) {
+	methodName := methodNameChecked("GetBootstrapConfig")
+	shardId := types.MainShardId
+	shardApi, ok := api.apisRo[shardId]
+	if !ok {
+		return nil, makeShardNotFoundError(methodName, shardId)
+	}
+	result, err := shardApi.GetBootstrapConfig(ctx)
+	if err != nil {
+		return nil, makeCallError(methodName, shardId, err)
+	}
+	return result, nil
+}
+
 func (api *nodeApiOverShardApis) ClientVersion(ctx context.Context) (string, error) {
 	methodName := methodNameChecked("ClientVersion")
 	shardId := types.MainShardId

--- a/nil/services/rpc/rawapi/internal/node_api.go
+++ b/nil/services/rpc/rawapi/internal/node_api.go
@@ -62,6 +62,8 @@ type NodeApi interface {
 	GetShardIdList(ctx context.Context) ([]types.ShardId, error)
 	GetNumShards(ctx context.Context) (uint64, error)
 
+	GetBootstrapConfig(ctx context.Context) (*rpctypes.BootstrapConfig, error)
+
 	ClientVersion(ctx context.Context) (string, error)
 
 	GetTxpoolStatus(ctx context.Context, shardId types.ShardId) (uint64, error)

--- a/nil/services/rpc/rawapi/internal/node_builder.go
+++ b/nil/services/rpc/rawapi/internal/node_builder.go
@@ -5,6 +5,7 @@ import (
 	"github.com/NilFoundation/nil/nil/internal/db"
 	"github.com/NilFoundation/nil/nil/internal/network"
 	"github.com/NilFoundation/nil/nil/internal/types"
+	rpctypes "github.com/NilFoundation/nil/nil/services/rpc/types"
 	"github.com/NilFoundation/nil/nil/services/txnpool"
 )
 
@@ -38,8 +39,11 @@ func (nb *nodeApiBuilder) BuildAndReset() NodeApi {
 	return &rv
 }
 
-func (nb *nodeApiBuilder) WithLocalShardApiRo(shardId types.ShardId) *nodeApiBuilder {
-	var localShardApi shardApiRo = newLocalShardApiRo(shardId, nb.db)
+func (nb *nodeApiBuilder) WithLocalShardApiRo(
+	shardId types.ShardId,
+	bootstrapConfig *rpctypes.BootstrapConfig,
+) *nodeApiBuilder {
+	var localShardApi shardApiRo = newLocalShardApiRo(shardId, nb.db, bootstrapConfig)
 	if assert.Enable {
 		localShardApi = newShardApiClientDirectEmulatorRo(localShardApi)
 	}
@@ -49,7 +53,8 @@ func (nb *nodeApiBuilder) WithLocalShardApiRo(shardId types.ShardId) *nodeApiBui
 }
 
 func (nb *nodeApiBuilder) WithLocalShardApiRw(shardId types.ShardId, txnpool txnpool.Pool) *nodeApiBuilder {
-	var localShardApi shardApiRw = newLocalShardApiRw(newLocalShardApiRo(shardId, nb.db), txnpool)
+	var bootstrapConfig *rpctypes.BootstrapConfig // = nil — not used in rw API methods
+	var localShardApi shardApiRw = newLocalShardApiRw(newLocalShardApiRo(shardId, nb.db, bootstrapConfig), txnpool)
 	if assert.Enable {
 		localShardApi = newShardApiClientDirectEmulatorRw(localShardApi)
 	}

--- a/nil/services/rpc/rawapi/internal/server.go
+++ b/nil/services/rpc/rawapi/internal/server.go
@@ -38,6 +38,8 @@ type NetworkTransportProtocolRo interface {
 	GetNumShards() pb.Uint64Response
 
 	ClientVersion() pb.StringResponse
+
+	GetBootstrapConfig() pb.BootstrapConfigResponse
 }
 
 type NetworkTransportProtocolRw interface {

--- a/nil/services/rpc/rawapi/internal/shard_api.go
+++ b/nil/services/rpc/rawapi/internal/shard_api.go
@@ -59,6 +59,8 @@ type shardApiRo interface {
 	GetNumShards(ctx context.Context) (uint64, error)
 
 	ClientVersion(ctx context.Context) (string, error)
+
+	GetBootstrapConfig(ctx context.Context) (*rpctypes.BootstrapConfig, error)
 }
 
 const apiNameRw = "rawapi_rw"

--- a/nil/services/rpc/rawapi/pb/conversion_bootstrap_config.go
+++ b/nil/services/rpc/rawapi/pb/conversion_bootstrap_config.go
@@ -1,0 +1,71 @@
+package pb
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/NilFoundation/nil/nil/common"
+	"github.com/NilFoundation/nil/nil/internal/network"
+	rpctypes "github.com/NilFoundation/nil/nil/services/rpc/types"
+	"gopkg.in/yaml.v3"
+)
+
+func (bc *BootstrapConfigResponse) PackProtoMessage(config *rpctypes.BootstrapConfig, err error) error {
+	if err != nil {
+		bc.Result = &BootstrapConfigResponse_Error{Error: new(Error).PackProtoMessage(err)}
+		return nil
+	}
+
+	zeroStateConfigYaml, err := yaml.Marshal(config.ZeroStateConfig)
+	if err != nil {
+		return err
+	}
+
+	bc.Result = &BootstrapConfigResponse_Data{
+		Data: &BootstrapConfig{
+			NShards:             config.NShards,
+			ZeroStateConfigYaml: string(zeroStateConfigYaml),
+			DhtBootstrapPeers: slices.Collect(common.Transform(
+				slices.Values(config.DhtBootstrapPeers),
+				func(peer network.AddrInfo) string { return peer.String() })),
+			BootstrapPeers: slices.Collect(common.Transform(
+				slices.Values(config.BootstrapPeers),
+				func(peer network.AddrInfo) string { return peer.String() })),
+		},
+	}
+
+	return nil
+}
+
+func (bc *BootstrapConfigResponse) UnpackProtoMessage() (*rpctypes.BootstrapConfig, error) {
+	switch res := bc.GetResult().(type) {
+	case *BootstrapConfigResponse_Data:
+		config := &rpctypes.BootstrapConfig{
+			NShards: res.Data.GetNShards(),
+		}
+		if err := yaml.Unmarshal([]byte(res.Data.GetZeroStateConfigYaml()), &config.ZeroStateConfig); err != nil {
+			return nil, err
+		}
+		config.DhtBootstrapPeers = make(network.AddrInfoSlice, len(res.Data.GetDhtBootstrapPeers()))
+		for i, peer := range res.Data.GetDhtBootstrapPeers() {
+			var addrInfo network.AddrInfo
+			if err := addrInfo.Set(peer); err != nil {
+				return nil, err
+			}
+			config.DhtBootstrapPeers[i] = addrInfo
+		}
+		config.BootstrapPeers = make(network.AddrInfoSlice, len(res.Data.GetBootstrapPeers()))
+		for i, peer := range res.Data.GetBootstrapPeers() {
+			var addrInfo network.AddrInfo
+			if err := addrInfo.Set(peer); err != nil {
+				return nil, err
+			}
+			config.BootstrapPeers[i] = addrInfo
+		}
+		return config, nil
+
+	case *BootstrapConfigResponse_Error:
+		return nil, res.Error.UnpackProtoMessage()
+	}
+	return nil, fmt.Errorf("unexpected response type: %T", bc.GetResult())
+}

--- a/nil/services/rpc/rawapi/proto/Makefile.inc
+++ b/nil/services/rpc/rawapi/proto/Makefile.inc
@@ -2,6 +2,7 @@
 pb_rawapi: \
 	nil/services/rpc/rawapi/pb/account.pb.go \
 	nil/services/rpc/rawapi/pb/block.pb.go \
+	nil/services/rpc/rawapi/pb/bootstrap_config.pb.go \
 	nil/services/rpc/rawapi/pb/transaction.pb.go \
 	nil/services/rpc/rawapi/pb/call.pb.go \
 	nil/services/rpc/rawapi/pb/common.pb.go \
@@ -13,6 +14,9 @@ nil/services/rpc/rawapi/pb/account.pb.go: nil/services/rpc/rawapi/proto/account.
 
 nil/services/rpc/rawapi/pb/block.pb.go: nil/services/rpc/rawapi/proto/block.proto
 	protoc --go_out=nil/services/rpc/rawapi/ nil/services/rpc/rawapi/proto/block.proto
+
+nil/services/rpc/rawapi/pb/bootstrap_config.pb.go: nil/services/rpc/rawapi/proto/bootstrap_config.proto
+	protoc --go_out=nil/services/rpc/rawapi/ nil/services/rpc/rawapi/proto/bootstrap_config.proto
 
 nil/services/rpc/rawapi/pb/transaction.pb.go: nil/services/rpc/rawapi/proto/transaction.proto
 	protoc --go_out=nil/services/rpc/rawapi/ nil/services/rpc/rawapi/proto/transaction.proto

--- a/nil/services/rpc/rawapi/proto/bootstrap_config.proto
+++ b/nil/services/rpc/rawapi/proto/bootstrap_config.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+package rawapi;
+
+option go_package = "/pb";
+
+import "nil/services/rpc/rawapi/proto/common.proto";
+
+message BootstrapConfig {
+  uint32 nShards = 1;
+  string zeroStateConfigYaml = 2;
+  repeated string dhtBootstrapPeers = 3;
+  repeated string bootstrapPeers = 4;
+}
+
+message BootstrapConfigResponse {
+  oneof result {
+    Error error = 1;
+    BootstrapConfig data = 2;
+  }
+}

--- a/nil/services/rpc/types/bootstrap_config.go
+++ b/nil/services/rpc/types/bootstrap_config.go
@@ -1,0 +1,13 @@
+package types
+
+import (
+	"github.com/NilFoundation/nil/nil/internal/execution"
+	"github.com/NilFoundation/nil/nil/internal/network"
+)
+
+type BootstrapConfig struct {
+	NShards           uint32                     `json:"nShards"`
+	ZeroStateConfig   *execution.ZeroStateConfig `json:"zeroStateConfig,omitempty"`
+	BootstrapPeers    network.AddrInfoSlice      `json:"bootstrapPeers,omitempty"`
+	DhtBootstrapPeers network.AddrInfoSlice      `json:"bootstrapDhtPeers,omitempty"`
+}

--- a/nil/tests/rpc_suite.go
+++ b/nil/tests/rpc_suite.go
@@ -115,7 +115,7 @@ func (s *RpcSuite) Start(cfg *nilservice.Config) {
 		nodeApiBuilder := rawapi.NodeApiBuilder(s.Db, nil)
 		for shardId := range types.ShardId(s.ShardsNum) {
 			nodeApiBuilder.
-				WithLocalShardApiRo(shardId).
+				WithLocalShardApiRo(shardId, nil).
 				WithLocalShardApiRw(shardId, service.TxnPools[shardId])
 		}
 		localApi := nodeApiBuilder.BuildAndReset()


### PR DESCRIPTION
This is an alternative approach to the one proposed in #813.

Pros:
- No hardcodes
- No infrastructure lock-in, works fine locally, with or without relays

Caveats:
- Establishing a connection using relays requires additional research, debugging and experimentation with `EnableAutoNATv2` and `EnableHolePunching` in real or near real conditions. To avoid being blocked by this now, I've enabled the `WithInfiniteLimits` setting on relays, and `WithAllowLimitedConn` on nodes. This should work "cheap but surly".