### PR TITLE
start nild binary inside clijs tests

### DIFF
--- a/clijs/test/commands/abi/encode-decode.test.ts
+++ b/clijs/test/commands/abi/encode-decode.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect } from "vitest";
 import { CliTest } from "../../setup.js";
 
-// To run this test you need to run the nild:
-// nild run --http-port 8529
-// TODO: Setup nild automatically before running the tests
 describe("abi:encode-decode", () => {
   CliTest("tests abi encoding and decoding", async ({ runCommand }) => {
     const encoded = (

--- a/clijs/test/commands/block.test.ts
+++ b/clijs/test/commands/block.test.ts
@@ -2,9 +2,6 @@ import type { Block } from "@nilfoundation/niljs";
 import { describe, expect } from "vitest";
 import { CliTest } from "../setup.js";
 
-// To run this test you need to run the nild:
-// nild run --http-port 8529
-// TODO: Setup nild automatically before running the tests
 describe("block:get blocks", () => {
   CliTest("tests getting blocks", async ({ runCommand }) => {
     const block1 = (await runCommand(["block", "latest", "-s", "1"])).result as Block<boolean>;

--- a/clijs/test/commands/receipt.test.ts
+++ b/clijs/test/commands/receipt.test.ts
@@ -2,8 +2,6 @@ import type { Hex, ProcessedReceipt } from "@nilfoundation/niljs";
 import { describe, expect } from "vitest";
 import { CliTest } from "../setup.js";
 
-// To run this test you need to run the nild:
-// nild run --http-port 8529
 describe("receipt:get_receipt", () => {
   CliTest("tests getting receipts", async ({ runCommand, smartAccount }) => {
     const txHash = (

--- a/clijs/test/commands/smart-account/balance.test.ts
+++ b/clijs/test/commands/smart-account/balance.test.ts
@@ -3,9 +3,6 @@ import ConfigManager from "../../../src/common/config.js";
 import { ConfigKeys } from "../../../src/common/config.js";
 import { CliTest } from "../../setup.js";
 
-// To run this test you need to run the nild:
-// nild run --http-port 8529
-// TODO: Setup nild automatically before running the tests
 describe("smart-account:balance", () => {
   CliTest("runs smart-account:balance cmd", async ({ cfgPath, runCommand }) => {
     const { result } = await runCommand(["smart-account", "new"]);

--- a/clijs/test/commands/smart-account/deploy.test.ts
+++ b/clijs/test/commands/smart-account/deploy.test.ts
@@ -2,9 +2,6 @@ import type { Hex } from "@nilfoundation/niljs";
 import { describe, expect } from "vitest";
 import { CliTest } from "../../setup.js";
 
-// To run this test you need to run the nild:
-// nild run --http-port 8529
-// TODO: Setup nild automatically before running the tests
 describe("smart-account:deploy", () => {
   CliTest("tests smart account deploy and send-transaction", async ({ runCommand }) => {
     const smartAccountAddress = (await runCommand(["smart-account", "new"])).result as Hex;

--- a/clijs/test/commands/smart-account/estimate.test.ts
+++ b/clijs/test/commands/smart-account/estimate.test.ts
@@ -2,9 +2,6 @@ import type { Hex } from "@nilfoundation/niljs";
 import { describe, expect } from "vitest";
 import { CliTest } from "../../setup.js";
 
-// To run this test you need to run the nild:
-// nild run --http-port 8529
-// TODO: Setup nild automatically before running the tests
 describe("smart-account:estimate", () => {
   CliTest("tests smart account deploy and estimate tx", async ({ runCommand }) => {
     const smartAccountAddress = (await runCommand(["smart-account", "new"])).result as Hex;

--- a/clijs/test/commands/smart-account/new.test.ts
+++ b/clijs/test/commands/smart-account/new.test.ts
@@ -3,9 +3,6 @@ import ConfigManager from "../../../src/common/config.js";
 import { ConfigKeys } from "../../../src/common/config.js";
 import { CliTest } from "../../setup.js";
 
-// To run this test you need to run the nild:
-// nild run --http-port 8529
-// TODO: Setup nild automatically before running the tests
 describe("smart-account:new", () => {
   CliTest("runs smart-account:new cmd", async ({ cfgPath, runCommand }) => {
     const { result } = await runCommand(["smart-account", "new"]);

--- a/clijs/test/commands/smart-account/send-token.test.ts
+++ b/clijs/test/commands/smart-account/send-token.test.ts
@@ -2,9 +2,6 @@ import type { Hex } from "@nilfoundation/niljs";
 import { describe, expect } from "vitest";
 import { CliTest } from "../../setup.js";
 
-// To run this test you need to run the nild:
-// nild run --http-port 8529
-// TODO: Setup nild automatically before running the tests
 describe("smart-account:send-token", () => {
   CliTest("tests smart account send tokens", async ({ runCommand }) => {
     const smartAccountAddress = (await runCommand(["smart-account", "new"])).result as Hex;

--- a/clijs/test/globalSetup.ts
+++ b/clijs/test/globalSetup.ts
@@ -1,0 +1,46 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { closeSync, openSync } from "node:fs";
+import { testEnv } from "./testEnv.js";
+
+interface Nild {
+  pid: number;
+  process: ChildProcess;
+  logFd: number;
+}
+
+let nildInstance: Nild;
+
+export async function setup() {
+  console.log("launching nild:", testEnv.nild);
+  const logFd = openSync("nild.log", "w");
+  const nild = spawn(testEnv.nild, ["run", "--http-port", "8529", "--collator-tick-ms", "100"], {
+    stdio: ["ignore", logFd, logFd],
+  });
+
+  await new Promise((resolve, reject) => {
+    nild.once("error", reject);
+    nild.once("spawn", resolve);
+  });
+
+  if (!nild.pid) {
+    throw new Error("Failed to start nild");
+  }
+
+  nildInstance = {
+    pid: nild.pid,
+    process: nild,
+    logFd: logFd,
+  };
+}
+
+export async function teardown() {
+  console.log("stopping nild");
+
+  nildInstance.process.kill("SIGTERM");
+  await new Promise<void>((resolve) => {
+    nildInstance.process.once("exit", () => {
+      closeSync(nildInstance.logFd);
+      resolve();
+    });
+  });
+}

--- a/clijs/test/testEnv.ts
+++ b/clijs/test/testEnv.ts
@@ -1,10 +1,12 @@
 const defaultRpcEndpoint = "http://127.0.0.1:8529";
 const defaultFaucetServiceEndpoint = "http://127.0.0.1:8529";
 const defaultCometaServiceEndpoint = "http://127.0.0.1:8529";
+const defaultNildBinary = "nild";
 const testEnv = {
   endpoint: process.env.RPC_ENDPOINT ?? defaultRpcEndpoint,
   faucetServiceEndpoint: process.env.FAUCET_SERVICE_ENDPOINT ?? defaultFaucetServiceEndpoint,
   cometaServiceEndpoint: process.env.COMETA_SERVICE_ENDPOINT ?? defaultCometaServiceEndpoint,
+  nild: process.env.NILD ?? defaultNildBinary,
 } as const;
 
 export { testEnv };

--- a/clijs/vitest.config.ts
+++ b/clijs/vitest.config.ts
@@ -14,5 +14,8 @@ export default defineConfig({
       provider: "v8",
       reportOnFailure: true,
     },
+    globalSetup: [
+      "./test/globalSetup.ts",
+    ],
   },
 });

--- a/nix/clijs.nix
+++ b/nix/clijs.nix
@@ -75,7 +75,11 @@ stdenv.mkDerivation rec {
 
     echo "smoke check passed"
 
-    env NILD=nild pnpm run test:ci
+    env NILD=nild pnpm run test:ci || {
+      echo "tests failed. nild.log:"
+      cat nild.log
+      exit 1
+    }
 
     echo "tests finished successfully"
   '';

--- a/nix/clijs.nix
+++ b/nix/clijs.nix
@@ -75,12 +75,7 @@ stdenv.mkDerivation rec {
 
     echo "smoke check passed"
 
-
-    nohup nild run --http-port 8529 --collator-tick-ms=100 > nild.log 2>&1 & echo $! > nild_pid &
-
-    pnpm run test:ci
-
-    kill `cat nild_pid` && rm nild_pid
+    env NILD=nild pnpm run test:ci
 
     echo "tests finished successfully"
   '';


### PR DESCRIPTION
this PR makes clijs tests self-sufficient, now you need to provide `nild` binary to correctly run tests