### PR TITLE
fix(RPC): add `address` field to `eth_getProof` response

### DIFF
--- a/nil/services/rpc/jsonrpc/eth_accounts.go
+++ b/nil/services/rpc/jsonrpc/eth_accounts.go
@@ -101,6 +101,7 @@ func (api *APIImplRo) GetProof(
 
 	// Create the basic proof result
 	result := &EthProof{
+		Address:      address,
 		AccountProof: hexutil.FromBytesSlice(accountProofBytes),
 		StorageProof: storageProofs,
 	}

--- a/nil/services/rpc/jsonrpc/eth_accounts_test.go
+++ b/nil/services/rpc/jsonrpc/eth_accounts_test.go
@@ -191,7 +191,7 @@ func (suite *SuiteEthAccounts) TestGetSeqno() {
 	suite.Equal(hexutil.Uint64(1), res)
 }
 
-func (suite *SuiteEthAccounts) TestGetProofNew() {
+func (suite *SuiteEthAccounts) TestGetProof() {
 	ctx := suite.T().Context()
 
 	// Test keys to check in proofs
@@ -227,6 +227,7 @@ func (suite *SuiteEthAccounts) TestGetProofNew() {
 	suite.Require().NoError(err)
 
 	// Verify empty result for non-existing address
+	suite.Equal(nonExistingAddr, resNonExisting.Address)
 	suite.NotEmpty(resNonExisting.AccountProof)
 	suite.Zero(resNonExisting.Balance)
 	suite.Zero(resNonExisting.CodeHash)
@@ -256,6 +257,7 @@ func (suite *SuiteEthAccounts) verifyProofResult(res *EthProof, smartContractsRo
 	suite.Require().NoError(sc.UnmarshalSSZ(val))
 
 	// Verify account fields
+	suite.Equal(suite.smcAddr, res.Address)
 	suite.Require().Equal(res.Balance, sc.Balance)
 	suite.Require().Equal(res.CodeHash, sc.CodeHash)
 	suite.Require().Equal(res.Nonce, sc.Seqno)

--- a/nil/services/rpc/jsonrpc/types.go
+++ b/nil/services/rpc/jsonrpc/types.go
@@ -591,13 +591,15 @@ type EstimateFeeRes struct {
 }
 
 // @component EthProof ethProof object "Response for eth_getProof."
-// @componentprop Balance balance integer true the balance of the account. See `eth_getBalance`
-// @componentprop CodeHash codeHash string true 32 Bytes - hash of the code of the account.
-// @componentprop Nonce nonce integer true nonce of the account. See eth_getTransactionCount
-// @componentprop StorageHash storageHash string true 32 Bytes - hash of the StorageRoot. All storage will deliver a MerkleProof starting with this rootHash.
-// @componentprop AccountProof accountProof array true Array of ssz-serialized MerkleTree-Nodes, starting with the stateRoot-Node, following the path of the address hash as path.
-// @componentprop StorageProof storageProof array true Array of storage-entries as requested.
+// @componentprop Address address string true "The address associated with the account"
+// @componentprop Balance balance integer true "The balance of the account. See `eth_getBalance`."
+// @componentprop CodeHash codeHash string true "32 Bytes - hash of the code of the account."
+// @componentprop Nonce nonce integer true "Nonce of the account. See eth_getTransactionCount."
+// @componentprop StorageHash storageHash string true "32 Bytes - hash of the StorageRoot. All storage will deliver a MerkleProof starting with this rootHash."
+// @componentprop AccountProof accountProof array true "Array of ssz-serialized MerkleTree-Nodes, starting with the stateRoot-Node, following the path of the address hash as path."
+// @componentprop StorageProof storageProof array true "Array of storage-entries as requested."
 type EthProof struct {
+	Address      types.Address   `json:"address"`
 	Balance      types.Value     `json:"balance"`
 	CodeHash     common.Hash     `json:"codeHash"`
 	Nonce        types.Seqno     `json:"nonce"`


### PR DESCRIPTION
## Short Summary

Add `address` field to `eth_getProof` response

## What Changes Were Made

- Add `address` field to `eth_getProof` response
- Adjust tests
- Adjust docstrings for `EthProof` structure

## Related Issue

Fixes to https://github.com/NilFoundation/nil/pull/851

## Checklist

_Please mark each item with an `x` inside the brackets (e.g., [x]) once completed._

- [x] I have read and followed the [Contributing Guide](https://github.com/NilFoundation/nil/blob/main/CONTRIBUTION-GUIDE.md)
- [x] I have tested the changes locally
- [x] I have added relevant tests (if applicable)
- [x] I have updated documentation/comments (if applicable)
