### PR TITLE
Sync Committee: Block Storage Fix

### DIFF
--- a/nil/services/synccommittee/core/batches/constraints/checker.go
+++ b/nil/services/synccommittee/core/batches/constraints/checker.go
@@ -57,7 +57,7 @@ func (c *checker) CheckConstraints(ctx context.Context, batch *types.BlockBatch)
 	} else {
 		c.logger.Info().
 			Stringer(logging.FieldBatchId, batch.Id).
-			Msgf("Batch constraint(s) are violated, result: %s", batchResult)
+			Msgf("Batch constraints are violated, result: %s", batchResult)
 	}
 
 	return batchResult, nil

--- a/nil/services/synccommittee/core/batches/constraints/result.go
+++ b/nil/services/synccommittee/core/batches/constraints/result.go
@@ -54,6 +54,10 @@ func (r *CheckResult) JoinWith(other *CheckResult) {
 	r.Details = joinedDetails
 }
 
+func (r *CheckResult) CanBeExtended() bool {
+	return r.Type == CheckResultTypeCanBeExtended
+}
+
 func newCheckResult(resultType CheckResultType, format string, args ...any) CheckResult {
 	return CheckResult{
 		Type:    resultType,

--- a/nil/services/synccommittee/core/fetching/aggregator_test.go
+++ b/nil/services/synccommittee/core/fetching/aggregator_test.go
@@ -235,7 +235,7 @@ func (s *AggregatorTestSuite) Test_Block_Storage_Capacity_Exceeded() {
 	s.Require().NotNil(latestFetchedBeforeNext)
 
 	err = agg.processBlockRange(s.ctx)
-	s.Require().ErrorIs(err, storage.ErrCapacityLimitReached)
+	s.Require().NoError(err)
 
 	latestFetchedAfterNext, err := blockStorage.GetLatestFetched(s.ctx)
 	s.Require().NoError(err)

--- a/nil/services/synccommittee/core/task_state_change_handler.go
+++ b/nil/services/synccommittee/core/task_state_change_handler.go
@@ -61,12 +61,12 @@ func (h *taskStateChangeHandler) OnTaskTerminated(
 	switch {
 	case result.IsSuccess():
 		log.NewTaskResultEvent(h.logger, zerolog.InfoLevel, result).
-			Msg("received successful task result")
+			Msg("Received successful task result")
 		return h.onTaskSuccess(ctx, task, result)
 
 	case result.HasRetryableError():
 		log.NewTaskResultEvent(h.logger, zerolog.WarnLevel, result).
-			Msg("task execution failed with retryable error")
+			Msg("Task execution failed with retryable error")
 		return nil
 
 	default:
@@ -76,7 +76,7 @@ func (h *taskStateChangeHandler) OnTaskTerminated(
 
 func (h *taskStateChangeHandler) resetState(ctx context.Context, task *types.Task, result *types.TaskResult) error {
 	log.NewTaskResultEvent(h.logger, zerolog.WarnLevel, result).
-		Msg("task execution failed with critical error, state will be reset")
+		Msg("Task execution failed with critical error, state will be reset")
 
 	err := h.stateResetLauncher.LaunchPartialResetWithSuspension(ctx, nil, task.BatchId)
 
@@ -96,13 +96,13 @@ func (h *taskStateChangeHandler) resetState(ctx context.Context, task *types.Tas
 func (h *taskStateChangeHandler) onTaskSuccess(ctx context.Context, task *types.Task, result *types.TaskResult) error {
 	if task.TaskType != types.ProofBatch {
 		log.NewTaskEvent(h.logger, zerolog.DebugLevel, task).
-			Msgf("task has type %s, just update pending dependency", task.TaskType)
+			Msgf("Task has type %s, just update pending dependency", task.TaskType)
 		return nil
 	}
 
 	log.NewTaskResultEvent(h.logger, zerolog.InfoLevel, result).
 		Stringer(logging.FieldBatchId, task.BatchId).
-		Msg("Proof batch completed")
+		Msg("Batch proof generation is completed successfully")
 
 	err := h.batchSetter.SetBatchAsProved(ctx, task.BatchId)
 

--- a/nil/services/synccommittee/internal/metrics/task_storage_metrics.go
+++ b/nil/services/synccommittee/internal/metrics/task_storage_metrics.go
@@ -6,7 +6,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/NilFoundation/nil/nil/common/check"
 	"github.com/NilFoundation/nil/nil/internal/telemetry"
 	"github.com/NilFoundation/nil/nil/internal/telemetry/telattr"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
@@ -87,8 +86,7 @@ func (h *taskStorageMetricsHandler) registerStatsCallback(meter telemetry.Meter)
 	_, err := meter.RegisterCallback(
 		func(ctx context.Context, observer metric.Observer) error {
 			provider, ok := h.provider.Load().(types.TaskStatsProvider)
-			check.PanicIfNot(ok)
-			if provider == nil {
+			if !ok || provider == nil {
 				return nil
 			}
 

--- a/nil/services/synccommittee/internal/storage/block_storage_op_batch_count.go
+++ b/nil/services/synccommittee/internal/storage/block_storage_op_batch_count.go
@@ -41,6 +41,15 @@ func (t batchCountOp) addStoredCount(tx db.RwTx, delta int32, config BlockStorag
 	return t.putBatchesCount(tx, newBatchesCount)
 }
 
+func (t batchCountOp) hasFreeSpace(tx db.RoTx, config BlockStorageConfig) (bool, error) {
+	currentBatchesCount, err := t.getBatchesCount(tx)
+	if err != nil {
+		return false, err
+	}
+	hasSpace := currentBatchesCount < config.StoredBatchesLimit
+	return hasSpace, nil
+}
+
 func (batchCountOp) getBatchesCount(tx db.RoTx) (uint32, error) {
 	bytes, err := tx.Get(storedBatchesCountTable, mainShardKey)
 	switch {


### PR DESCRIPTION
### Sync Committee: Block Storage Fix

This PR addresses the following error encountered on `nil-dev` after a full state reset was triggered:

```
error preparing batch: error loading latest batch from the storage: batch with the specified id is not found, id=23d4376b-f92e-488a-abb6-8a3dc8cf6c20
```

Changes:
* Fixed `BlockStorage.ResetAllBatches(...)` by setting `latestBatchId` to `nil`
* Added `BlockStorage.HasFreeSpace(...)` method to avoid unnecessary batch creation in `Aggregator`