### PR TITLE
Proof Provider: Persistent TaskExecutorId

### DIFF
--- a/nil/services/synccommittee/core/block_tasks_integration_test.go
+++ b/nil/services/synccommittee/core/block_tasks_integration_test.go
@@ -83,7 +83,7 @@ func (s *BlockTasksIntegrationTestSuite) Test_Provide_Tasks_And_Handle_Success_R
 	err = s.taskStorage.AddTaskEntries(s.ctx, proofTask)
 	s.Require().NoError(err)
 
-	executorId := testaide.RandomExecutorId()
+	executorId := types.NewRandomExecutorId()
 
 	// requesting batch proof task for execution
 	taskToExecute, err := s.scheduler.GetTask(s.ctx, api.NewTaskRequest(executorId))
@@ -123,7 +123,7 @@ func (s *BlockTasksIntegrationTestSuite) Test_Provide_Tasks_And_Handle_Failure_R
 	err = s.taskStorage.AddTaskEntries(s.ctx, proofTask)
 	s.Require().NoError(err)
 
-	executorId := testaide.RandomExecutorId()
+	executorId := types.NewRandomExecutorId()
 
 	// requesting batch proof task
 	taskToExecute, err := s.scheduler.GetTask(s.ctx, api.NewTaskRequest(executorId))

--- a/nil/services/synccommittee/core/fetching/aggregator_test.go
+++ b/nil/services/synccommittee/core/fetching/aggregator_test.go
@@ -292,7 +292,7 @@ func (s *AggregatorTestSuite) Test_Latest_Fetched_Does_Not_Exist_On_Chain() {
 // requireNoNewTasks asserts that there are no new tasks available for execution
 func (s *AggregatorTestSuite) requireNoNewTasks() {
 	s.T().Helper()
-	task, err := s.taskStorage.RequestTaskToExecute(s.ctx, testaide.RandomExecutorId())
+	task, err := s.taskStorage.RequestTaskToExecute(s.ctx, scTypes.NewRandomExecutorId())
 	s.Require().NoError(err)
 	s.Require().Nil(task, "expected no new tasks available for execution, but got one")
 }
@@ -317,7 +317,7 @@ func (s *AggregatorTestSuite) requireBatchHandled(batch *scTypes.BlockBatch) {
 	}
 
 	// one ProofBatch task created
-	taskToExecute, err := s.taskStorage.RequestTaskToExecute(s.ctx, testaide.RandomExecutorId())
+	taskToExecute, err := s.taskStorage.RequestTaskToExecute(s.ctx, scTypes.NewRandomExecutorId())
 	s.Require().NoError(err)
 	s.Require().NotNil(taskToExecute)
 	s.Require().Equal(scTypes.ProofBatch, taskToExecute.TaskType)

--- a/nil/services/synccommittee/core/task_state_change_handler_test.go
+++ b/nil/services/synccommittee/core/task_state_change_handler_test.go
@@ -61,7 +61,7 @@ func (s *TaskStateChangeHandlerTestSuite) TearDownSuite() {
 
 func (s *TaskStateChangeHandlerTestSuite) Test_OnTaskTerminated_Success() {
 	task, batch := s.batchTaskSetUp()
-	result := testaide.NewSuccessTaskResult(task.Id, testaide.RandomExecutorId())
+	result := testaide.NewSuccessTaskResult(task.Id, types.NewRandomExecutorId())
 
 	err := s.handler.OnTaskTerminated(s.ctx, task, result)
 	s.Require().NoError(err)
@@ -76,7 +76,7 @@ func (s *TaskStateChangeHandlerTestSuite) Test_OnTaskTerminated_Success() {
 
 func (s *TaskStateChangeHandlerTestSuite) Test_OnTaskTerminated_Retryable_Error() {
 	task, _ := s.batchTaskSetUp()
-	result := testaide.NewRetryableErrorTaskResult(task.Id, testaide.RandomExecutorId())
+	result := testaide.NewRetryableErrorTaskResult(task.Id, types.NewRandomExecutorId())
 
 	err := s.handler.OnTaskTerminated(s.ctx, task, result)
 	s.Require().NoError(err)
@@ -91,7 +91,7 @@ func (s *TaskStateChangeHandlerTestSuite) Test_OnTaskTerminated_Retryable_Error(
 
 func (s *TaskStateChangeHandlerTestSuite) Test_OnTaskTerminated_Non_Retryable_Error() {
 	task, _ := s.batchTaskSetUp()
-	result := testaide.NewNonRetryableErrorTaskResult(task.Id, testaide.RandomExecutorId())
+	result := testaide.NewNonRetryableErrorTaskResult(task.Id, types.NewRandomExecutorId())
 
 	err := s.handler.OnTaskTerminated(s.ctx, task, result)
 	s.Require().NoError(err)
@@ -123,7 +123,7 @@ func (s *TaskStateChangeHandlerTestSuite) batchTaskSetUp() (*types.Task, *types.
 func (s *TaskStateChangeHandlerTestSuite) Test_OnTaskTerminated_Unknown_Batch() {
 	task := testaide.NewTaskOfType(types.ProofBatch)
 	task.BatchId = types.NewBatchId()
-	executor := testaide.RandomExecutorId()
+	executor := types.NewRandomExecutorId()
 
 	testCases := []struct {
 		name   string

--- a/nil/services/synccommittee/internal/api/task_request_handler.go
+++ b/nil/services/synccommittee/internal/api/task_request_handler.go
@@ -9,7 +9,7 @@ import (
 const (
 	TaskRequestHandlerNamespace         = "TaskRequestHandler"
 	TaskRequestHandlerGetTask           = TaskRequestHandlerNamespace + "_getTask"
-	TaskRequestHandlerCheckIfTaskExists = TaskRequestHandlerNamespace + "_checkIfTaskExists"
+	TaskRequestHandlerCheckIfTaskExists = TaskRequestHandlerNamespace + "_checkIfTaskIsActive"
 	TaskRequestHandlerSetTaskResult     = TaskRequestHandlerNamespace + "_setTaskResult"
 )
 
@@ -35,7 +35,7 @@ func NewTaskCheckRequest(taskId types.TaskId, executorId types.TaskExecutorId) *
 
 type TaskRequestHandler interface {
 	GetTask(context context.Context, request *TaskRequest) (*types.Task, error)
-	CheckIfTaskExists(context context.Context, request *TaskCheckRequest) (bool, error)
+	CheckIfTaskIsActive(context context.Context, request *TaskCheckRequest) (bool, error)
 	SetTaskResult(context context.Context, result *types.TaskResult) error
 }
 

--- a/nil/services/synccommittee/internal/executor/id_source.go
+++ b/nil/services/synccommittee/internal/executor/id_source.go
@@ -1,0 +1,47 @@
+package executor
+
+import (
+	"context"
+	"sync"
+
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
+)
+
+type inMemoryIdSource struct {
+	cachedId types.TaskExecutorId
+	once     sync.Once
+}
+
+// NewInMemoryIdSource creates a new `IdSource` which generates a random `TaskExecutorId` on
+// the first call of `GetCurrentId` and caches it in memory.
+func NewInMemoryIdSource() IdSource {
+	return &inMemoryIdSource{}
+}
+
+func (n *inMemoryIdSource) GetCurrentId(context.Context) (*types.TaskExecutorId, error) {
+	n.once.Do(func() {
+		n.cachedId = types.NewRandomExecutorId()
+	})
+
+	return &n.cachedId, nil
+}
+
+type IdStorage interface {
+	GetOrAdd(ctx context.Context, idGenerator func() types.TaskExecutorId) (*types.TaskExecutorId, error)
+}
+
+type persistentIdSource struct {
+	storage IdStorage
+}
+
+// NewPersistentIdSource creates a new `IdSource` backed by persistent storage
+// to preserve the same `TaskExecutorId` value between application restarts.
+func NewPersistentIdSource(storage IdStorage) IdSource {
+	return &persistentIdSource{
+		storage: storage,
+	}
+}
+
+func (p *persistentIdSource) GetCurrentId(ctx context.Context) (*types.TaskExecutorId, error) {
+	return p.storage.GetOrAdd(ctx, types.NewRandomExecutorId)
+}

--- a/nil/services/synccommittee/internal/executor/id_source_test.go
+++ b/nil/services/synccommittee/internal/executor/id_source_test.go
@@ -1,0 +1,137 @@
+package executor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/NilFoundation/nil/nil/common/logging"
+	"github.com/NilFoundation/nil/nil/internal/db"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/storage"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
+	"github.com/stretchr/testify/suite"
+	"golang.org/x/sync/errgroup"
+)
+
+func TestIdSourceSuite(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(IdSourceTestSuite))
+}
+
+type IdSourceTestSuite struct {
+	suite.Suite
+	context context.Context
+	cancel  context.CancelFunc
+
+	database  db.DB
+	idStorage IdStorage
+}
+
+func (s *IdSourceTestSuite) SetupSuite() {
+	s.context, s.cancel = context.WithCancel(context.Background())
+	logger := logging.NewLogger("id_source_test")
+
+	var err error
+	s.database, err = db.NewBadgerDbInMemory()
+	s.Require().NoError(err)
+	s.idStorage = storage.NewExecutorIdStorage(s.database, logger)
+}
+
+func (s *IdSourceTestSuite) TearDownSuite() {
+	s.cancel()
+}
+
+func (s *IdSourceTestSuite) TearDownTest() {
+	err := s.database.DropAll()
+	s.Require().NoError(err, "failed to clear database in TearDownTest")
+}
+
+func (s *IdSourceTestSuite) Test_Generate_New_Id_And_Store() {
+	for _, testCase := range s.testCases() {
+		s.Run(testCase.name, func() {
+			s.testGenerateNewAndCache(testCase.idSource)
+		})
+	}
+}
+
+func (s *IdSourceTestSuite) testGenerateNewAndCache(idSource IdSource) {
+	s.T().Helper()
+
+	newId, err := idSource.GetCurrentId(s.context)
+	s.Require().NoError(err)
+	s.Require().NotNil(newId)
+	s.Require().NotEqual(types.UnknownExecutorId, *newId)
+
+	existingId, err := idSource.GetCurrentId(s.context)
+	s.Require().NoError(err)
+	s.Require().Equal(newId, existingId)
+}
+
+func (s *IdSourceTestSuite) Test_Concurrent_Access() {
+	for _, testCase := range s.testCases() {
+		s.Run(testCase.name, func() {
+			s.testConcurrentAccess(testCase.idSource)
+		})
+	}
+}
+
+func (s *IdSourceTestSuite) testConcurrentAccess(idSource IdSource) {
+	s.T().Helper()
+
+	const goroutines = 10
+	ids := make(chan *types.TaskExecutorId, goroutines)
+
+	var group errgroup.Group
+	for range goroutines {
+		group.Go(func() error {
+			id, err := idSource.GetCurrentId(s.context)
+			if err != nil {
+				return err
+			}
+			ids <- id
+			return nil
+		})
+	}
+
+	err := group.Wait()
+	s.Require().NoError(err)
+
+	expectedId := <-ids
+	s.Require().NotNil(expectedId)
+	s.Require().NotEqual(types.UnknownExecutorId, *expectedId)
+
+	for range goroutines - 1 {
+		id := <-ids
+		s.Require().NotNil(id)
+		s.Require().Equal(*expectedId, *id)
+	}
+}
+
+func (s *IdSourceTestSuite) Test_PersistentSource_RetrievesExistingId() {
+	idSource := NewPersistentIdSource(s.idStorage)
+
+	expectedId := types.NewRandomExecutorId()
+	_, err := s.idStorage.GetOrAdd(s.context, func() types.TaskExecutorId {
+		return expectedId
+	})
+	s.Require().NoError(err)
+
+	actualId, err := idSource.GetCurrentId(s.context)
+	s.Require().NoError(err)
+	s.Require().NotNil(actualId)
+	s.Require().Equal(expectedId, *actualId)
+}
+
+func (s *IdSourceTestSuite) testCases() []struct {
+	name     string
+	idSource IdSource
+} {
+	s.T().Helper()
+
+	return []struct {
+		name     string
+		idSource IdSource
+	}{
+		{"In_Memory_Source", NewInMemoryIdSource()},
+		{"Persistent_Source", NewPersistentIdSource(s.idStorage)},
+	}
+}

--- a/nil/services/synccommittee/internal/rpc/task_debug_rpc_test.go
+++ b/nil/services/synccommittee/internal/rpc/task_debug_rpc_test.go
@@ -40,7 +40,7 @@ func TestTaskSchedulerDebugRpcTestSuite(t *testing.T) {
 }
 
 var (
-	someExecutor   = testaide.RandomExecutorId()
+	someExecutor   = types.NewRandomExecutorId()
 	running        = types.Running
 	failed         = types.Failed
 	proofBatchType = types.ProofBatch
@@ -51,13 +51,13 @@ var (
 
 func newTaskEntries(now time.Time) []*types.TaskEntry {
 	return []*types.TaskEntry{
-		testaide.NewTaskEntry(now.Add(-6*time.Minute), running, testaide.RandomExecutorId()),
+		testaide.NewTaskEntry(now.Add(-6*time.Minute), running, types.NewRandomExecutorId()),
 		testaide.NewTaskEntry(now.Add(-4*time.Minute), running, someExecutor),
 		testaide.NewTaskEntry(now.Add(-8*time.Minute), running, someExecutor),
 		testaide.NewTaskEntryOfType(proofBatchType, now.Add(-2*time.Minute), failed, someExecutor),
 		testaide.NewTaskEntryOfType(
-			proofBatchType, now.Add(-10*time.Minute), types.WaitingForInput, testaide.RandomExecutorId()),
-		testaide.NewTaskEntry(now, types.WaitingForExecutor, testaide.RandomExecutorId()),
+			proofBatchType, now.Add(-10*time.Minute), types.WaitingForInput, types.NewRandomExecutorId()),
+		testaide.NewTaskEntry(now, types.WaitingForExecutor, types.NewRandomExecutorId()),
 	}
 }
 
@@ -247,7 +247,7 @@ func (s *TaskSchedulerDebugRpcTestSuite) Test_Get_Task_Tree_Not_Found() {
 
 func (s *TaskSchedulerDebugRpcTestSuite) Test_Get_Task_Tree_No_Dependencies() {
 	now := s.clock.Now()
-	entry := testaide.NewTaskEntry(now, running, testaide.RandomExecutorId())
+	entry := testaide.NewTaskEntry(now, running, types.NewRandomExecutorId())
 	err := s.storage.AddTaskEntries(s.context, entry)
 	s.Require().NoError(err)
 
@@ -269,19 +269,19 @@ func (s *TaskSchedulerDebugRpcTestSuite) Test_Get_Task_Tree_With_Dependencies() 
 
 	now := s.clock.Now()
 
-	taskA := testaide.NewTaskEntry(now, types.WaitingForInput, testaide.RandomExecutorId())
+	taskA := testaide.NewTaskEntry(now, types.WaitingForInput, types.NewRandomExecutorId())
 
-	taskB := testaide.NewTaskEntry(now, types.WaitingForInput, testaide.RandomExecutorId())
+	taskB := testaide.NewTaskEntry(now, types.WaitingForInput, types.NewRandomExecutorId())
 	taskA.AddDependency(taskB)
 
-	taskC := testaide.NewTaskEntry(now, types.WaitingForInput, testaide.RandomExecutorId())
+	taskC := testaide.NewTaskEntry(now, types.WaitingForInput, types.NewRandomExecutorId())
 	taskA.AddDependency(taskC)
 
-	taskD := testaide.NewTaskEntry(now, types.Running, testaide.RandomExecutorId())
+	taskD := testaide.NewTaskEntry(now, types.Running, types.NewRandomExecutorId())
 	taskB.AddDependency(taskD)
 	taskC.AddDependency(taskD)
 
-	taskE := testaide.NewTaskEntry(now, types.Running, testaide.RandomExecutorId())
+	taskE := testaide.NewTaskEntry(now, types.Running, types.NewRandomExecutorId())
 	taskC.AddDependency(taskE)
 
 	err := s.storage.AddTaskEntries(s.context, taskA, taskB, taskC, taskD, taskE)
@@ -331,7 +331,7 @@ func (s *TaskSchedulerDebugRpcTestSuite) Test_Get_Task_Tree_With_Terminated_Depe
 	err := s.storage.AddTaskEntries(s.context, taskA, taskB, taskC)
 	s.Require().NoError(err)
 
-	executor := testaide.RandomExecutorId()
+	executor := types.NewRandomExecutorId()
 
 	s.requestAndSendResult(&taskB.Task, executor, true)
 	s.requestAndSendResult(&taskC.Task, executor, false)

--- a/nil/services/synccommittee/internal/rpc/task_request_handler_rpc_suite_test.go
+++ b/nil/services/synccommittee/internal/rpc/task_request_handler_rpc_suite_test.go
@@ -78,14 +78,14 @@ var (
 
 	firstDepResult = types.NewSuccessProverTaskResult(
 		types.NewTaskId(),
-		testaide.RandomExecutorId(),
+		types.NewRandomExecutorId(),
 		nil,
 		nil,
 	)
 
 	secondDepResult = types.NewSuccessProverTaskResult(
 		types.NewTaskId(),
-		testaide.RandomExecutorId(),
+		types.NewRandomExecutorId(),
 		nil,
 		nil,
 	)

--- a/nil/services/synccommittee/internal/rpc/task_request_handler_rpc_test.go
+++ b/nil/services/synccommittee/internal/rpc/task_request_handler_rpc_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/api"
-	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/testaide"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
 	"github.com/stretchr/testify/suite"
 )
@@ -22,7 +21,7 @@ func (s *TaskRequestHandlerTestSuite) Test_TaskRequestHandler_GetTask() {
 	}{
 		{"Returns_Task_Without_Deps", firstExecutorId},
 		{"Returns_Task_With_Deps", secondExecutorId},
-		{"Returns_Nil", testaide.RandomExecutorId()},
+		{"Returns_Nil", types.NewRandomExecutorId()},
 	}
 
 	for _, testCase := range testCases {
@@ -55,20 +54,20 @@ func (s *TaskRequestHandlerTestSuite) Test_TaskRequestHandler_UpdateTaskStatus()
 			"Success_Result_Final_Proof",
 			types.NewSuccessProverTaskResult(
 				types.NewTaskId(),
-				testaide.RandomExecutorId(),
+				types.NewRandomExecutorId(),
 				types.TaskOutputArtifacts{types.FinalProof: "final-proof.1.0xAABC"},
 				types.TaskResultData{10, 20, 30, 40},
 			),
 		},
 		{
 			"Success_Result_Provider",
-			types.NewSuccessProviderTaskResult(types.NewTaskId(), testaide.RandomExecutorId(), nil, nil),
+			types.NewSuccessProviderTaskResult(types.NewTaskId(), types.NewRandomExecutorId(), nil, nil),
 		},
 		{
 			"Failure_Result_Provider",
 			types.NewFailureProverTaskResult(
 				types.NewTaskId(),
-				testaide.RandomExecutorId(),
+				types.NewRandomExecutorId(),
 				types.NewTaskExecError(types.TaskErrUnknown, "something went wrong"),
 			),
 		},

--- a/nil/services/synccommittee/internal/rpc/task_request_rpc_client.go
+++ b/nil/services/synccommittee/internal/rpc/task_request_rpc_client.go
@@ -28,7 +28,7 @@ func (r *taskRequestRpcClient) GetTask(ctx context.Context, request *api.TaskReq
 	)
 }
 
-func (r *taskRequestRpcClient) CheckIfTaskExists(ctx context.Context, request *api.TaskCheckRequest) (bool, error) {
+func (r *taskRequestRpcClient) CheckIfTaskIsActive(ctx context.Context, request *api.TaskCheckRequest) (bool, error) {
 	return doRPCCall[*api.TaskCheckRequest, bool](
 		ctx,
 		r.client,

--- a/nil/services/synccommittee/internal/scheduler/task_cancel_checker.go
+++ b/nil/services/synccommittee/internal/scheduler/task_cancel_checker.go
@@ -66,7 +66,7 @@ func (c *TaskCancelChecker) processRunningTasks(ctx context.Context) error {
 
 	isTaskActiveFunc := func(ctx context.Context, id types.TaskId) (bool, error) {
 		taskRequest := api.NewTaskCheckRequest(id, *executorId)
-		exists, err := c.requestHandler.CheckIfTaskExists(ctx, taskRequest)
+		exists, err := c.requestHandler.CheckIfTaskIsActive(ctx, taskRequest)
 		if err != nil {
 			return false, fmt.Errorf("failed to check task: %w", err)
 		}

--- a/nil/services/synccommittee/internal/scheduler/task_cancel_checker.go
+++ b/nil/services/synccommittee/internal/scheduler/task_cancel_checker.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/NilFoundation/nil/nil/common/logging"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/api"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/executor"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/srv"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
 )
@@ -28,24 +29,24 @@ type TaskSource interface {
 type TaskCancelChecker struct {
 	srv.WorkerLoop
 
-	requestHandler api.TaskRequestHandler
-	taskSource     TaskSource
-	executorId     types.TaskExecutorId
-	config         TaskCancelCheckerConfig
+	requestHandler   api.TaskRequestHandler
+	taskSource       TaskSource
+	executorIdSource executor.IdSource
+	config           TaskCancelCheckerConfig
 }
 
 func NewTaskCancelChecker(
 	requestHandler api.TaskRequestHandler,
 	taskSource TaskSource,
-	executorId types.TaskExecutorId,
+	executorIdSource executor.IdSource,
 	metrics srv.WorkerMetrics,
 	logger logging.Logger,
 ) *TaskCancelChecker {
 	checker := &TaskCancelChecker{
-		requestHandler: requestHandler,
-		taskSource:     taskSource,
-		executorId:     executorId,
-		config:         MakeDefaultCheckerConfig(),
+		requestHandler:   requestHandler,
+		taskSource:       taskSource,
+		executorIdSource: executorIdSource,
+		config:           MakeDefaultCheckerConfig(),
 	}
 
 	loopConfig := srv.NewWorkerLoopConfig(
@@ -58,23 +59,28 @@ func NewTaskCancelChecker(
 }
 
 func (c *TaskCancelChecker) processRunningTasks(ctx context.Context) error {
-	canceledCounter, err := c.taskSource.CancelTasksByParentId(ctx, c.isActive)
+	executorId, err := c.executorIdSource.GetCurrentId(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get current executor id: %w", err)
+	}
+
+	isTaskActiveFunc := func(ctx context.Context, id types.TaskId) (bool, error) {
+		taskRequest := api.NewTaskCheckRequest(id, *executorId)
+		exists, err := c.requestHandler.CheckIfTaskExists(ctx, taskRequest)
+		if err != nil {
+			return false, fmt.Errorf("failed to check task: %w", err)
+		}
+		return exists, nil
+	}
+
+	canceledCounter, err := c.taskSource.CancelTasksByParentId(ctx, isTaskActiveFunc)
 	if err != nil {
 		return fmt.Errorf("failed to cancel dead tasks: %w", err)
 	}
 	if canceledCounter == 0 {
-		c.Logger.Debug().Msg("no task canceled")
+		c.Logger.Debug().Msg("No task canceled")
 	} else {
-		c.Logger.Warn().Msgf("canceled %d dead tasks", canceledCounter)
+		c.Logger.Warn().Msgf("Canceled %d dead tasks", canceledCounter)
 	}
 	return nil
-}
-
-func (c *TaskCancelChecker) isActive(ctx context.Context, taskId types.TaskId) (bool, error) {
-	taskRequest := api.NewTaskCheckRequest(taskId, c.executorId)
-	isExists, err := c.requestHandler.CheckIfTaskExists(ctx, taskRequest)
-	if err != nil {
-		return isExists, fmt.Errorf("failed to check task: %w", err)
-	}
-	return isExists, nil
 }

--- a/nil/services/synccommittee/internal/scheduler/task_cancel_checker_test.go
+++ b/nil/services/synccommittee/internal/scheduler/task_cancel_checker_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/NilFoundation/nil/nil/common/logging"
 	"github.com/NilFoundation/nil/nil/internal/db"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/api"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/executor"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/metrics"
-	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/srv"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/storage"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/testaide"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
@@ -143,7 +143,7 @@ func (s *TaskCancelCheckerSuite) newTestTaskCancelChecker(handler api.TaskReques
 	return NewTaskCancelChecker(
 		handler,
 		s.taskStorage,
-		testaide.RandomExecutorId(),
+		executor.NewInMemoryIdSource(),
 		srv.NewNoopWorkerMetrics(),
 		s.logger,
 	)

--- a/nil/services/synccommittee/internal/scheduler/task_cancel_checker_test.go
+++ b/nil/services/synccommittee/internal/scheduler/task_cancel_checker_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/api"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/executor"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/metrics"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/srv"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/storage"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/testaide"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
@@ -64,7 +65,7 @@ func (s *TaskCancelCheckerSuite) Test_Check_Empty_Storage() {
 
 	err := cancelChecker.processRunningTasks(s.ctx)
 	s.Require().NoError(err)
-	s.Require().Zero(handlerMock.CheckIfTaskExistsCalls())
+	s.Require().Zero(handlerMock.CheckIfTaskIsActiveCalls())
 }
 
 func (s *TaskCancelCheckerSuite) Test_Check_Alive_Task() {
@@ -81,7 +82,7 @@ func (s *TaskCancelCheckerSuite) Test_Check_Alive_Task() {
 	s.Require().NoError(err)
 
 	handlerMock := &api.TaskRequestHandlerMock{
-		CheckIfTaskExistsFunc: func(contextMoqParam context.Context, request *api.TaskCheckRequest) (bool, error) {
+		CheckIfTaskIsActiveFunc: func(contextMoqParam context.Context, request *api.TaskCheckRequest) (bool, error) {
 			return true, nil
 		},
 	}
@@ -92,7 +93,7 @@ func (s *TaskCancelCheckerSuite) Test_Check_Alive_Task() {
 	s.Require().NoError(err)
 
 	// Parent task was checked
-	checkTaskCall := handlerMock.CheckIfTaskExistsCalls()
+	checkTaskCall := handlerMock.CheckIfTaskIsActiveCalls()
 	s.Require().Len(checkTaskCall, 1)
 	s.Require().Equal(parentTaskId, checkTaskCall[0].Request.TaskId)
 	// Checked task was not removed
@@ -116,7 +117,7 @@ func (s *TaskCancelCheckerSuite) Test_Check_Dead_Task() {
 	s.Require().NoError(err)
 
 	handlerMock := &api.TaskRequestHandlerMock{
-		CheckIfTaskExistsFunc: func(contextMoqParam context.Context, request *api.TaskCheckRequest) (bool, error) {
+		CheckIfTaskIsActiveFunc: func(contextMoqParam context.Context, request *api.TaskCheckRequest) (bool, error) {
 			return false, nil
 		},
 	}
@@ -127,7 +128,7 @@ func (s *TaskCancelCheckerSuite) Test_Check_Dead_Task() {
 	s.Require().NoError(err)
 
 	// Parent task was checked
-	checkTaskCall := handlerMock.CheckIfTaskExistsCalls()
+	checkTaskCall := handlerMock.CheckIfTaskIsActiveCalls()
 	s.Require().Len(checkTaskCall, 1)
 	s.Require().Equal(parentTaskId, checkTaskCall[0].Request.TaskId)
 	// Checked task was not removed

--- a/nil/services/synccommittee/internal/scheduler/task_result_sender_test.go
+++ b/nil/services/synccommittee/internal/scheduler/task_result_sender_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/api"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/srv"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/storage"
-	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/testaide"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
 	"github.com/stretchr/testify/suite"
 )
@@ -64,7 +63,7 @@ func (s *TaskResultSenderSuite) Test_Send_Result_Empty_Storage() {
 }
 
 func (s *TaskResultSenderSuite) Test_Send_Result_Faulty_Client() {
-	resultToSend := types.NewSuccessProviderTaskResult(types.NewTaskId(), testaide.RandomExecutorId(), nil, nil)
+	resultToSend := types.NewSuccessProviderTaskResult(types.NewTaskId(), types.NewRandomExecutorId(), nil, nil)
 	err := s.resultStorage.Put(s.ctx, resultToSend)
 	s.Require().NoError(err)
 
@@ -86,7 +85,7 @@ func (s *TaskResultSenderSuite) Test_Send_Result_Faulty_Client() {
 }
 
 func (s *TaskResultSenderSuite) Test_Send_And_Delete_Result() {
-	resultToSend := types.NewSuccessProviderTaskResult(types.NewTaskId(), testaide.RandomExecutorId(), nil, nil)
+	resultToSend := types.NewSuccessProviderTaskResult(types.NewTaskId(), types.NewRandomExecutorId(), nil, nil)
 	err := s.resultStorage.Put(s.ctx, resultToSend)
 	s.Require().NoError(err)
 

--- a/nil/services/synccommittee/internal/scheduler/task_scheduler.go
+++ b/nil/services/synccommittee/internal/scheduler/task_scheduler.go
@@ -117,7 +117,7 @@ func (s *taskScheduler) GetTask(ctx context.Context, request *api.TaskRequest) (
 	return task, nil
 }
 
-func (s *taskScheduler) CheckIfTaskExists(ctx context.Context, request *api.TaskCheckRequest) (bool, error) {
+func (s *taskScheduler) CheckIfTaskIsActive(ctx context.Context, request *api.TaskCheckRequest) (bool, error) {
 	s.Logger.Debug().Stringer(logging.FieldTaskId, request.TaskId).Msg("received new check task request")
 
 	taskEntry, err := s.storage.TryGetTaskEntry(ctx, request.TaskId)

--- a/nil/services/synccommittee/internal/storage/executor_id_storage.go
+++ b/nil/services/synccommittee/internal/storage/executor_id_storage.go
@@ -1,0 +1,98 @@
+package storage
+
+import (
+	"context"
+	"errors"
+
+	"github.com/NilFoundation/nil/nil/common/logging"
+	"github.com/NilFoundation/nil/nil/internal/db"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
+)
+
+const (
+	// executorIdTable stores a task executor identifier assigned to the current running service.
+	// Key: executorIdRowKey, Value: types.TaskExecutorId.
+	executorIdTable db.TableName = "task_executor_id"
+)
+
+var executorIdRowKey = []byte(executorIdTable)
+
+type executorIdStorage struct {
+	commonStorage
+}
+
+func NewExecutorIdStorage(
+	database db.DB,
+	logger logging.Logger,
+) *executorIdStorage {
+	return &executorIdStorage{
+		commonStorage: makeCommonStorage(database, logger),
+	}
+}
+
+func (s *executorIdStorage) GetOrAdd(
+	ctx context.Context, idGenerator func() types.TaskExecutorId,
+) (*types.TaskExecutorId, error) {
+	var id *types.TaskExecutorId
+	err := s.retryRunner.Do(ctx, func(ctx context.Context) error {
+		var err error
+		id, err = s.getOrAdd(ctx, idGenerator)
+		return err
+	})
+	return id, err
+}
+
+func (s *executorIdStorage) getOrAdd(
+	ctx context.Context,
+	idGenerator func() types.TaskExecutorId,
+) (*types.TaskExecutorId, error) {
+	tx, err := s.database.CreateRwTx(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	id, err := s.tryGetId(tx)
+	if err != nil {
+		return nil, err
+	}
+	if id != nil {
+		return id, nil
+	}
+
+	generated := idGenerator()
+	if err := s.putId(tx, generated); err != nil {
+		return nil, err
+	}
+
+	if err := s.commit(tx); err != nil {
+		return nil, err
+	}
+
+	return &generated, nil
+}
+
+func (s *executorIdStorage) tryGetId(tx db.RoTx) (*types.TaskExecutorId, error) {
+	idBytes, err := tx.Get(executorIdTable, executorIdRowKey)
+	switch {
+	case errors.Is(err, db.ErrKeyNotFound):
+		return nil, nil
+	case err != nil:
+		return nil, err
+	}
+
+	var id types.TaskExecutorId
+	if err := id.UnmarshalBinary(idBytes); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (s *executorIdStorage) putId(tx db.RwTx, id types.TaskExecutorId) error {
+	bytes, err := id.MarshalBinary()
+	if err != nil {
+		return err
+	}
+	return tx.Put(executorIdTable, executorIdRowKey, bytes)
+}

--- a/nil/services/synccommittee/internal/storage/task_result_storage_test.go
+++ b/nil/services/synccommittee/internal/storage/task_result_storage_test.go
@@ -49,7 +49,7 @@ func (s *TaskResultStorageSuite) TearDownTest() {
 func (s *TaskResultStorageSuite) Test_Put_Same_Task_Result_N_Times() {
 	result := types.NewSuccessProviderTaskResult(
 		types.NewTaskId(),
-		testaide.RandomExecutorId(),
+		types.NewRandomExecutorId(),
 		types.TaskOutputArtifacts{types.AggregatedProof: "agg-proof.1.1.0xAABC"},
 		testaide.RandomTaskResultData(),
 	)
@@ -67,7 +67,7 @@ func (s *TaskResultStorageSuite) Test_Put_Same_Task_Result_N_Times() {
 func (s *TaskResultStorageSuite) Test_SetAsSubmitted_Same_Task_Result_N_Times() {
 	result := types.NewFailureProviderTaskResult(
 		types.NewTaskId(),
-		testaide.RandomExecutorId(),
+		types.NewRandomExecutorId(),
 		types.NewTaskExecError(types.TaskErrUnknown, "something went wrong"),
 	)
 
@@ -117,18 +117,18 @@ func newTaskResults() []*types.TaskResult {
 	return []*types.TaskResult{
 		types.NewSuccessProviderTaskResult(
 			types.NewTaskId(),
-			testaide.RandomExecutorId(),
+			types.NewRandomExecutorId(),
 			types.TaskOutputArtifacts{types.AggregatedProof: "agg-proof.1.1.0xAABC"},
 			testaide.RandomTaskResultData(),
 		),
 		types.NewFailureProviderTaskResult(
 			types.NewTaskId(),
-			testaide.RandomExecutorId(),
+			types.NewRandomExecutorId(),
 			types.NewTaskExecError(types.TaskErrUnknown, "something went wrong"),
 		),
 		types.NewSuccessProverTaskResult(
 			types.NewTaskId(),
-			testaide.RandomExecutorId(),
+			types.NewRandomExecutorId(),
 			types.TaskOutputArtifacts{
 				types.PartialProofChallenges:     "challenge.1.1.0xAABC",
 				types.AssignmentTableDescription: "assignment_table_description.1.1.0xAABC",
@@ -139,7 +139,7 @@ func newTaskResults() []*types.TaskResult {
 		),
 		types.NewFailureProverTaskResult(
 			types.NewTaskId(),
-			testaide.RandomExecutorId(),
+			types.NewRandomExecutorId(),
 			types.NewTaskExecError(types.TaskErrIO, "prover failed to handle task"),
 		),
 	}

--- a/nil/services/synccommittee/internal/testaide/prover_tasks.go
+++ b/nil/services/synccommittee/internal/testaide/prover_tasks.go
@@ -4,7 +4,6 @@ package testaide
 
 import (
 	"crypto/rand"
-	"math"
 	"math/big"
 	"time"
 
@@ -59,14 +58,6 @@ func NewTaskOfType(taskType types.TaskType) *types.Task {
 		BatchId:  types.NewBatchId(),
 		TaskType: taskType,
 	}
-}
-
-func RandomExecutorId() types.TaskExecutorId {
-	bigInt, err := rand.Int(rand.Reader, big.NewInt(math.MaxInt32))
-	if err != nil {
-		panic(err)
-	}
-	return types.TaskExecutorId(uint32(bigInt.Uint64()))
 }
 
 func RandomTaskResultData() types.TaskResultData {

--- a/nil/services/synccommittee/internal/types/prover_tasks.go
+++ b/nil/services/synccommittee/internal/types/prover_tasks.go
@@ -1,9 +1,11 @@
 package types
 
 import (
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"iter"
+	mathRand "math/rand"
 	"strconv"
 	"time"
 
@@ -76,16 +78,40 @@ type TaskExecutorId uint32
 
 const UnknownExecutorId TaskExecutorId = 0
 
-func (e TaskExecutorId) String() string {
-	return strconv.FormatUint(uint64(e), 10)
+func NewRandomExecutorId() TaskExecutorId {
+	var randInt uint32
+	for randInt == 0 {
+		randInt = mathRand.Uint32() //nolint:gosec
+	}
+	return TaskExecutorId(randInt)
 }
 
-func (e *TaskExecutorId) Set(str string) error {
+func (id TaskExecutorId) MarshalBinary() ([]byte, error) {
+	intValue := uint32(id)
+	value := make([]byte, 4)
+	binary.LittleEndian.PutUint32(value, intValue)
+	return value, nil
+}
+
+func (id *TaskExecutorId) UnmarshalBinary(data []byte) error {
+	if len(data) != 4 {
+		return fmt.Errorf("invalid bytes length for TaskExecutorId, got %d, expected 4", len(data))
+	}
+	intValue := binary.LittleEndian.Uint32(data)
+	*id = TaskExecutorId(intValue)
+	return nil
+}
+
+func (id TaskExecutorId) String() string {
+	return strconv.FormatUint(uint64(id), 10)
+}
+
+func (id *TaskExecutorId) Set(str string) error {
 	parsedValue, err := strconv.ParseUint(str, 10, 32)
 	if err != nil {
 		return fmt.Errorf("%w: invalid value for TaskExecutorId, got %s", err, str)
 	}
-	*e = TaskExecutorId(parsedValue)
+	*id = TaskExecutorId(parsedValue)
 	return nil
 }
 

--- a/nil/services/synccommittee/internal/types/prover_tasks.go
+++ b/nil/services/synccommittee/internal/types/prover_tasks.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"iter"
-	mathRand "math/rand"
+	"math/rand"
 	"strconv"
 	"time"
 
@@ -81,7 +81,7 @@ const UnknownExecutorId TaskExecutorId = 0
 func NewRandomExecutorId() TaskExecutorId {
 	var randInt uint32
 	for randInt == 0 {
-		randInt = mathRand.Uint32() //nolint:gosec
+		randInt = rand.Uint32() //nolint:gosec
 	}
 	return TaskExecutorId(randInt)
 }

--- a/nil/services/synccommittee/proofprovider/task_handler_test.go
+++ b/nil/services/synccommittee/proofprovider/task_handler_test.go
@@ -72,7 +72,7 @@ func (s *TaskHandlerTestSuite) TestReturnErrorOnUnexpectedTaskType() {
 		{name: "TaskTypeNone", taskType: types.TaskTypeNone},
 	}
 
-	executorId := testaide.RandomExecutorId()
+	executorId := types.NewRandomExecutorId()
 
 	for _, testCase := range testCases {
 		s.Run(testCase.name, func() {
@@ -89,7 +89,7 @@ func (s *TaskHandlerTestSuite) TestReturnErrorOnUnexpectedTaskType() {
 
 func (s *TaskHandlerTestSuite) TestHandleBatchProofTask() {
 	now := s.clock.Now()
-	executorId := testaide.RandomExecutorId()
+	executorId := types.NewRandomExecutorId()
 	batch := testaide.NewBlockBatch(testaide.ShardsCount)
 	taskEntry, err := batch.CreateProofTask(now)
 	s.Require().NoError(err)
@@ -180,7 +180,7 @@ func (s *TaskHandlerTestSuite) TestMaxActiveTasksLimit() {
 	s.True(s.taskHandler.IsReadyToHandle(s.context))
 	// Add one batch
 	now := s.clock.Now()
-	executorId := testaide.RandomExecutorId()
+	executorId := types.NewRandomExecutorId()
 	batch := testaide.NewBlockBatch(testaide.ShardsCount)
 	taskEntry, err := batch.CreateProofTask(now)
 	s.Require().NoError(err)

--- a/nil/services/synccommittee/prover/service.go
+++ b/nil/services/synccommittee/prover/service.go
@@ -64,6 +64,7 @@ func New(config Config, database db.DB) (*Prover, error) {
 		executor.DefaultConfig(),
 		taskRpcClient,
 		handler,
+		executor.NewInMemoryIdSource(),
 		metricsHandler,
 		logger,
 	)


### PR DESCRIPTION
### Proof Provider: Persistent TaskExecutorId

Refactor `TaskExecutor` and related components to use `executor.IdSource` for generating `TaskExecutorId`

Previously, both `Prover` and `ProofProvider` used random "nonce" IDs that were regenerated on each service startup. While it's fine for `Prover` to use a volatile identifier, `ProofProvider` requires a persistent ID to support top-level task result submission after a restart

Introduced `IdSource` implementations:
* `InMemoryIdSource` – used by `Prover`
* `PersistentIdSource` – backed by a database and used by `ProofProvider`