### PR TITLE
relayer: expose smart account addr via debug api

### DIFF
--- a/nil/services/relayer/service.go
+++ b/nil/services/relayer/service.go
@@ -176,6 +176,7 @@ func New(
 		l1Storage,
 		l2Storage,
 		rs.L1FinalityEnsurer,
+		l2SmartAccountAddr,
 		clock,
 		rs.Logger,
 	)


### PR DESCRIPTION
## Short Summary

For the testing purposes we need a convenient way to fetch relayer L2 smart account addr. Added it to the debug API

## Checklist

- [x] I have read and followed the [Contributing Guide](https://github.com/NilFoundation/nil/blob/main/CONTRIBUTION-GUIDE.md)
- [x] I have tested the changes locally
- [x] I have added relevant tests (if applicable)
- [x] I have updated documentation/comments (if applicable)
