### PR TITLE
docs(readme): remove stray invisible Unicode char

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ The current RPC is loosely modeled after the Ethereum RPC. The RPC exposes the f
 
 ### Filters
 
-* `NewFilter() `
+* `NewFilter()`
 * `NewPendingTransactionFilter()`
 * `NewBlockFilter()`
 * `UninstallFilter()`


### PR DESCRIPTION
## Short Summary

Removed stray invisible Unicode char after `NewFilter()` in README, restoring correct markdown, copy/search accuracy, and doc generation.


## Checklist

- [x] I have read and followed the [Contributing Guide](https://github.com/NilFoundation/nil/blob/main/CONTRIBUTION-GUIDE.md)
- [x] I have tested the changes locally
- [ ] I have added relevant tests (if applicable)
- [x] I have updated documentation/comments (if applicable)
