### PR TITLE
[version] Restart services on chain or protocol change

### DIFF
--- a/nil/internal/collate/bootstrap.go
+++ b/nil/internal/collate/bootstrap.go
@@ -2,17 +2,11 @@ package collate
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/NilFoundation/nil/nil/common"
-	"github.com/NilFoundation/nil/nil/common/check"
 	"github.com/NilFoundation/nil/nil/common/logging"
 	"github.com/NilFoundation/nil/nil/internal/db"
 	"github.com/NilFoundation/nil/nil/internal/network"
-	"github.com/NilFoundation/nil/nil/internal/types"
 )
-
-const topicVersion = "/nil/version"
 
 func topicBootstrapShard() network.ProtocolID {
 	return "/nil/snap"
@@ -51,32 +45,6 @@ func SetBootstrapHandler(ctx context.Context, nm network.Manager, db db.DB) {
 	)
 
 	logger.Info().Msg("Enabled bootstrap endpoint")
-}
-
-func SetVersionHandler(ctx context.Context, nm network.Manager, fabric db.DB) error {
-	tx, err := fabric.CreateRoTx(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to create transaction: %w", err)
-	}
-	defer tx.Rollback()
-
-	// The genesis block must have been initialized before this method is called.
-	version, err := db.ReadBlockHashByNumber(tx, types.MainShardId, 0)
-	if err != nil {
-		return fmt.Errorf("failed to read genesis block hash: %w", err)
-	}
-	check.PanicIfNot(!version.Empty())
-
-	resp, err := version.MarshalNil()
-	if err != nil {
-		return fmt.Errorf("failed to marshal genesis block hash: %w", err)
-	}
-
-	nm.SetRequestHandler(ctx, topicVersion, func(ctx context.Context, _ []byte) ([]byte, error) {
-		return resp, nil
-	})
-
-	return nil
 }
 
 func fetchShardSnap(
@@ -118,18 +86,4 @@ func fetchSnapshot(
 		return err
 	}
 	return fetchShardSnap(ctx, nm, peerId, db, logger)
-}
-
-func fetchGenesisBlockHash(ctx context.Context, nm network.Manager, peerId network.PeerID) (common.Hash, error) {
-	resp, err := nm.SendRequestAndGetResponse(ctx, peerId, topicVersion, nil)
-	if err != nil {
-		return common.EmptyHash, fmt.Errorf("failed to fetch genesis block hash: %w", err)
-	}
-
-	var res common.Hash
-	if err := res.UnmarshalNil(resp); err != nil {
-		return common.EmptyHash, fmt.Errorf("failed to unmarshal genesis block hash: %w", err)
-	}
-
-	return res, nil
 }

--- a/nil/internal/collate/version.go
+++ b/nil/internal/collate/version.go
@@ -1,0 +1,127 @@
+package collate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/NilFoundation/nil/nil/common"
+	"github.com/NilFoundation/nil/nil/common/check"
+	"github.com/NilFoundation/nil/nil/common/logging"
+	"github.com/NilFoundation/nil/nil/internal/db"
+	"github.com/NilFoundation/nil/nil/internal/network"
+	"github.com/NilFoundation/nil/nil/internal/types"
+)
+
+const topicVersion = "/nil/version"
+
+type NodeVersion struct {
+	ProtocolVersion  string
+	GenesisBlockHash common.Hash
+}
+
+type VersionChecker struct {
+	nm     network.Manager
+	fabric db.DB
+	logger logging.Logger
+}
+
+func NewVersionChecker(nm network.Manager, fabric db.DB, logger logging.Logger) *VersionChecker {
+	return &VersionChecker{
+		nm:     nm,
+		fabric: fabric,
+		logger: logger,
+	}
+}
+
+func (v *VersionChecker) SetVersionHandler(ctx context.Context) error {
+	tx, err := v.fabric.CreateRoTx(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	// The genesis block must have been initialized before this method is called.
+	version, err := db.ReadBlockHashByNumber(tx, types.MainShardId, 0)
+	if err != nil {
+		return fmt.Errorf("failed to read genesis block hash: %w", err)
+	}
+	check.PanicIfNot(!version.Empty())
+
+	resp, err := version.MarshalNil()
+	if err != nil {
+		return fmt.Errorf("failed to marshal genesis block hash: %w", err)
+	}
+
+	v.nm.SetRequestHandler(ctx, topicVersion, func(ctx context.Context, _ []byte) ([]byte, error) {
+		return resp, nil
+	})
+
+	return nil
+}
+
+func (v *VersionChecker) GetLocalVersion(ctx context.Context) (NodeVersion, error) {
+	protocolVersion := v.nm.ProtocolVersion()
+
+	tx, err := v.fabric.CreateRoTx(ctx)
+	if err != nil {
+		return NodeVersion{}, err
+	}
+	defer tx.Rollback()
+
+	res, err := db.ReadBlockHashByNumber(tx, types.MainShardId, 0)
+	if err != nil {
+		if errors.Is(err, db.ErrKeyNotFound) {
+			return NodeVersion{protocolVersion, common.EmptyHash}, nil
+		}
+		return NodeVersion{}, err
+	}
+	return NodeVersion{protocolVersion, res}, err
+}
+
+func (v *VersionChecker) FetchRemoteVersion(ctx context.Context, peers network.AddrInfoSlice) (NodeVersion, error) {
+	var err error
+	for _, peer := range peers {
+		var peerId network.PeerID
+		peerId, err = v.nm.Connect(ctx, network.AddrInfo(peer))
+		if err != nil {
+			v.logger.Debug().Err(err).Msg("failed to fetch remote version from peer")
+			continue
+		}
+
+		var protocolVersion string
+		protocolVersion, err = v.nm.GetPeerProtocolVersion(peerId)
+		if err != nil {
+			v.logger.Debug().Err(err).
+				Stringer(logging.FieldPeerId, peerId).
+				Msg("failed to fetch protocol version from peer")
+			continue
+		}
+
+		var res common.Hash
+		res, err = v.fetchGenesisBlockHash(ctx, peerId)
+		if err != nil {
+			v.logger.Debug().Err(err).
+				Stringer(logging.FieldPeerId, peerId).
+				Msg("failed to fetch genesis block hash from peer")
+			continue
+		}
+
+		return NodeVersion{protocolVersion, res}, nil
+	}
+	return NodeVersion{}, fmt.Errorf("failed to fetch version from all peers; last error: %w", err)
+}
+
+func (v *VersionChecker) fetchGenesisBlockHash(ctx context.Context, peerId network.PeerID) (common.Hash, error) {
+	resp, err := v.nm.SendRequestAndGetResponse(ctx, peerId, topicVersion, nil)
+	if err != nil {
+		return common.EmptyHash, fmt.Errorf("failed to fetch genesis block hash: %w", err)
+	}
+
+	var res common.Hash
+	if err := res.UnmarshalNil(resp); err != nil {
+		return common.EmptyHash, fmt.Errorf("failed to unmarshal genesis block hash: %w", err)
+	}
+
+	return res, nil
+}

--- a/nil/services/indexer/badger/badger.go
+++ b/nil/services/indexer/badger/badger.go
@@ -52,9 +52,17 @@ func NewBadgerDriver(path string) (*BadgerDriver, error) {
 	return storage, nil
 }
 
-func (b *BadgerDriver) SetupScheme(ctx context.Context, params driver.SetupParams) error {
-	// no need to setup scheme
-	return nil
+func (b *BadgerDriver) FetchVersion(ctx context.Context) (common.Hash, error) {
+	block, err := b.FetchBlock(ctx, types.MainShardId, 0)
+	if block == nil || err != nil {
+		return common.EmptyHash, err
+	}
+
+	return block.Hash(types.MainShardId), nil
+}
+
+func (b *BadgerDriver) ResetDB(context.Context) error {
+	return b.db.DropAll()
 }
 
 func (b *BadgerDriver) IndexBlocks(ctx context.Context, blocksToIndex []*driver.BlockWithShardId) error {
@@ -161,7 +169,7 @@ func (b *BadgerDriver) indexBlockTransactions(
 	return nil
 }
 
-func (d *BadgerDriver) IndexTxPool(ctx context.Context, txPoolStatuses []*driver.TxPoolStatus) error {
+func (b *BadgerDriver) IndexTxPool(context.Context, []*driver.TxPoolStatus) error {
 	return errors.New("not implemented")
 }
 

--- a/nil/services/indexer/driver/driver.go
+++ b/nil/services/indexer/driver/driver.go
@@ -16,7 +16,8 @@ type IndexerDriver interface {
 	FetchEarliestAbsentBlockId(context.Context, types.ShardId) (types.BlockNumber, error)
 	FetchNextPresentBlockId(context.Context, types.ShardId, types.BlockNumber) (types.BlockNumber, error)
 	FetchAddressActions(context.Context, types.Address, types.BlockNumber) ([]indexertypes.AddressAction, error)
-	SetupScheme(ctx context.Context, params SetupParams) error
+	FetchVersion(context.Context) (common.Hash, error)
+	ResetDB(ctx context.Context) error
 	IndexBlocks(context.Context, []*BlockWithShardId) error
 	IndexTxPool(context.Context, []*TxPoolStatus) error
 	HaveBlock(context.Context, types.ShardId, types.BlockNumber) (bool, error)

--- a/nil/services/indexer/fetch_block.go
+++ b/nil/services/indexer/fetch_block.go
@@ -5,11 +5,8 @@ import (
 	"errors"
 
 	"github.com/NilFoundation/nil/nil/common/check"
-	"github.com/NilFoundation/nil/nil/common/logging"
 	"github.com/NilFoundation/nil/nil/internal/types"
 )
-
-var logger = logging.NewLogger("fetch-block")
 
 var ErrBlockNotFound = errors.New("block not found")
 

--- a/nil/tests/archive_node/complex_test.go
+++ b/nil/tests/archive_node/complex_test.go
@@ -84,7 +84,9 @@ func (s *SuiteArchiveNodeComplex) TestProtocolUpdate() {
 		s.stopArchiveNode()
 		s.Cancel()
 		s.startCluster(newProtocolVersion)
+	})
 
+	s.Run("RunArchiveNode", func() {
 		_, _, rc := s.runArchiveNode(database)
 
 		select {


### PR DESCRIPTION
Syncing nodes stop if the chain or protocol version changed.
Indexer stops if the chain version changed.

Changes:
- Moved existing version-related stuff to a separate file and refactored a bit for my needs.
- Added a version check loop to the syncers (called on the main shard syncer only).
- Added a version check loop to the indexer.
- Refactored indexer a bit.
- Implemented version check and db reset in badger indexer.

Fixes https://github.com/NilFoundation/nil/issues/769 and https://github.com/NilFoundation/nil/issues/659

Tested locally:
1. Start cluster -> Start archive node -> Stop cluster; drop validator keys and db (keep network keys); start the cluster anew -> Archive node stops after discovering the change in the version.
2. Same for indexer instead of archive.