### PR TITLE
[pprof] Serve on pprof port for external network too

### DIFF
--- a/nil/internal/profiling/profiling.go
+++ b/nil/internal/profiling/profiling.go
@@ -10,6 +10,6 @@ const DefaultPort = 6060
 
 func Start(port int) {
 	go func() {
-		_ = http.ListenAndServe("localhost:"+strconv.Itoa(port), nil) //nolint:gosec
+		_ = http.ListenAndServe(":"+strconv.Itoa(port), nil) //nolint:gosec
 	}()
 }


### PR DESCRIPTION
I've found it unfortunate that cluster node pprof is not available from the external network (and it's hard to get profiles from the cluster machines).