### PR TITLE
docs: correct “go run spec_generator” command syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ To run the spec generator:
 
 ```bash
 cp nil/cmd/spec_generator/spec_generator.go .
-go run spec_generator.
+go run spec_generator.go
 rm spec_generator.go
 ```
 


### PR DESCRIPTION
## Short Summary

fix `go run spec_generator.` 

## Checklist

_Please mark each item with an `x` inside the brackets (e.g., [x]) once completed._

- [x] I have read and followed the [Contributing Guide](https://github.com/NilFoundation/nil/blob/main/CONTRIBUTION-GUIDE.md)
- [x] I have tested the changes locally
- [ ] I have added relevant tests (if applicable)
- [x] I have updated documentation/comments (if applicable)
