### PR TITLE
fix relayer Makefile

### DIFF
--- a/nil/services/relayer/Makefile.inc
+++ b/nil/services/relayer/Makefile.inc
@@ -7,11 +7,11 @@ $(root_relayer)/compile_abi:
 	solc $(root_contracts)/bridge/l2/interfaces/IRelayMessage.sol --abi --overwrite -o $(root_relayer)/rollup-bridge-contracts-compiled-abi/contracts/bridge/l2/L2BridgeMessenger.sol --allow-paths .,$(root_contracts)/common/libraries --no-cbor-metadata --metadata-hash none --pretty-json
 
 .PHONY: $(root_relayer)/embed_l2_abi
-$(root_relayer)/embed_l2_abi:
+$(root_relayer)/embed_l2_abi: $(root_relayer)/compile_abi
 	cp $(root_relayer)/rollup-bridge-contracts-compiled-abi/contracts/bridge/l2/L2BridgeMessenger.sol/IRelayMessage.abi $(root_relayer)/internal/l2/L2BridgeMessenger.json.abi
 
 .PHONY: $(root_relayer)/embed_l1_abi
-$(root_relayer)/embed_l1_abi:
+$(root_relayer)/embed_l1_abi: $(root_relayer)/compile_abi
 	cp $(root_relayer)/rollup-bridge-contracts-compiled-abi/contracts/bridge/l1/L1BridgeMessenger.sol/IRelayMessage.abi $(root_relayer)/internal/l1/L1BridgeMessenger.json.abi
 
 .PHONY: $(root_relayer)/generate_l1_abi


### PR DESCRIPTION
## Short Summary

Follow up fix to the https://github.com/NilFoundation/nil/pull/839

## What Changes Were Made

<!-- List the changes introduced in this PR -->
- embed_abi targets depend on compile_abi (order of execution is not guaranteed otherwise)

## Checklist
- [x] I have read and followed the [Contributing Guide](https://github.com/NilFoundation/nil/blob/main/CONTRIBUTION-GUIDE.md)
- [x] I have tested the changes locally
