### PR TITLE
[types] drop unused EvmState struct

### DIFF
--- a/nil/internal/config/generate.go
+++ b/nil/internal/config/generate.go
@@ -1,3 +1,3 @@
 package config
 
-//go:generate go run github.com/NilFoundation/fastssz/sszgen --path params.go -include ../types/address.go,../types/uint256.go,../types/transaction.go,../../common/hash.go,../../common/length.go --objs ListValidators,ParamValidators,ValidatorInfo,ParamGasPrice,ParamFees,ParamL1BlockInfo,ParamSudoKey,WorkaroundToImportTypes
+//go:generate go run github.com/NilFoundation/fastssz/sszgen --path params.go -include ../types/address.go,../types/uint256.go,../types/transaction.go,../../common/hash.go,../../common/length.go --objs ListValidators,ParamValidators,ValidatorInfo,ParamGasPrice,ParamL1BlockInfo,WorkaroundToImportTypes

--- a/nil/internal/types/transaction.go
+++ b/nil/internal/types/transaction.go
@@ -253,13 +253,6 @@ func NewFeePackFromFeeCredit(feeCredit Value) FeePack {
 	return FeePack{FeeCredit: feeCredit, MaxPriorityFeePerGas: NewZeroValue(), MaxFeePerGas: MaxFeePerGasDefault}
 }
 
-// EvmState contains EVM data to be saved/restored during await request.
-type EvmState struct {
-	Memory []byte `ssz-max:"10000000"`
-	Stack  []byte `ssz-max:"32768"`
-	Pc     uint64
-}
-
 // AsyncRequestInfo contains information about the incomplete request, that is a request which waits for response to a
 // nested request.
 type AsyncRequestInfo struct {

--- a/nil/services/rpc/filters/filters_test.go
+++ b/nil/services/rpc/filters/filters_test.go
@@ -278,8 +278,7 @@ func (s *SuiteFilters) TestBlocksRange() {
 	receipt := &types.Receipt{ContractAddress: address, Logs: logsInput}
 	receiptEncoded, err := receipt.MarshalSSZ()
 	s.Require().NoError(err)
-	key, err := receipt.HashTreeRoot()
-	s.Require().NoError(err)
+	key := receipt.Hash()
 	s.Require().NoError(receiptsMpt.Set(key[:], receiptEncoded))
 
 	block := types.Block{


### PR DESCRIPTION
It's unused after d391624f4f64524aed14ecd139e2fa4bbbc21d8c.
