### PR TITLE
[types] build/usage improvements

### DIFF
--- a/nil/client/client.go
+++ b/nil/client/client.go
@@ -178,13 +178,11 @@ func CreateExternalTransaction(
 
 	// Create the transaction with the bytecode to run
 	extTxn := &types.ExternalTransaction{
-		To:                   contractAddress,
-		Data:                 bytecode,
-		Seqno:                seqno,
-		Kind:                 kind,
-		FeeCredit:            fee.FeeCredit,
-		MaxPriorityFeePerGas: fee.MaxPriorityFeePerGas,
-		MaxFeePerGas:         fee.MaxFeePerGas,
+		To:      contractAddress,
+		Data:    bytecode,
+		Seqno:   seqno,
+		Kind:    kind,
+		FeePack: fee,
 	}
 
 	if fee.FeeCredit.IsZero() {

--- a/nil/internal/collate/proposer.go
+++ b/nil/internal/collate/proposer.go
@@ -249,12 +249,10 @@ func CreateL1BlockUpdateTransaction(header *l1types.Header, txId types.Transacti
 
 	txn := &types.Transaction{
 		TransactionDigest: types.TransactionDigest{
-			Flags:                types.NewTransactionFlags(types.TransactionFlagInternal),
-			To:                   types.L1BlockInfoAddress,
-			FeeCredit:            types.GasToValue(types.DefaultMaxGasInBlock.Uint64()),
-			MaxFeePerGas:         types.MaxFeePerGasDefault,
-			MaxPriorityFeePerGas: types.Value0,
-			Data:                 calldata,
+			Flags:   types.NewTransactionFlags(types.TransactionFlagInternal),
+			To:      types.L1BlockInfoAddress,
+			FeePack: types.NewFeePackFromGas(types.DefaultMaxGasInBlock),
+			Data:    calldata,
 		},
 		TxId: txId,
 		From: types.L1BlockInfoAddress,

--- a/nil/internal/execution/execution_state_test.go
+++ b/nil/internal/execution/execution_state_test.go
@@ -419,8 +419,7 @@ func (s *SuiteExecutionState) TestTransactionStatus() {
 		txn.To = counterAddr
 		txn.Data = contracts.NewCounterAddCallData(s.T(), 47)
 		txn.Seqno = 1
-		txn.FeeCredit = toGasCredit(0)
-		txn.MaxFeePerGas = types.MaxFeePerGasDefault
+		txn.FeePack = types.NewFeePackFromGas(0)
 		txn.From = counterAddr
 		res := es.AddAndHandleTransaction(s.ctx, txn, dummyPayer{})
 		s.Equal(types.ErrorOutOfGas, res.Error.Code())
@@ -432,8 +431,7 @@ func (s *SuiteExecutionState) TestTransactionStatus() {
 		txn.To = counterAddr
 		txn.Data = []byte("wrong calldata")
 		txn.Seqno = 1
-		txn.FeeCredit = toGasCredit(1_000_000)
-		txn.MaxFeePerGas = types.MaxFeePerGasDefault
+		txn.FeePack = types.NewFeePackFromGas(1_000_000)
 		txn.From = counterAddr
 		res := es.AddAndHandleTransaction(s.ctx, txn, dummyPayer{})
 		fmt.Println(res.Error.Error())
@@ -447,8 +445,7 @@ func (s *SuiteExecutionState) TestTransactionStatus() {
 		txn.Data = contracts.NewFaucetWithdrawToCallData(s.T(),
 			types.GenerateRandomAddress(types.MainShardId), types.NewValueFromUint64(1_000))
 		txn.Seqno = 1
-		txn.FeeCredit = toGasCredit(100_000)
-		txn.MaxFeePerGas = types.MaxFeePerGasDefault
+		txn.FeePack = types.NewFeePackFromGas(100_000)
 		txn.From = faucetAddr
 		res := es.AddAndHandleTransaction(s.ctx, txn, dummyPayer{})
 		s.Equal(types.ErrorTransactionToMainShard, res.Error.Code())
@@ -461,8 +458,7 @@ func (s *SuiteExecutionState) TestTransactionStatus() {
 		txn.Data = contracts.NewFaucetWithdrawToCallData(s.T(),
 			types.GenerateRandomAddress(shardId+1), types.NewValueFromUint64(1_000))
 		txn.Seqno = 1
-		txn.FeeCredit = toGasCredit(100_000)
-		txn.MaxFeePerGas = types.MaxFeePerGasDefault
+		txn.FeePack = types.NewFeePackFromGas(100_000)
 		txn.From = faucetAddr
 		res := es.AddAndHandleTransaction(s.ctx, txn, dummyPayer{})
 		s.Equal(types.ErrorShardIdIsTooBig, res.Error.Code())
@@ -496,15 +492,14 @@ func (s *SuiteExecutionState) TestTransactionStatus() {
 		txn.To = dstAddr
 		txn.Data = contracts.NewFaucetWithdrawToCallData(s.T(), dstAddr, types.NewValueFromUint64(1_000))
 		txn.Seqno = 1
-		txn.FeeCredit = toGasCredit(100_000)
-		txn.MaxFeePerGas = types.MaxFeePerGasDefault
+		txn.FeePack = types.NewFeePackFromGas(100_000)
 		txn.From = faucetAddr
 		res := es.AddAndHandleTransaction(s.ctx, txn, dummyPayer{})
 		s.False(res.Failed())
 
 		txn = NewDeployTransaction(deployPayload, shardId, faucetAddr, 2, types.Value{})
 		txn.Flags = types.NewTransactionFlags(types.TransactionFlagDeploy)
-		txn.FeeCredit = toGasCredit(100_000_000_000_000)
+		txn.FeePack = types.NewFeePackFromGas(100_000_000_000_000)
 
 		acc, err := es.GetAccount(txn.To)
 		s.Require().NoError(err)
@@ -542,8 +537,7 @@ func (s *SuiteExecutionState) TestPrecompiles() {
 	txn.To = testAddr
 	txn.Data = []byte("wrong calldata")
 	txn.Seqno = 1
-	txn.FeeCredit = toGasCredit(1_000_000)
-	txn.MaxFeePerGas = types.MaxFeePerGasDefault
+	txn.FeePack = types.NewFeePackFromGas(1_000_000)
 	txn.From = testAddr
 
 	s.Run("testAsyncCall: success", func() {

--- a/nil/internal/execution/testaide.go
+++ b/nil/internal/execution/testaide.go
@@ -138,12 +138,11 @@ func NewDeployTransaction(payload types.DeployPayload,
 ) *types.Transaction {
 	return &types.Transaction{
 		TransactionDigest: types.TransactionDigest{
-			Flags:        types.NewTransactionFlags(types.TransactionFlagInternal, types.TransactionFlagDeploy),
-			Data:         payload.Bytes(),
-			Seqno:        seqno,
-			FeeCredit:    types.GasToValue(10_000_000),
-			To:           types.CreateAddress(shardId, payload),
-			MaxFeePerGas: types.MaxFeePerGasDefault,
+			Flags:   types.NewTransactionFlags(types.TransactionFlagInternal, types.TransactionFlagDeploy),
+			Data:    payload.Bytes(),
+			Seqno:   seqno,
+			FeePack: types.NewFeePackFromGas(10_000_000),
+			To:      types.CreateAddress(shardId, payload),
 		},
 		From:  from,
 		Value: value,
@@ -153,11 +152,10 @@ func NewDeployTransaction(payload types.DeployPayload,
 func NewExecutionTransaction(from, to types.Address, seqno types.Seqno, callData []byte) *types.Transaction {
 	return &types.Transaction{
 		TransactionDigest: types.TransactionDigest{
-			To:           to,
-			Data:         callData,
-			Seqno:        seqno,
-			FeeCredit:    DefaultGasCredit,
-			MaxFeePerGas: types.MaxFeePerGasDefault,
+			To:      to,
+			Data:    callData,
+			Seqno:   seqno,
+			FeePack: types.NewFeePackFromFeeCredit(DefaultGasCredit),
 		},
 		From: from,
 	}

--- a/nil/internal/execution/zerostate.go
+++ b/nil/internal/execution/zerostate.go
@@ -202,10 +202,10 @@ func (es *ExecutionState) GenerateZeroState(stateConfig *ZeroStateConfig) error 
 
 		mainDeployTxn := &types.Transaction{
 			TransactionDigest: types.TransactionDigest{
-				Flags:        types.NewTransactionFlags(types.TransactionFlagInternal),
-				Seqno:        0,
-				Data:         code,
-				MaxFeePerGas: types.MaxFeePerGasDefault,
+				Flags:   types.NewTransactionFlags(types.TransactionFlagInternal),
+				Seqno:   0,
+				Data:    code,
+				FeePack: types.NewFeePackFromFeeCredit(types.NewZeroValue()),
 			},
 		}
 

--- a/nil/internal/execution/zerostate_test.go
+++ b/nil/internal/execution/zerostate_test.go
@@ -90,10 +90,12 @@ func (s *SuiteZeroState) TestWithdrawFromFaucet() {
 	gasLimit := types.Gas(100_000).ToValue(types.DefaultGasPrice)
 	callTransaction := &types.Transaction{
 		TransactionDigest: types.TransactionDigest{
-			Data:         calldata,
-			To:           s.faucetAddr,
-			FeeCredit:    gasLimit,
-			MaxFeePerGas: types.MaxFeePerGasDefault,
+			Data: calldata,
+			To:   s.faucetAddr,
+			FeePack: types.FeePack{
+				FeeCredit:    gasLimit,
+				MaxFeePerGas: types.MaxFeePerGasDefault,
+			},
 		},
 		From: s.faucetAddr,
 	}

--- a/nil/internal/types/Makefile.inc
+++ b/nil/internal/types/Makefile.inc
@@ -1,29 +1,41 @@
+SSZ_TARGETS = \
+    nil/internal/types/signature_encoding.go \
+    nil/internal/types/account_encoding.go \
+    nil/internal/types/block_encoding.go \
+    nil/internal/types/collator_encoding.go \
+    nil/internal/types/log_encoding.go \
+    nil/internal/types/transaction_encoding.go \
+    nil/internal/types/receipt_encoding.go \
+    nil/internal/types/version_info_encoding.go
+
+SSZGEN := cd nil/internal/types && go run github.com/NilFoundation/fastssz/sszgen
+
 .PHONY: ssz_types
-ssz_types: nil/internal/types/signature_encoding.go nil/internal/types/account_encoding.go nil/internal/types/block_encoding.go nil/internal/types/collator_encoding.go nil/internal/types/log_encoding.go nil/internal/types/transaction_encoding.go nil/internal/types/receipt_encoding.go nil/internal/types/version_info_encoding.go nil/internal/types/error_string.go 
-
-nil/internal/types/signature_encoding.go: nil/internal/types/signature.go nil/common/length.go
-	cd nil/internal/types && go generate signature.go
-
-nil/internal/types/log_encoding.go: nil/internal/types/log.go nil/common/length.go nil/internal/types/address.go nil/common/hash.go nil/internal/types/block.go
-	cd nil/internal/types && go generate log.go
-
-nil/internal/types/receipt_encoding.go: nil/internal/types/receipt.go nil/common/length.go nil/internal/types/address.go nil/internal/types/block.go nil/internal/types/bloom.go nil/internal/types/log.go nil/common/hash.go
-	cd nil/internal/types && go generate receipt.go
-
-nil/internal/types/transaction_encoding.go: nil/internal/types/transaction.go nil/common/length.go nil/internal/types/address.go nil/internal/types/uint256.go nil/internal/types/code.go nil/internal/types/shard.go nil/internal/types/bloom.go nil/internal/types/log.go nil/common/hash.go nil/internal/types/signature.go nil/internal/types/account.go
-	cd nil/internal/types && go generate transaction.go
-
-nil/internal/types/block_encoding.go: nil/internal/types/block.go nil/common/length.go nil/internal/types/address.go nil/internal/types/uint256.go nil/internal/types/code.go nil/internal/types/shard.go nil/internal/types/bloom.go nil/internal/types/log.go nil/internal/types/transaction.go nil/common/hash.go nil/internal/types/signature.go 
-	cd nil/internal/types && go generate block.go
-
-nil/internal/types/collator_encoding.go: nil/internal/types/collator.go nil/internal/types/shard.go nil/internal/types/block.go nil/internal/types/transaction.go
-	cd nil/internal/types && go generate collator.go
-
-nil/internal/types/account_encoding.go: nil/internal/types/account.go nil/common/length.go nil/internal/types/transaction.go nil/internal/types/address.go nil/internal/types/uint256.go nil/internal/types/code.go nil/internal/types/shard.go nil/internal/types/bloom.go nil/internal/types/log.go nil/common/hash.go
-	cd nil/internal/types && go generate account.go
-
-nil/internal/types/version_info_encoding.go: nil/internal/types/version_info.go nil/common/hash.go nil/common/length.go
-	cd nil/internal/types && go generate version_info.go
+ssz_types: $(SSZ_TARGETS) nil/internal/types/error_string.go
 
 nil/internal/types/error_string.go: nil/internal/types/exec_errors.go
-	cd nil/internal/types && go generate exec_errors.go
+	cd nil/internal/types && stringer -type=ErrorCode -trimprefix=Error
+
+nil/internal/types/signature_encoding.go: nil/internal/types/signature.go nil/common/length.go
+	$(SSZGEN) --path signature.go -include ../../common/hexutil/bytes.go --objs BlsAggregateSignature
+
+nil/internal/types/log_encoding.go: nil/internal/types/log.go nil/common/length.go nil/internal/types/address.go nil/common/hash.go nil/internal/types/block.go
+	$(SSZGEN) --path log.go -include ../../common/hexutil/bytes.go,../../common/length.go,address.go,../../common/hash.go,block.go,uint256.go --objs Log,DebugLog
+
+nil/internal/types/receipt_encoding.go: nil/internal/types/receipt.go nil/common/length.go nil/internal/types/address.go nil/internal/types/block.go nil/internal/types/bloom.go nil/internal/types/log.go nil/common/hash.go nil/internal/types/error_string.go
+	$(SSZGEN) --path receipt.go -include ../../common/hexutil/bytes.go,../../common/length.go,address.go,gas.go,value.go,block.go,bloom.go,log.go,transaction.go,exec_errors.go,../../common/hash.go,uint256.go --objs Receipt
+
+nil/internal/types/transaction_encoding.go: nil/internal/types/transaction.go nil/common/length.go nil/internal/types/address.go nil/internal/types/uint256.go nil/internal/types/code.go nil/internal/types/shard.go nil/internal/types/bloom.go nil/internal/types/log.go nil/common/hash.go nil/internal/types/signature.go nil/internal/types/account.go
+	$(SSZGEN) --path transaction.go -include ../../common/hexutil/bytes.go,../../common/length.go,address.go,gas.go,value.go,code.go,shard.go,bloom.go,log.go,../../common/hash.go,signature.go,account.go,bitflags.go --objs Transaction,ExternalTransaction,InternalTransactionPayload,TransactionDigest,TransactionFlags,AsyncContext,AsyncResponsePayload
+
+nil/internal/types/block_encoding.go: nil/internal/types/block.go nil/common/length.go nil/internal/types/address.go nil/internal/types/uint256.go nil/internal/types/code.go nil/internal/types/shard.go nil/internal/types/bloom.go nil/internal/types/log.go nil/internal/types/transaction.go nil/common/hash.go nil/internal/types/signature.go nil/internal/types/signature_encoding.go
+	$(SSZGEN) --path block.go -include ../../common/hexutil/bytes.go,../../common/length.go,signature.go,address.go,code.go,shard.go,bloom.go,log.go,value.go,transaction.go,gas.go,../../common/hash.go --objs BlockData,Block,TxCountSSZ
+
+nil/internal/types/collator_encoding.go: nil/internal/types/collator.go nil/internal/types/shard.go nil/internal/types/block.go nil/internal/types/transaction.go
+	$(SSZGEN) --path collator.go -include shard.go,block.go,transaction.go --objs Neighbor,CollatorState
+
+nil/internal/types/account_encoding.go: nil/internal/types/account.go nil/common/length.go nil/internal/types/transaction.go nil/internal/types/address.go nil/internal/types/uint256.go nil/internal/types/code.go nil/internal/types/shard.go nil/internal/types/bloom.go nil/internal/types/log.go nil/common/hash.go
+	$(SSZGEN) --path account.go -include ../../common/length.go,transaction.go,address.go,value.go,code.go,shard.go,bloom.go,log.go,../../common/hash.go --objs SmartContract,TokenBalance
+
+nil/internal/types/version_info_encoding.go: nil/internal/types/version_info.go nil/common/hash.go nil/common/length.go
+	$(SSZGEN) --path version_info.go -include ../../common/hash.go,../../common/length.go --objs VersionInfo

--- a/nil/internal/types/account.go
+++ b/nil/internal/types/account.go
@@ -62,5 +62,3 @@ func (s *SmartContract) Hash() common.Hash {
 type TokensMap = map[TokenId]Value
 
 type RPCTokensMap = TokensMap
-
-//go:generate go run github.com/NilFoundation/fastssz/sszgen --path account.go -include ../../common/length.go,transaction.go,address.go,value.go,code.go,shard.go,bloom.go,log.go,../../common/hash.go --objs SmartContract,TokenBalance

--- a/nil/internal/types/block.go
+++ b/nil/internal/types/block.go
@@ -224,5 +224,3 @@ func (b *Block) VerifySignature(pubkeys []bls.PublicKey, shardId ShardId) error 
 }
 
 const InvalidDbTimestamp uint64 = math.MaxUint64
-
-//go:generate go run github.com/NilFoundation/fastssz/sszgen --path block.go -include ../../common/hexutil/bytes.go,../../common/length.go,signature.go,address.go,code.go,shard.go,bloom.go,log.go,value.go,transaction.go,gas.go,../../common/hash.go --objs BlockData,Block,TxCountSSZ

--- a/nil/internal/types/collator.go
+++ b/nil/internal/types/collator.go
@@ -12,5 +12,3 @@ type Neighbor struct {
 type CollatorState struct {
 	Neighbors []Neighbor `json:"neighbors" ssz-max:"10000"`
 }
-
-//go:generate go run github.com/NilFoundation/fastssz/sszgen --path collator.go -include shard.go,block.go,transaction.go --objs Neighbor,CollatorState

--- a/nil/internal/types/exec_errors.go
+++ b/nil/internal/types/exec_errors.go
@@ -321,5 +321,3 @@ func (e VmVerboseError) Error() string {
 func (e VmVerboseError) Unwrap() error {
 	return &e.VmError
 }
-
-//go:generate stringer -type=ErrorCode -trimprefix=Error

--- a/nil/internal/types/log.go
+++ b/nil/internal/types/log.go
@@ -54,5 +54,3 @@ func NewDebugLog(message []byte, data []Uint256) (*DebugLog, error) {
 func (l *Log) TopicsNum() int {
 	return len(l.Topics)
 }
-
-//go:generate go run github.com/NilFoundation/fastssz/sszgen --path log.go -include ../../common/hexutil/bytes.go,../../common/length.go,address.go,../../common/hash.go,block.go,uint256.go --objs Log,DebugLog

--- a/nil/internal/types/receipt.go
+++ b/nil/internal/types/receipt.go
@@ -24,5 +24,3 @@ type Receipt struct {
 func (r *Receipt) Hash() common.Hash {
 	return ToShardedHash(common.MustKeccakSSZ(r), ShardIdFromHash(r.TxnHash))
 }
-
-//go:generate go run github.com/NilFoundation/fastssz/sszgen --path receipt.go -include ../../common/hexutil/bytes.go,../../common/length.go,address.go,gas.go,value.go,block.go,bloom.go,log.go,transaction.go,exec_errors.go,../../common/hash.go,uint256.go --objs Receipt

--- a/nil/internal/types/signature.go
+++ b/nil/internal/types/signature.go
@@ -18,6 +18,3 @@ type BlsAggregateSignature struct {
 func (b BlsAggregateSignature) String() string {
 	return fmt.Sprintf("BlsAggregateSignature{Sig: %x, Mask: %x}", b.Sig, b.Mask)
 }
-
-// Generating this manually because fastssz purely supports nested structures
-//go:generate go run github.com/NilFoundation/fastssz/sszgen --path signature.go -include ../../common/hexutil/bytes.go --objs BlsAggregateSignature

--- a/nil/internal/types/transaction.go
+++ b/nil/internal/types/transaction.go
@@ -610,8 +610,6 @@ func (m TransactionFlags) IsResponse() bool {
 	return m.GetBit(TransactionFlagResponse)
 }
 
-//go:generate go run github.com/NilFoundation/fastssz/sszgen --path transaction.go -include ../../common/hexutil/bytes.go,../../common/length.go,address.go,gas.go,value.go,code.go,shard.go,bloom.go,log.go,../../common/hash.go,signature.go,account.go,bitflags.go --objs Transaction,ExternalTransaction,InternalTransactionPayload,TransactionDigest,TransactionFlags,EvmState,AsyncContext,AsyncResponsePayload
-
 type TxnWithHash struct {
 	*Transaction
 	hash common.Hash

--- a/nil/internal/types/version_info.go
+++ b/nil/internal/types/version_info.go
@@ -47,5 +47,3 @@ func NewVersionInfo() *VersionInfo {
 	}
 	return &VersionInfo{Version: common.KeccakHash(res)}
 }
-
-//go:generate go run github.com/NilFoundation/fastssz/sszgen --path version_info.go -include ../../common/hash.go,../../common/length.go --objs VersionInfo

--- a/nil/services/faucet/jsonrpc.go
+++ b/nil/services/faucet/jsonrpc.go
@@ -85,12 +85,11 @@ func (c *APIImpl) TopUpViaFaucet(
 		return common.EmptyHash, err
 	}
 	extTxn := &types.ExternalTransaction{
-		To:           faucetAddress,
-		Data:         callData,
-		Seqno:        seqno,
-		Kind:         types.ExecutionTransactionKind,
-		FeeCredit:    types.GasToValue(100_000),
-		MaxFeePerGas: types.MaxFeePerGasDefault,
+		To:      faucetAddress,
+		Data:    callData,
+		Seqno:   seqno,
+		Kind:    types.ExecutionTransactionKind,
+		FeePack: types.NewFeePackFromGas(100_000),
 	}
 
 	data, err := extTxn.MarshalSSZ()

--- a/nil/services/rpc/jsonrpc/txpool_api_test.go
+++ b/nil/services/rpc/jsonrpc/txpool_api_test.go
@@ -26,11 +26,13 @@ func newTransaction(address types.Address, seqno types.Seqno, priorityFee uint64
 	return &types.Transaction{
 		From: address,
 		TransactionDigest: types.TransactionDigest{
-			To:                   address,
-			Seqno:                seqno,
-			MaxPriorityFeePerGas: types.NewValueFromUint64(priorityFee),
-			MaxFeePerGas:         types.NewValueFromUint64(defaultMaxFee),
-			Data:                 code,
+			To:    address,
+			Seqno: seqno,
+			FeePack: types.FeePack{
+				MaxPriorityFeePerGas: types.NewValueFromUint64(priorityFee),
+				MaxFeePerGas:         types.NewValueFromUint64(defaultMaxFee),
+			},
+			Data: code,
 		},
 	}
 }

--- a/nil/services/rpc/jsonrpc/types.go
+++ b/nil/services/rpc/jsonrpc/types.go
@@ -31,22 +31,20 @@ type (
 // @componentprop Value value string true "The transaction value."
 // @componentprop Token value array true "Token values."
 type Transaction struct {
-	Flags                types.TransactionFlags `json:"flags"`
-	RequestId            uint64                 `json:"requestId"`
-	Data                 hexutil.Bytes          `json:"data"`
-	From                 types.Address          `json:"from"`
-	FeeCredit            types.Value            `json:"feeCredit,omitempty"`
-	MaxPriorityFeePerGas types.Value            `json:"maxPriorityFeePerGas,omitempty"`
-	MaxFeePerGas         types.Value            `json:"maxFeePerGas,omitempty"`
-	Hash                 common.Hash            `json:"hash"`
-	Seqno                hexutil.Uint64         `json:"seqno"`
-	To                   types.Address          `json:"to"`
-	RefundTo             types.Address          `json:"refundTo"`
-	BounceTo             types.Address          `json:"bounceTo"`
-	Value                types.Value            `json:"value"`
-	Token                []types.TokenBalance   `json:"token,omitempty"`
-	ChainID              types.ChainId          `json:"chainId,omitempty"`
-	Signature            types.Signature        `json:"signature"`
+	types.FeePack
+	Flags     types.TransactionFlags `json:"flags"`
+	RequestId uint64                 `json:"requestId"`
+	Data      hexutil.Bytes          `json:"data"`
+	From      types.Address          `json:"from"`
+	Hash      common.Hash            `json:"hash"`
+	Seqno     hexutil.Uint64         `json:"seqno"`
+	To        types.Address          `json:"to"`
+	RefundTo  types.Address          `json:"refundTo"`
+	BounceTo  types.Address          `json:"bounceTo"`
+	Value     types.Value            `json:"value"`
+	Token     []types.TokenBalance   `json:"token,omitempty"`
+	ChainID   types.ChainId          `json:"chainId,omitempty"`
+	Signature types.Signature        `json:"signature"`
 }
 
 // @component RPCInTransaction rpcInTransaction object "The transaction whose information is requested."
@@ -321,22 +319,20 @@ func (re *RPCReceipt) IsCommitted() bool {
 
 func NewTransaction(transaction *types.Transaction) *Transaction {
 	return &Transaction{
-		Flags:                transaction.Flags,
-		RequestId:            transaction.RequestId,
-		Data:                 hexutil.Bytes(transaction.Data),
-		From:                 transaction.From,
-		FeeCredit:            transaction.FeeCredit,
-		MaxPriorityFeePerGas: transaction.MaxPriorityFeePerGas,
-		MaxFeePerGas:         transaction.MaxFeePerGas,
-		Hash:                 transaction.Hash(),
-		Seqno:                hexutil.Uint64(transaction.Seqno),
-		To:                   transaction.To,
-		RefundTo:             transaction.RefundTo,
-		BounceTo:             transaction.BounceTo,
-		Value:                transaction.Value,
-		Token:                transaction.Token,
-		ChainID:              transaction.ChainId,
-		Signature:            transaction.Signature,
+		Flags:     transaction.Flags,
+		RequestId: transaction.RequestId,
+		Data:      hexutil.Bytes(transaction.Data),
+		From:      transaction.From,
+		FeePack:   transaction.FeePack,
+		Hash:      transaction.Hash(),
+		Seqno:     hexutil.Uint64(transaction.Seqno),
+		To:        transaction.To,
+		RefundTo:  transaction.RefundTo,
+		BounceTo:  transaction.BounceTo,
+		Value:     transaction.Value,
+		Token:     transaction.Token,
+		ChainID:   transaction.ChainId,
+		Signature: transaction.Signature,
 	}
 }
 

--- a/nil/services/rpc/types/types.go
+++ b/nil/services/rpc/types/types.go
@@ -77,14 +77,12 @@ func (args CallArgs) ToTransaction() (*types.Transaction, error) {
 	}
 	return &types.Transaction{
 		TransactionDigest: types.TransactionDigest{
-			Flags:                args.Flags,
-			ChainId:              types.DefaultChainId,
-			Seqno:                args.Seqno,
-			FeeCredit:            args.Fee.FeeCredit,
-			To:                   args.To,
-			Data:                 data,
-			MaxPriorityFeePerGas: args.Fee.MaxPriorityFeePerGas,
-			MaxFeePerGas:         args.Fee.MaxFeePerGas,
+			Flags:   args.Flags,
+			ChainId: types.DefaultChainId,
+			Seqno:   args.Seqno,
+			FeePack: args.Fee,
+			To:      args.To,
+			Data:    data,
 		},
 		From:  txnFrom,
 		Value: args.Value,

--- a/nil/services/synccommittee/internal/testaide/blocks.go
+++ b/nil/services/synccommittee/internal/testaide/blocks.go
@@ -59,17 +59,19 @@ func RandomShardId() types.ShardId {
 func NewRpcInTransaction() *jsonrpc.RPCInTransaction {
 	return &jsonrpc.RPCInTransaction{
 		Transaction: jsonrpc.Transaction{
-			Flags:                types.NewTransactionFlags(types.TransactionFlagInternal, types.TransactionFlagRefund),
-			Seqno:                10,
-			From:                 types.HexToAddress("0x0002F09EC9F5cCA264eba822BB887f5c900c6e71"),
-			To:                   types.HexToAddress("0x0002F09EC9F5cCA264eba822BB887f5c900c6e72"),
-			Value:                types.NewValue(uint256.NewInt(1000)),
-			Data:                 []byte{10, 20, 30, 40},
-			FeeCredit:            types.NewValue(uint256.NewInt(100)),
-			MaxPriorityFeePerGas: types.NewValue(uint256.NewInt(10)),
-			MaxFeePerGas:         types.NewValue(uint256.NewInt(20)),
-			ChainID:              1234,
-			Signature:            hexutil.Bytes{10, 20, 30, 40},
+			Flags: types.NewTransactionFlags(types.TransactionFlagInternal, types.TransactionFlagRefund),
+			Seqno: 10,
+			From:  types.HexToAddress("0x0002F09EC9F5cCA264eba822BB887f5c900c6e71"),
+			To:    types.HexToAddress("0x0002F09EC9F5cCA264eba822BB887f5c900c6e72"),
+			Value: types.NewValue(uint256.NewInt(1000)),
+			Data:  []byte{10, 20, 30, 40},
+			FeePack: types.FeePack{
+				FeeCredit:            types.NewValue(uint256.NewInt(100)),
+				MaxPriorityFeePerGas: types.NewValue(uint256.NewInt(10)),
+				MaxFeePerGas:         types.NewValue(uint256.NewInt(20)),
+			},
+			ChainID:   1234,
+			Signature: hexutil.Bytes{10, 20, 30, 40},
 		},
 	}
 }

--- a/nil/services/synccommittee/prover/tracer/tracer_mock_client_test.go
+++ b/nil/services/synccommittee/prover/tracer/tracer_mock_client_test.go
@@ -105,9 +105,11 @@ func (s *TracerMockClientTestSuite) addContract(addr types.Address, code []byte)
 func (s *TracerMockClientTestSuite) addCallContractTransaction(addr types.Address) {
 	s.inMsgs = append(s.inMsgs, &types.Transaction{
 		TransactionDigest: types.TransactionDigest{
-			To:           addr,
-			FeeCredit:    types.GasToValue(1000000),
-			MaxFeePerGas: types.DefaultGasPrice,
+			To: addr,
+			FeePack: types.FeePack{
+				FeeCredit:    types.GasToValue(1000000),
+				MaxFeePerGas: types.DefaultGasPrice,
+			},
 		},
 		From: s.smartAccount,
 	})
@@ -248,9 +250,9 @@ func (s *TracerMockClientTestSuite) simpleContractCallTrace(code []byte) *Execut
 
 	tx := types.Transaction{
 		TransactionDigest: types.TransactionDigest{
-			Flags:     types.TransactionFlagsFromKind(true, types.ExecutionTransactionKind),
-			To:        types.ShardAndHexToAddress(s.shardId, "0x1234"),
-			FeeCredit: types.NewValueFromUint64(100500100500),
+			Flags:   types.TransactionFlagsFromKind(true, types.ExecutionTransactionKind),
+			To:      types.ShardAndHexToAddress(s.shardId, "0x1234"),
+			FeePack: types.NewFeePackFromGas(100500100500),
 		},
 		From: s.smartAccount,
 	}

--- a/nil/services/txnpool/txnpool_test.go
+++ b/nil/services/txnpool/txnpool_test.go
@@ -32,10 +32,12 @@ var defaultBaseFee = types.NewValueFromUint64(100)
 func newTransaction(address types.Address, seqno types.Seqno, priorityFee uint64) *types.Transaction {
 	return &types.Transaction{
 		TransactionDigest: types.TransactionDigest{
-			To:                   address,
-			Seqno:                seqno,
-			MaxPriorityFeePerGas: types.NewValueFromUint64(priorityFee),
-			MaxFeePerGas:         types.NewValueFromUint64(defaultMaxFee),
+			To:    address,
+			Seqno: seqno,
+			FeePack: types.FeePack{
+				MaxPriorityFeePerGas: types.NewValueFromUint64(priorityFee),
+				MaxFeePerGas:         types.NewValueFromUint64(defaultMaxFee),
+			},
 		},
 	}
 }
@@ -43,10 +45,12 @@ func newTransaction(address types.Address, seqno types.Seqno, priorityFee uint64
 func newTransaction2(address types.Address, seqno types.Seqno, priorityFee, maxFee, value uint64) *types.Transaction {
 	return &types.Transaction{
 		TransactionDigest: types.TransactionDigest{
-			To:                   address,
-			Seqno:                seqno,
-			MaxPriorityFeePerGas: types.NewValueFromUint64(priorityFee),
-			MaxFeePerGas:         types.NewValueFromUint64(maxFee),
+			To:    address,
+			Seqno: seqno,
+			FeePack: types.FeePack{
+				MaxPriorityFeePerGas: types.NewValueFromUint64(priorityFee),
+				MaxFeePerGas:         types.NewValueFromUint64(maxFee),
+			},
 		},
 		Value: types.NewValueFromUint64(value),
 	}

--- a/nil/tests/basic/basic_test.go
+++ b/nil/tests/basic/basic_test.go
@@ -154,11 +154,10 @@ func (s *SuiteRpc) TestRpcContractSendTransaction() {
 			callerSeqno, err := s.Client.GetTransactionCount(s.Context, callerAddr, "pending")
 			s.Require().NoError(err)
 			callCallerMethod := &types.ExternalTransaction{
-				Seqno:        callerSeqno,
-				To:           callerAddr,
-				Data:         callData,
-				FeeCredit:    s.GasToValue(feeCredit),
-				MaxFeePerGas: types.MaxFeePerGasDefault,
+				Seqno:   callerSeqno,
+				To:      callerAddr,
+				Data:    callData,
+				FeePack: types.NewFeePackFromGas(types.Gas(feeCredit)),
 			}
 			s.Require().NoError(callCallerMethod.Sign(execution.MainPrivateKey))
 			hash, err = s.Client.SendTransaction(s.Context, callCallerMethod)
@@ -406,12 +405,11 @@ func (s *SuiteRpc) TestRpcCallWithTransactionSend() {
 
 	s.Run("Send raw external transaction", func() {
 		extTxn := &types.ExternalTransaction{
-			To:           smartAccountAddr,
-			Data:         extPayload,
-			Seqno:        callerSeqno,
-			Kind:         types.ExecutionTransactionKind,
-			FeeCredit:    s.GasToValue(100_000),
-			MaxFeePerGas: types.MaxFeePerGasDefault,
+			To:      smartAccountAddr,
+			Data:    extPayload,
+			Seqno:   callerSeqno,
+			Kind:    types.ExecutionTransactionKind,
+			FeePack: types.NewFeePackFromGas(100_000),
 		}
 
 		extBytecode, err := extTxn.MarshalSSZ()

--- a/nil/tests/modifiers/rpc_modifiers_test.go
+++ b/nil/tests/modifiers/rpc_modifiers_test.go
@@ -78,11 +78,10 @@ func (s *SuiteModifiersRpc) TestInternalIncorrect() {
 	s.Require().NoError(err)
 
 	transactionToSend := &types.ExternalTransaction{
-		Seqno:        seqno,
-		Data:         internalFuncCalldata,
-		To:           s.testAddr,
-		FeeCredit:    s.GasToValue(100_000),
-		MaxFeePerGas: types.MaxFeePerGasDefault,
+		Seqno:   seqno,
+		Data:    internalFuncCalldata,
+		To:      s.testAddr,
+		FeePack: types.NewFeePackFromGas(100_000),
 	}
 	s.Require().NoError(transactionToSend.Sign(s.smartAccountPrivateKey))
 	txnHash, err := s.Client.SendTransaction(s.Context, transactionToSend)
@@ -109,11 +108,10 @@ func (s *SuiteModifiersRpc) TestExternalCorrect() {
 	s.Require().NoError(err)
 
 	transactionToSend := &types.ExternalTransaction{
-		Seqno:        seqno,
-		Data:         internalFuncCalldata,
-		To:           s.testAddr,
-		FeeCredit:    s.GasToValue(100_000),
-		MaxFeePerGas: types.MaxFeePerGasDefault,
+		Seqno:   seqno,
+		Data:    internalFuncCalldata,
+		To:      s.testAddr,
+		FeePack: types.NewFeePackFromGas(100_000),
 	}
 	s.Require().NoError(transactionToSend.Sign(s.smartAccountPrivateKey))
 	txnHash, err := s.Client.SendTransaction(s.Context, transactionToSend)
@@ -140,11 +138,10 @@ func (s *SuiteModifiersRpc) TestExternalSyncCall() {
 	s.Require().NoError(err)
 
 	transactionToSend := &types.ExternalTransaction{
-		Seqno:        seqno,
-		Data:         internalFuncCalldata,
-		To:           s.testAddr,
-		FeeCredit:    s.GasToValue(100_000),
-		MaxFeePerGas: types.MaxFeePerGasDefault,
+		Seqno:   seqno,
+		Data:    internalFuncCalldata,
+		To:      s.testAddr,
+		FeePack: types.NewFeePackFromGas(100_000),
 	}
 	txnHash, err := s.Client.SendTransaction(s.Context, transactionToSend)
 	s.Require().NoError(err)
@@ -161,11 +158,10 @@ func (s *SuiteModifiersRpc) TestInternalSyncCall() {
 	s.Require().NoError(err)
 
 	transactionToSend := &types.ExternalTransaction{
-		Seqno:        seqno,
-		Data:         internalFuncCalldata,
-		To:           s.testAddr,
-		FeeCredit:    s.GasToValue(100_000),
-		MaxFeePerGas: types.MaxFeePerGasDefault,
+		Seqno:   seqno,
+		Data:    internalFuncCalldata,
+		To:      s.testAddr,
+		FeePack: types.NewFeePackFromGas(100_000),
 	}
 	txnHash, err := s.Client.SendTransaction(s.Context, transactionToSend)
 	s.Require().NoError(err)

--- a/nil/tests/regression/regression_test.go
+++ b/nil/tests/regression/regression_test.go
@@ -159,13 +159,11 @@ func (s *SuiteRegression) TestInsufficientFundsIncExtSeqno() {
 	fee := types.NewFeePackFromGas(100_000_000_000_000_000)
 
 	txn := &types.ExternalTransaction{
-		Kind:                 types.ExecutionTransactionKind,
-		To:                   s.testAddress,
-		Data:                 calldata,
-		Seqno:                seqno,
-		FeeCredit:            fee.FeeCredit,
-		MaxFeePerGas:         fee.MaxFeePerGas,
-		MaxPriorityFeePerGas: fee.MaxPriorityFeePerGas,
+		Kind:    types.ExecutionTransactionKind,
+		To:      s.testAddress,
+		Data:    calldata,
+		Seqno:   seqno,
+		FeePack: fee,
 	}
 
 	txHash, err := s.Client.SendTransaction(s.T().Context(), txn)
@@ -211,13 +209,11 @@ func (s *SuiteRegression) TestInsufficientFundsDeploy() {
 
 	fee := types.NewFeePackFromGas(100_000_000_000_000_000)
 	txn := &types.ExternalTransaction{
-		Kind:                 types.DeployTransactionKind,
-		To:                   addr,
-		Data:                 deployPayload.Bytes(),
-		Seqno:                0,
-		FeeCredit:            fee.FeeCredit,
-		MaxFeePerGas:         fee.MaxFeePerGas,
-		MaxPriorityFeePerGas: fee.MaxPriorityFeePerGas,
+		Kind:    types.DeployTransactionKind,
+		To:      addr,
+		Data:    deployPayload.Bytes(),
+		Seqno:   0,
+		FeePack: fee,
 	}
 
 	txHash, err = s.Client.SendTransaction(s.T().Context(), txn)
@@ -254,13 +250,11 @@ func (s *SuiteRegression) TestUnsuccessfulDeployWithGasUsed() {
 
 	fee := types.NewFeePackFromGas(1_000)
 	txn := &types.ExternalTransaction{
-		Kind:                 types.DeployTransactionKind,
-		To:                   addr,
-		Data:                 deployPayload.Bytes(),
-		Seqno:                0,
-		FeeCredit:            fee.FeeCredit,
-		MaxFeePerGas:         fee.MaxFeePerGas,
-		MaxPriorityFeePerGas: fee.MaxPriorityFeePerGas,
+		Kind:    types.DeployTransactionKind,
+		To:      addr,
+		Data:    deployPayload.Bytes(),
+		Seqno:   0,
+		FeePack: fee,
 	}
 
 	txHash, err = s.Client.SendTransaction(s.T().Context(), txn)

--- a/nix/nil.nix
+++ b/nix/nil.nix
@@ -127,6 +127,6 @@ buildGo124Module rec {
     export GOMODCACHE=/tmp/${vendorHash}/go/mod/cache
     chmod -R u+w vendor
     mkdir -p ~/.solc-select/artifacts/solc-0.8.28
-    ln -f -s ${solc}/bin/solc ~/.solc-select/artifacts/solc-0.8.28/solc-0.8.28  
+    ln -f -s ${solc}/bin/solc ~/.solc-select/artifacts/solc-0.8.28/solc-0.8.28
   '';
 }

--- a/uniswap/contracts/UniswapV2Router01.sol
+++ b/uniswap/contracts/UniswapV2Router01.sol
@@ -65,7 +65,7 @@ contract UniswapV2Router01 is IUniswapV2Router01, NilTokenBase {
         tokensToSend[0].amount = amountA;
         tokensToSend[1].id = tokens[1].id;
         tokensToSend[1].amount = amountA;
-        (bool result, bytes memory __) = smartCall(
+        (bool result, ) = smartCall(
             pair,
             tokensToSend,
             abi.encodeWithSignature("mint(address)", to)


### PR DESCRIPTION
This patch set contains two improvements:
  * Reducing code duplication via reusing FeePack structure
  * Replacing "go:generate" directives to Makefile usage (just to support only one build system and also it will be useful in future when we will change SSZ to RLP encoding). 