### PR TITLE
[execution] Store function signatures for embedded contracts

### DIFF
--- a/nil/contracts/generate.go
+++ b/nil/contracts/generate.go
@@ -2,9 +2,9 @@ package contracts
 
 import "embed"
 
-//go:generate bash -c "solc ../../smart-contracts/contracts/*.sol --bin --abi --overwrite -o ./compiled --no-cbor-metadata --metadata-hash none"
-//go:generate bash -c "solc solidity/system/*.sol --bin --abi --overwrite -o ./compiled/system --allow-paths ./solidity/lib --no-cbor-metadata --metadata-hash none"
-//go:generate bash -c "solc solidity/tests/*.sol --allow-paths ../../ --base-path ../../ --bin --abi --overwrite -o ./compiled/tests --no-cbor-metadata --metadata-hash none"
+//go:generate bash -c "solc ../../smart-contracts/contracts/*.sol --bin --abi --hashes --overwrite -o ./compiled --no-cbor-metadata --metadata-hash none"
+//go:generate bash -c "solc solidity/system/*.sol --bin --abi --hashes --overwrite -o ./compiled/system --allow-paths ./solidity/lib --no-cbor-metadata --metadata-hash none"
+//go:generate bash -c "solc solidity/tests/*.sol --allow-paths ../../ --base-path ../../ --bin --abi --hashes --overwrite -o ./compiled/tests --no-cbor-metadata --metadata-hash none"
 //go:generate bash -c "ln -nsf ../.. @nilfoundation && solc ../../uniswap/contracts/*.sol --bin --abi --overwrite -o ./compiled/uniswap --allow-paths .,../.. --via-ir && rm @nilfoundation"
 //go:embed compiled/*
 var Fs embed.FS

--- a/nil/internal/contracts/contract.go
+++ b/nil/internal/contracts/contract.go
@@ -1,9 +1,17 @@
 package contracts
 
 import (
+	"bufio"
 	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
 
 	"github.com/NilFoundation/nil/nil/common"
+	"github.com/NilFoundation/nil/nil/common/check"
 	"github.com/NilFoundation/nil/nil/common/concurrent"
 	"github.com/NilFoundation/nil/nil/common/hexutil"
 	"github.com/NilFoundation/nil/nil/contracts"
@@ -111,4 +119,147 @@ func UnpackData(fileName, methodName string, data []byte) ([]any, error) {
 		return nil, err
 	}
 	return abiCallee.Unpack(methodName, data)
+}
+
+type Signature struct {
+	Contracts     []string
+	FuncName      string
+	FuncSignature string
+}
+
+var (
+	signaturesMap     = map[uint32]*Signature{}
+	signaturesMapOnce sync.Once
+)
+
+func initSignaturesMap() error {
+	if err := initSignaturesMapFromDir("compiled"); err != nil {
+		return err
+	}
+	if err := initSignaturesMapFromDir("compiled/tests"); err != nil {
+		return err
+	}
+	if err := initSignaturesMapFromDir("compiled/system"); err != nil { //nolint:if-return
+		return err
+	}
+	return nil
+}
+
+func initSignaturesMapFromDir(dir string) error {
+	files, err := contracts.Fs.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	for _, f := range files {
+		if f.IsDir() || !strings.HasSuffix(f.Name(), ".signatures") {
+			continue
+		}
+		file, err := contracts.Fs.Open(dir + "/" + f.Name())
+		if err != nil {
+			return fmt.Errorf("failed to open file %s: %w", f.Name(), err)
+		}
+		dirContract := strings.TrimPrefix(dir, "compiled")
+		dirContract = strings.TrimPrefix(dirContract, "/")
+		contractName := strings.TrimSuffix(f.Name(), ".signatures")
+		if dirContract != "" {
+			contractName = dirContract + "/" + strings.TrimSuffix(f.Name(), ".signatures")
+		}
+
+		scanner := bufio.NewScanner(file)
+		readingFuncs := false
+		for scanner.Scan() {
+			line := scanner.Text()
+			if readingFuncs {
+				if line == "" {
+					break
+				}
+				parts := strings.SplitN(line, ":", 2)
+				idStr := strings.TrimSpace(parts[0])
+				id, err := strconv.ParseUint(idStr, 16, 32)
+				if err != nil {
+					return fmt.Errorf("failed to parse func id %s: %w", idStr, err)
+				}
+
+				if sig, ok := signaturesMap[uint32(id)]; ok {
+					sig.Contracts = append(sig.Contracts, contractName)
+				} else {
+					signature := &Signature{}
+					signature.FuncSignature = strings.TrimSpace(parts[1])
+					parts = strings.SplitN(signature.FuncSignature, "(", 2)
+					signature.FuncName = strings.TrimSpace(parts[0])
+					signature.Contracts = append(signature.Contracts, contractName)
+					signaturesMap[uint32(id)] = signature
+				}
+			} else if line == "Function signatures:" {
+				readingFuncs = true
+			}
+		}
+	}
+	return nil
+}
+
+func GetFuncIdSignatureFromBytes(data []byte) (*Signature, error) {
+	if len(data) < 4 {
+		return nil, errors.New("data too short")
+	}
+	return GetFuncIdSignature(binary.BigEndian.Uint32(data[:4]))
+}
+
+func GetFuncIdSignature(id uint32) (*Signature, error) {
+	signaturesMapOnce.Do(func() {
+		check.PanicIfErr(initSignaturesMap())
+	})
+	if sig, ok := signaturesMap[id]; ok {
+		return sig, nil
+	}
+	return nil, fmt.Errorf("signature not found for id %x", id)
+}
+
+func DecodeCallData(method *abi.Method, calldata []byte) (string, error) {
+	if len(calldata) == 0 {
+		return "", errors.New("empty calldata")
+	}
+	if len(calldata) < 4 {
+		return "", fmt.Errorf("too short calldata: %d", len(calldata))
+	}
+
+	if method == nil {
+		sig, err := GetFuncIdSignatureFromBytes(calldata)
+		if err != nil {
+			return "", err
+		}
+		abiContract, err := GetAbi(sig.Contracts[0])
+		if err != nil {
+			return "", fmt.Errorf("failed to get abi: %w", err)
+		}
+		m, ok := abiContract.Methods[sig.FuncName]
+		if !ok {
+			return "", fmt.Errorf("method not found: %s", sig.FuncName)
+		}
+		method = &m
+	}
+
+	args, err := method.Inputs.Unpack(calldata[4:])
+	if err != nil {
+		return "", fmt.Errorf("failed to unpack arguments: %w", err)
+	}
+	res := method.Name + "("
+	adjustArg := func(arg any) string {
+		switch v := arg.(type) {
+		case []byte:
+			return hexutil.Encode(v)
+		default:
+			return fmt.Sprintf("%v", v)
+		}
+	}
+	for i, arg := range args {
+		if i > 0 {
+			res += fmt.Sprintf(", %v", adjustArg(arg))
+		} else {
+			res += adjustArg(arg)
+		}
+	}
+	res += ")"
+
+	return res, nil
 }

--- a/nil/internal/contracts/contract_test.go
+++ b/nil/internal/contracts/contract_test.go
@@ -1,0 +1,56 @@
+package contracts
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeCallData(t *testing.T) {
+	t.Parallel()
+
+	t.Run("SmartAccount", func(t *testing.T) {
+		t.Parallel()
+
+		saAbi, err := GetAbi(NameSmartAccount)
+		require.NoError(t, err)
+
+		data, err := saAbi.Pack("bounce", "test string")
+		require.NoError(t, err)
+
+		decoded, err := DecodeCallData(nil, data)
+		require.NoError(t, err)
+		require.Equal(t, "bounce(test string)", decoded)
+	})
+
+	t.Run("tests/Test", func(t *testing.T) {
+		t.Parallel()
+
+		abi, err := GetAbi(NameTest)
+		require.NoError(t, err)
+
+		data, err := abi.Pack("emitLog", "test string", true)
+		require.NoError(t, err)
+
+		decoded, err := DecodeCallData(nil, data)
+		require.NoError(t, err)
+		require.Equal(t, "emitLog(test string, true)", decoded)
+	})
+
+	t.Run("system", func(t *testing.T) {
+		t.Parallel()
+
+		abi, err := GetAbi(NameL1BlockInfo)
+		require.NoError(t, err)
+
+		data, err := abi.Pack(
+			"setL1BlockInfo", uint64(1), uint64(2), big.NewInt(3), big.NewInt(4), [32]byte{1, 2, 3, 4})
+		require.NoError(t, err)
+
+		decoded, err := DecodeCallData(nil, data)
+		require.NoError(t, err)
+		require.Equal(t,
+			"setL1BlockInfo(1, 2, 3, 4, [1 2 3 4 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0])", decoded)
+	})
+}

--- a/nil/internal/execution/state_trace.go
+++ b/nil/internal/execution/state_trace.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/NilFoundation/nil/nil/common"
 	"github.com/NilFoundation/nil/nil/common/hexutil"
+	"github.com/NilFoundation/nil/nil/internal/contracts"
 	"github.com/NilFoundation/nil/nil/internal/db"
 	"github.com/NilFoundation/nil/nil/internal/mpt"
 	"github.com/NilFoundation/nil/nil/internal/types"
@@ -68,6 +69,9 @@ func (bt *BlocksTracer) PrintTransaction(txn *types.Transaction, hash common.Has
 			}
 		}
 		fmt.Fprintln(bt.file, "]")
+	}
+	if decoded, err := contracts.DecodeCallData(nil, txn.Data); err == nil {
+		bt.Printf("decoded: %s\n", decoded)
 	}
 	if len(txn.Data) < 1024 {
 		bt.Printf("data: %s\n", hexutil.Encode(txn.Data))

--- a/nil/services/cometa/contract.go
+++ b/nil/services/cometa/contract.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/NilFoundation/nil/nil/common/hexutil"
 	"github.com/NilFoundation/nil/nil/internal/abi"
+	"github.com/NilFoundation/nil/nil/internal/contracts"
 	"github.com/NilFoundation/nil/nil/services/rpc/jsonrpc"
 )
 
@@ -170,32 +171,7 @@ func (c *Contract) DecodeCallData(calldata []byte) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("method not found in ABI: %s", methodName)
 	}
-	if len(calldata) < 4 {
-		return "", fmt.Errorf("too short calldata: %d", len(calldata))
-	}
-	args, err := method.Inputs.Unpack(calldata[4:])
-	if err != nil {
-		return "", fmt.Errorf("failed to unpack arguments: %w", err)
-	}
-	res := methodName + "("
-	adjustArg := func(arg any) string {
-		switch v := arg.(type) {
-		case []byte:
-			return hexutil.Encode(v)
-		default:
-			return fmt.Sprintf("%v", v)
-		}
-	}
-	for i, arg := range args {
-		if i > 0 {
-			res += fmt.Sprintf(", %v", adjustArg(arg))
-		} else {
-			res += adjustArg(arg)
-		}
-	}
-	res += ")"
-
-	return res, nil
+	return contracts.DecodeCallData(&method, calldata)
 }
 
 func (c *Contract) DecodeLog(log *jsonrpc.RPCLog) (string, error) {


### PR DESCRIPTION
Now all embedded contracts (those located in `ni/contracts/solidity` folder) have `func_id => signature` map.
It allows decoding their calldata from anywhere.