### PR TITLE
feat(RPC): add eth_getProof method

### DIFF
--- a/nil/client/rpc/client.go
+++ b/nil/client/rpc/client.go
@@ -76,6 +76,7 @@ const (
 	Eth_getNumShards                     = "eth_getNumShards"
 	Eth_gasPrice                         = "eth_gasPrice"
 	Eth_chainId                          = "eth_chainId"
+	Eth_getProof                         = "eth_getProof"
 	Debug_getBlockByHash                 = "debug_getBlockByHash"
 	Debug_getBlockByNumber               = "debug_getBlockByNumber"
 	Debug_getContract                    = "debug_getContract"

--- a/nil/internal/types/storage.go
+++ b/nil/internal/types/storage.go
@@ -4,10 +4,9 @@ import (
 	"fmt"
 
 	"github.com/NilFoundation/nil/nil/common"
-	"github.com/holiman/uint256"
 )
 
-type Storage map[common.Hash]uint256.Int
+type Storage map[common.Hash]Uint256
 
 func (s Storage) String() (str string) {
 	for key, value := range s {

--- a/nil/services/rpc/jsonrpc/eth_accounts.go
+++ b/nil/services/rpc/jsonrpc/eth_accounts.go
@@ -2,9 +2,15 @@ package jsonrpc
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
+	"github.com/NilFoundation/nil/nil/common"
 	"github.com/NilFoundation/nil/nil/common/check"
 	"github.com/NilFoundation/nil/nil/common/hexutil"
+	"github.com/NilFoundation/nil/nil/internal/db"
+	"github.com/NilFoundation/nil/nil/internal/execution"
+	"github.com/NilFoundation/nil/nil/internal/mpt"
 	"github.com/NilFoundation/nil/nil/internal/types"
 	rawapitypes "github.com/NilFoundation/nil/nil/services/rpc/rawapi/types"
 	"github.com/NilFoundation/nil/nil/services/rpc/transport"
@@ -57,6 +63,147 @@ func (api *APIImplRo) GetCode(
 		return nil, err
 	}
 	return hexutil.Bytes(code), nil
+}
+
+// GetProof implements eth_getProof. For more info refer to `EthProof`.
+func (api *APIImplRo) GetProof(
+	ctx context.Context,
+	address types.Address,
+	storageKeys []common.Hash,
+	blockNrOrHash transport.BlockNumberOrHash,
+) (*EthProof, error) {
+	// Fetch the smart contract data
+	smartContract, err := api.rawapi.GetContract(ctx, address, toBlockReference(blockNrOrHash))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get contract: %w", err)
+	}
+
+	// Process account proof
+	accountProofBytes, err := extractAccountProofBytes(smartContract.ProofEncoded)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract account proof: %w", err)
+	}
+
+	// Prepare storage data for trie
+	keys, values := extractStorageKeyValues(smartContract.Storage)
+
+	// Build storage trie
+	trie, err := buildStorageTrie(keys, values)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build storage trie: %w", err)
+	}
+
+	// Generate storage proofs for each requested key
+	storageProofs, err := generateStorageProofs(trie.Reader, storageKeys)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate storage proofs: %w", err)
+	}
+
+	// Create the basic proof result
+	result := &EthProof{
+		AccountProof: hexutil.FromBytesSlice(accountProofBytes),
+		StorageProof: storageProofs,
+	}
+
+	// If contract data is available, add contract details
+	if len(smartContract.ContractSSZ) > 0 {
+		if err := addContractDetailsToProof(result, smartContract.ContractSSZ); err != nil {
+			return nil, fmt.Errorf("failed to add contract details: %w", err)
+		}
+	}
+
+	return result, nil
+}
+
+// extractAccountProofBytes decodes and extracts the account proof bytes
+func extractAccountProofBytes(proofEncoded []byte) ([][]byte, error) {
+	proof, err := mpt.DecodeProof(proofEncoded)
+	if err != nil {
+		return nil, err
+	}
+
+	return proof.PathToNode.ToBytesSlice()
+}
+
+// extractStorageKeyValues extracts keys and values from storage map
+func extractStorageKeyValues(storage map[common.Hash]types.Uint256) ([]common.Hash, []*types.Uint256) {
+	keys := make([]common.Hash, 0, len(storage))
+	values := make([]*types.Uint256, 0, len(storage))
+
+	for key, val := range storage {
+		localVal := val // Create a local copy to avoid pointer issues
+		keys = append(keys, key)
+		values = append(values, &localVal)
+	}
+
+	return keys, values
+}
+
+// buildStorageTrie creates and populates a storage trie with the given keys and values
+func buildStorageTrie(keys []common.Hash, values []*types.Uint256) (*mpt.MerklePatriciaTrie, error) {
+	trie := mpt.NewInMemMPT()
+	storageTrie := execution.NewStorageTrie(trie)
+
+	if err := storageTrie.UpdateBatch(keys, values); err != nil {
+		return nil, err
+	}
+
+	return trie, nil
+}
+
+// generateStorageProofs creates proofs for each requested storage key
+func generateStorageProofs(trie *mpt.Reader, storageKeys []common.Hash) ([]StorageProof, error) {
+	storageProofs := make([]StorageProof, 0, len(storageKeys))
+
+	for _, key := range storageKeys {
+		// Get value for the key
+		value, err := trie.Get(key.Bytes())
+		if err != nil && !errors.Is(err, db.ErrKeyNotFound) {
+			return nil, err
+		}
+
+		// Build proof for the key
+		proof, err := mpt.BuildSimpleProof(trie, key.Bytes())
+		if err != nil {
+			return nil, err
+		}
+
+		// Convert proof to bytes
+		proofBytesSlice, err := proof.ToBytesSlice()
+		if err != nil {
+			return nil, err
+		}
+
+		// Create storage proof for the key
+		storageProof := StorageProof{
+			Key:   hexutil.Big(*key.Big()),
+			Value: *hexutil.NewBig(common.BytesToHash(value).Big()),
+		}
+
+		// Add proof bytes if available
+		if len(proofBytesSlice) != 0 {
+			storageProof.Proof = hexutil.FromBytesSlice(proofBytesSlice)
+		}
+
+		storageProofs = append(storageProofs, storageProof)
+	}
+
+	return storageProofs, nil
+}
+
+// addContractDetailsToProof adds smart contract details to the proof result
+func addContractDetailsToProof(result *EthProof, contractSSZ []byte) error {
+	contract := new(types.SmartContract)
+	if err := contract.UnmarshalSSZ(contractSSZ); err != nil {
+		return err
+	}
+
+	result.Balance = contract.Balance
+	result.CodeHash = contract.CodeHash
+	result.Nonce = contract.Seqno
+	result.StorageHash = contract.StorageRoot
+
+	return nil
 }
 
 func blockNrToBlockReference(num transport.BlockNumber) rawapitypes.BlockReference {

--- a/nil/services/rpc/jsonrpc/eth_accounts_test.go
+++ b/nil/services/rpc/jsonrpc/eth_accounts_test.go
@@ -1,7 +1,6 @@
 package jsonrpc
 
 import (
-	"context"
 	"testing"
 
 	"github.com/NilFoundation/nil/nil/common"
@@ -9,7 +8,9 @@ import (
 	"github.com/NilFoundation/nil/nil/internal/config"
 	"github.com/NilFoundation/nil/nil/internal/db"
 	"github.com/NilFoundation/nil/nil/internal/execution"
+	"github.com/NilFoundation/nil/nil/internal/mpt"
 	"github.com/NilFoundation/nil/nil/internal/types"
+	rawapitypes "github.com/NilFoundation/nil/nil/services/rpc/rawapi/types"
 	"github.com/NilFoundation/nil/nil/services/rpc/transport"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/suite"
@@ -41,7 +42,7 @@ func (suite *SuiteEthAccounts) SetupSuite() {
 	suite.SuiteAccountsBase.SetupSuite()
 
 	shardId := types.BaseShardId
-	ctx := context.Background()
+	ctx := suite.T().Context()
 
 	var err error
 	tx, err := suite.db.CreateRwTx(ctx)
@@ -63,6 +64,9 @@ func (suite *SuiteEthAccounts) SetupSuite() {
 	suite.Require().NoError(es.SetBalance(suite.smcAddr, types.NewValueFromUint64(1234)))
 	suite.Require().NoError(es.SetExtSeqno(suite.smcAddr, 567))
 
+	suite.Require().NoError(es.SetState(suite.smcAddr, common.HexToHash("0x1"), common.HexToHash("0x2")))
+	suite.Require().NoError(es.SetState(suite.smcAddr, common.HexToHash("0x3"), common.HexToHash("0x4")))
+
 	blockRes, err := es.Commit(0, nil)
 	suite.Require().NoError(err)
 	suite.blockHash = blockRes.BlockHash
@@ -82,7 +86,7 @@ func (suite *SuiteEthAccounts) TearDownSuite() {
 }
 
 func (suite *SuiteEthAccounts) TestGetBalance() {
-	ctx := context.Background()
+	ctx := suite.T().Context()
 
 	blockNum := transport.BlockNumberOrHash{BlockNumber: transport.LatestBlock.BlockNumber}
 	res, err := suite.api.GetBalance(ctx, suite.smcAddr, blockNum)
@@ -107,7 +111,7 @@ func (suite *SuiteEthAccounts) TestGetBalance() {
 }
 
 func (suite *SuiteEthAccounts) TestGetCode() {
-	ctx := context.Background()
+	ctx := suite.T().Context()
 
 	blockNum := transport.BlockNumberOrHash{BlockNumber: transport.LatestBlock.BlockNumber}
 	res, err := suite.api.GetCode(ctx, suite.smcAddr, blockNum)
@@ -132,7 +136,7 @@ func (suite *SuiteEthAccounts) TestGetCode() {
 }
 
 func (suite *SuiteEthAccounts) TestGetSeqno() {
-	ctx := context.Background()
+	ctx := suite.T().Context()
 
 	blockNum := transport.BlockNumberOrHash{BlockNumber: transport.LatestBlock.BlockNumber}
 	res, err := suite.api.GetTransactionCount(ctx, suite.smcAddr, blockNum)
@@ -151,7 +155,7 @@ func (suite *SuiteEthAccounts) TestGetSeqno() {
 
 	blockNumber := transport.BlockNumber(1000)
 	blockNum = transport.BlockNumberOrHash{BlockNumber: &blockNumber}
-	_, err = suite.api.GetTransactionCount(ctx, suite.smcAddr, blockNum)
+	res, err = suite.api.GetTransactionCount(ctx, suite.smcAddr, blockNum)
 	suite.Require().NoError(err)
 	suite.Equal(hexutil.Uint64(0), res)
 
@@ -185,6 +189,130 @@ func (suite *SuiteEthAccounts) TestGetSeqno() {
 	res, err = suite.api.GetTransactionCount(ctx, suite.smcAddr, blockNum)
 	suite.Require().NoError(err)
 	suite.Equal(hexutil.Uint64(1), res)
+}
+
+func (suite *SuiteEthAccounts) TestGetProofNew() {
+	ctx := suite.T().Context()
+
+	// Test keys to check in proofs
+	keys := []common.Hash{
+		common.HexToHash("0x1"), // existing key
+		common.HexToHash("0x2"), // non-existing key
+	}
+
+	// GetBlockByNumber response doesn't contain storage root, using rawapi method instead
+	blockData, err := suite.api.rawapi.GetFullBlockData(ctx, suite.smcAddr.ShardId(),
+		rawapitypes.NamedBlockIdentifierAsBlockReference(rawapitypes.LatestBlock))
+	suite.Require().NoError(err)
+	block, err := blockData.DecodeSSZ()
+	suite.Require().NoError(err)
+
+	// Test with block number
+	blockNum := transport.BlockNumberOrHash{BlockNumber: transport.LatestBlock.BlockNumber}
+	resByNum, err := suite.api.GetProof(ctx, suite.smcAddr, keys, blockNum)
+	suite.Require().NoError(err)
+
+	suite.verifyProofResult(resByNum, block.SmartContractsRoot)
+
+	// Test with block hash
+	blockHash := transport.BlockNumberOrHash{BlockHash: &suite.blockHash}
+	resByHash, err := suite.api.GetProof(ctx, suite.smcAddr, keys, blockHash)
+	suite.Require().NoError(err)
+
+	suite.verifyProofResult(resByHash, block.SmartContractsRoot)
+
+	// Test with non-existing address
+	nonExistingAddr := types.GenerateRandomAddress(types.BaseShardId)
+	resNonExisting, err := suite.api.GetProof(ctx, nonExistingAddr, keys, blockHash)
+	suite.Require().NoError(err)
+
+	// Verify empty result for non-existing address
+	suite.NotEmpty(resNonExisting.AccountProof)
+	suite.Zero(resNonExisting.Balance)
+	suite.Zero(resNonExisting.CodeHash)
+	suite.Zero(resNonExisting.Nonce)
+	suite.Zero(resNonExisting.StorageHash)
+	suite.Len(resNonExisting.StorageProof, 2)
+	suite.EqualValues(1, resNonExisting.StorageProof[0].Key.Uint64())
+	suite.EqualValues(0, resNonExisting.StorageProof[0].Value.Uint64())
+	suite.Nil(resNonExisting.StorageProof[0].Proof)
+	suite.EqualValues(2, resNonExisting.StorageProof[1].Key.Uint64())
+	suite.EqualValues(0, resNonExisting.StorageProof[1].Value.Uint64())
+	suite.Nil(resNonExisting.StorageProof[1].Proof)
+}
+
+// verifyProofResult verifies both account proof and storage proofs in the response
+func (suite *SuiteEthAccounts) verifyProofResult(res *EthProof, smartContractsRoot common.Hash) {
+	suite.T().Helper()
+
+	// Verify account proof
+	proof, err := mpt.SimpleProofFromBytesSlice(hexutil.ToBytesSlice(res.AccountProof))
+	suite.Require().NoError(err)
+
+	val, err := proof.Verify(smartContractsRoot, suite.smcAddr.Hash().Bytes())
+	suite.Require().NoError(err)
+
+	var sc types.SmartContract
+	suite.Require().NoError(sc.UnmarshalSSZ(val))
+
+	// Verify account fields
+	suite.Require().Equal(res.Balance, sc.Balance)
+	suite.Require().Equal(res.CodeHash, sc.CodeHash)
+	suite.Require().Equal(res.Nonce, sc.Seqno)
+	suite.Require().Equal(res.StorageHash, sc.StorageRoot)
+
+	// Verify first storage proof (existing key)
+	suite.verifyStorageProof(
+		res.StorageProof[0],
+		res.StorageHash,
+		common.HexToHash("0x1"),
+		common.HexToHash("0x2"),
+		false,
+	)
+
+	// Verify second storage proof (non-existing key)
+	suite.verifyStorageProof(
+		res.StorageProof[1],
+		res.StorageHash,
+		common.HexToHash("0x2"),
+		common.Hash{},
+		true,
+	)
+}
+
+// verifyStorageProof verifies an individual storage proof
+func (suite *SuiteEthAccounts) verifyStorageProof(
+	storageProof StorageProof,
+	storageRoot common.Hash,
+	key common.Hash,
+	expectedValue common.Hash,
+	expectNil bool,
+) {
+	suite.T().Helper()
+
+	suite.Require().Equal(key.Big().Uint64(), storageProof.Key.Uint64())
+
+	if expectNil {
+		suite.Require().Equal(uint64(0), storageProof.Value.Uint64()) // no value for such key
+	} else {
+		var u types.Uint256
+		suite.Require().NoError(u.UnmarshalSSZ(storageProof.Value.ToInt().Bytes()))
+		suite.Require().Equal(expectedValue.Uint256(), u.Int())
+	}
+
+	proof, err := mpt.SimpleProofFromBytesSlice(hexutil.ToBytesSlice(storageProof.Proof))
+	suite.Require().NoError(err)
+
+	val, err := proof.Verify(storageRoot, key.Bytes())
+	suite.Require().NoError(err)
+
+	if expectNil {
+		suite.Require().Nil(val)
+	} else {
+		var u types.Uint256
+		suite.Require().NoError(u.UnmarshalSSZ(val))
+		suite.Require().Equal(expectedValue.Uint256(), u.Int())
+	}
 }
 
 func TestSuiteEthAccounts(t *testing.T) {

--- a/nil/services/rpc/jsonrpc/types.go
+++ b/nil/services/rpc/jsonrpc/types.go
@@ -593,3 +593,29 @@ type EstimateFeeRes struct {
 	AveragePriorityFee types.Value `json:"averagePriorityFee"`
 	MaxBasFee          types.Value `json:"maxBaseFee"`
 }
+
+// @component EthProof ethProof object "Response for eth_getProof."
+// @componentprop Balance balance integer true the balance of the account. See `eth_getBalance`
+// @componentprop CodeHash codeHash string true 32 Bytes - hash of the code of the account.
+// @componentprop Nonce nonce integer true nonce of the account. See eth_getTransactionCount
+// @componentprop StorageHash storageHash string true 32 Bytes - hash of the StorageRoot. All storage will deliver a MerkleProof starting with this rootHash.
+// @componentprop AccountProof accountProof array true Array of ssz-serialized MerkleTree-Nodes, starting with the stateRoot-Node, following the path of the address hash as path.
+// @componentprop StorageProof storageProof array true Array of storage-entries as requested.
+type EthProof struct {
+	Balance      types.Value     `json:"balance"`
+	CodeHash     common.Hash     `json:"codeHash"`
+	Nonce        types.Seqno     `json:"nonce"`
+	StorageHash  common.Hash     `json:"storageHash"`
+	AccountProof []hexutil.Bytes `json:"accountProof"`
+	StorageProof []StorageProof  `json:"storageProof"`
+}
+
+// @component StorageProof storageProof object "Underlying type of StorageProof inside EthProof"
+// @componentprop Key key string true the requested storage key
+// @componentprop Value value string true the storage value
+// @componentprop Proof proof array false Array of ssz-serialized MerkleTree-Nodes, starting with the stateRoot-Node, following the path of the key hash as path.
+type StorageProof struct {
+	Key   hexutil.Big     `json:"key"`
+	Value hexutil.Big     `json:"value"`
+	Proof []hexutil.Bytes `json:"proof,omitempty"`
+}

--- a/nil/services/synccommittee/prover/tracer/internal/mpttracer/serialization.go
+++ b/nil/services/synccommittee/prover/tracer/internal/mpttracer/serialization.go
@@ -195,7 +195,7 @@ func smartContractToProto(smartContract *types.SmartContract) *pb.SmartContract 
 	}
 }
 
-func proofPathToProto(pathToNode mpt.ProofPath) (*pb.HumanReadableProof, error) {
+func proofPathToProto(pathToNode mpt.SimpleProof) (*pb.HumanReadableProof, error) {
 	nodes := make([]*pb.Node, len(pathToNode))
 	for i, node := range pathToNode {
 		pbNode, err := nodeToProto(node)

--- a/nil/services/synccommittee/prover/tracer/internal/mpttracer/types.go
+++ b/nil/services/synccommittee/prover/tracer/internal/mpttracer/types.go
@@ -21,8 +21,8 @@ type GenericTrieUpdateTrace[T any] struct {
 	ValueBefore T
 	ValueAfter  T
 	Proof       mpt.Proof
-	PathBefore  mpt.ProofPath
-	PathAfter   mpt.ProofPath
+	PathBefore  mpt.SimpleProof
+	PathAfter   mpt.SimpleProof
 }
 
 // StorageTrieUpdateTrace is a type alias for storage trie updates


### PR DESCRIPTION
## Short Summary

Implement _eth_getProof_ RPC method for zeth proof collection. **NOTE: SSZ serialization is used instead of RLP.**

## What Changes Were Made
- Added `mpt.SimpleProof` to support Ethereum's proof structure, which differs from our existing `mpt.Proof`:
   - Contains only nodes without key and operation type
   - Serialized as [][]byte where each []byte is a serialized node (vs. single SSZ structure)

- Leveraged existing `GetContract` method in raw API which already returns account proof and full account storage, rather than adding a new raw API method. Implementation parses this response on the JSON-RPC side and formats it to match Ethereum's expected proof structure.

## Checklist

- [x] I have read and followed the [Contributing Guide](https://github.com/NilFoundation/nil/blob/main/CONTRIBUTION-GUIDE.md)
- [x] I have tested the changes locally
- [x] I have added relevant tests (if applicable)
- [x] I have updated documentation/comments (if applicable)
