### PR TITLE
[clijs] add receipt command

### DIFF
--- a/clijs/bin/dev.js
+++ b/clijs/bin/dev.js
@@ -3,4 +3,6 @@
 // eslint-disable-next-line n/shebang
 import {execute} from '@oclif/core'
 
-await execute({development: true, dir: import.meta.url})
+await execute({development: true, dir: import.meta.url});
+
+setImmediate(() => process.exit(0));

--- a/clijs/bin/run.js
+++ b/clijs/bin/run.js
@@ -2,4 +2,6 @@
 
 import {execute} from '@oclif/core'
 
-await execute({dir: import.meta.url})
+await execute({dir: import.meta.url});
+
+setImmediate(() => process.exit(0));

--- a/clijs/src/base.ts
+++ b/clijs/src/base.ts
@@ -191,7 +191,14 @@ abstract class BaseCommand extends Command {
   }
 
   protected async finally(err: Error | undefined): Promise<unknown> {
+    this.closeConnection();
     return super.finally(err);
+  }
+
+  protected closeConnection() {
+    this.rpcClient?.closeConnection();
+    this.cometaClient?.closeConnection();
+    this.faucetClient?.closeConnection();
   }
 }
 

--- a/clijs/src/commands/block.ts
+++ b/clijs/src/commands/block.ts
@@ -31,17 +31,28 @@ export default class BlockCommand extends BaseCommand {
       throw new Error("RPC client is not initialized");
     }
 
+    let block: Block<boolean>;
+
     if (/^0x[0-9a-fA-F]+$/.test(args.blockId)) {
-      return await this.rpcClient.getBlockByHash(args.blockId as Hex);
+      block = await this.rpcClient.getBlockByHash(args.blockId as Hex);
       // biome-ignore lint/style/noUselessElse: <explanation>
     } else if (validBlockTags.includes(args.blockId as BlockTag)) {
-      return await this.rpcClient.getBlockByNumber(
+      block = await this.rpcClient.getBlockByNumber(
         args.blockId as BlockTag,
         undefined,
         flags.shardId,
       );
+    } else {
+      block = await this.rpcClient.getBlockByNumber(toHex(args.blockId), undefined, flags.shardId);
     }
-    return await this.rpcClient.getBlockByNumber(toHex(args.blockId), undefined, flags.shardId);
+
+    if (flags.quiet) {
+      this.log(block as unknown as string);
+    } else {
+      this.log("Block:", block);
+    }
+
+    return block;
   }
 }
 

--- a/clijs/src/commands/receipt.ts
+++ b/clijs/src/commands/receipt.ts
@@ -1,0 +1,33 @@
+import type { ProcessedReceipt } from "@nilfoundation/niljs";
+import { BaseCommand } from "../base.js";
+import { hexArg } from "../types.js";
+
+export default class ReceiptCommand extends BaseCommand {
+  static override description = "Retrieve a receipt from the cluster";
+
+  static override examples = ["<%= config.bin %> <%= command.id %>"];
+
+  static args = {
+    hash: hexArg({
+      name: "hash",
+      required: true,
+      description: "transaction hash",
+    }),
+  };
+
+  async run(): Promise<ProcessedReceipt | null> {
+    const { args, flags } = await this.parse(ReceiptCommand);
+
+    if (!this.rpcClient) {
+      throw new Error("RPC client is not initialized");
+    }
+
+    const res = await this.rpcClient.getTransactionReceiptByHash(args.hash);
+    if (flags.quiet) {
+      this.log(res as unknown as string);
+    } else {
+      this.log("Receipt data:", res as unknown as string);
+    }
+    return res;
+  }
+}

--- a/clijs/src/sea.ts
+++ b/clijs/src/sea.ts
@@ -11,6 +11,7 @@ import AbiCommand from "./commands/abi";
 import AbiDecode from "./commands/abi/decode";
 import AbiEncode from "./commands/abi/encode";
 import BlockCommand from "./commands/block";
+import ReceiptCommand from "./commands/receipt";
 import SmartAccountBalance from "./commands/smart-account/balance.js";
 import SmartAccountCallReadOnly from "./commands/smart-account/call-readonly";
 import SmartAccountDeploy from "./commands/smart-account/deploy.js";
@@ -39,6 +40,8 @@ export const COMMANDS: Record<string, Command.Class> = {
   keygen: Keygen,
   "keygen:new": KeygenNew,
   "keygen:new-p2p": KeygenNewP2p,
+
+  receipt: ReceiptCommand,
 
   "smart-account": SmartAccount,
   "smart-account:balance": SmartAccountBalance,

--- a/clijs/test/commands/receipt.test.ts
+++ b/clijs/test/commands/receipt.test.ts
@@ -1,0 +1,25 @@
+import type { Hex, ProcessedReceipt } from "@nilfoundation/niljs";
+import { describe, expect } from "vitest";
+import { CliTest } from "../setup.js";
+
+// To run this test you need to run the nild:
+// nild run --http-port 8529
+describe("receipt:get_receipt", () => {
+  CliTest("tests getting receipts", async ({ runCommand, smartAccount }) => {
+    const txHash = (
+      await runCommand([
+        "smart-account",
+        "send-tokens",
+        smartAccount.address,
+        "--amount",
+        "100",
+        "--feeCredit",
+        10_000_000_000_000 as unknown as string,
+      ])
+    ).result as Hex;
+    expect(txHash).toBeTruthy();
+
+    const r = (await runCommand(["receipt", txHash])).result as ProcessedReceipt;
+    expect(r.success).toBeTruthy();
+  });
+});

--- a/niljs/src/clients/BaseClient.ts
+++ b/niljs/src/clients/BaseClient.ts
@@ -36,6 +36,13 @@ class BaseClient {
   }
 
   /**
+   * Closes the connection to the network.
+   */
+  public closeConnection() {
+    this.transport.closeConnection();
+  }
+
+  /**
    * Sends a request.
    * @param requestObject The request object. It contains the request method and parameters.
    * @returns The response.

--- a/niljs/src/utils/faucet.ts
+++ b/niljs/src/utils/faucet.ts
@@ -43,4 +43,7 @@ export async function topUp({
     },
     client,
   );
+
+  client.closeConnection();
+  faucetClient.closeConnection();
 }


### PR DESCRIPTION
add receipt command to clijs. also during this I noticed that the CLI hangs for ~5-10 seconds after finishing the command logic
main reason seems to be in many promises hanging inside the node event loop. those are created during package imports or some open-rpc connections and closed only by timeout. so this PR also adds logic to exit from the process on success