### PR TITLE
nilservice: indexer rpc fix

### DIFF
--- a/nil/services/nilservice/service.go
+++ b/nil/services/nilservice/service.go
@@ -26,7 +26,6 @@ import (
 	"github.com/NilFoundation/nil/nil/services/cometa"
 	"github.com/NilFoundation/nil/nil/services/faucet"
 	"github.com/NilFoundation/nil/nil/services/indexer"
-	"github.com/NilFoundation/nil/nil/services/indexer/driver"
 	"github.com/NilFoundation/nil/nil/services/rollup"
 	"github.com/NilFoundation/nil/nil/services/rpc"
 	"github.com/NilFoundation/nil/nil/services/rpc/httpcfg"
@@ -138,20 +137,6 @@ func startRpcServer(
 			return fmt.Errorf("failed to create indexer service: %w", err)
 		}
 		apiList = append(apiList, idx.GetRpcApi())
-
-		check.PanicIfErr(err)
-		task := concurrent.MakeTask(
-			"indexer",
-			func(ctx context.Context) (err error) {
-				return indexer.StartIndexer(ctx, &indexer.Cfg{
-					Client:        client,
-					IndexerDriver: idx.Driver,
-					BlocksChan:    make(chan *driver.BlockWithShardId, 1000),
-				})
-			})
-		if err := concurrent.Run(ctx, task); err != nil {
-			return err
-		}
 	}
 
 	if cfg.IsFaucetApiEnabled() {


### PR DESCRIPTION
## Short Summary

Nild: Fix Indexer RPC. Enable only indexer-rpc without running indexer task

## Checklist

- [v] I have read and followed the [Contributing Guide](https://github.com/NilFoundation/nil/blob/main/CONTRIBUTION-GUIDE.md)
- [v] I have tested the changes locally
- [v] I have added relevant tests (if applicable)
- [v] I have updated documentation/comments (if applicable)
