### PR TITLE
[GH-#] Check stdout in tests

### DIFF
--- a/clijs/src/commands/block.ts
+++ b/clijs/src/commands/block.ts
@@ -35,7 +35,6 @@ export default class BlockCommand extends BaseCommand {
 
     if (/^0x[0-9a-fA-F]+$/.test(args.blockId)) {
       block = await this.rpcClient.getBlockByHash(args.blockId as Hex);
-      // biome-ignore lint/style/noUselessElse: <explanation>
     } else if (validBlockTags.includes(args.blockId as BlockTag)) {
       block = await this.rpcClient.getBlockByNumber(
         args.blockId as BlockTag,

--- a/clijs/src/commands/receipt.ts
+++ b/clijs/src/commands/receipt.ts
@@ -23,10 +23,15 @@ export default class ReceiptCommand extends BaseCommand {
     }
 
     const res = await this.rpcClient.getTransactionReceiptByHash(args.hash);
+    const receiptJson = JSON.stringify(
+      res,
+      (k, v) => (typeof v === "bigint" ? v.toString() : v),
+      2,
+    );
     if (flags.quiet) {
-      this.log(res as unknown as string);
+      this.log(receiptJson);
     } else {
-      this.log("Receipt data:", res as unknown as string);
+      this.log("Receipt data:", receiptJson);
     }
     return res;
   }

--- a/clijs/test/commands/receipt.test.ts
+++ b/clijs/test/commands/receipt.test.ts
@@ -19,7 +19,20 @@ describe("receipt:get_receipt", () => {
     ).result as Hex;
     expect(txHash).toBeTruthy();
 
-    const r = (await runCommand(["receipt", txHash])).result as ProcessedReceipt;
-    expect(r.success).toBeTruthy();
+    {
+      const { result, stdout } = await runCommand(["receipt", txHash]);
+      expect((result as ProcessedReceipt).success).toBeTruthy();
+      expect(stdout).to.contains("Receipt data: ");
+      expect(JSON.parse(stdout.substring("Receipt data: ".length)).transactionHash).to.equal(
+        txHash,
+      );
+    }
+
+    {
+      const { result, stdout } = await runCommand(["receipt", "-q", txHash]);
+      expect((result as ProcessedReceipt).success).toBeTruthy();
+      expect(stdout).to.not.contains("Receipt data: ");
+      expect(JSON.parse(stdout).transactionHash).to.equal(txHash);
+    }
   });
 });

--- a/clijs/vitest.config.ts
+++ b/clijs/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["src/**/*.test.ts", "test/**/*.test.ts"],
+    disableConsoleIntercept: true,
     hookTimeout: 20_000,
     testTimeout: 40_000,
     globals: true,


### PR DESCRIPTION
Enable `disableConsoleIntercept` according to the [documentation](https://www.npmjs.com/package/@oclif/test) and check the output of the command.
Also, the receipt itself is now output in JSON format instead of JavaScript object literal.