### PR TITLE
docs: remove duplicate GetShardIdList() from Filters section

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,6 @@ The current RPC is loosely modeled after the Ethereum RPC. The RPC exposes the f
 * `UninstallFilter()`
 * `GetFilterChanges()`
 * `GetFilterLogs()`
-* `GetShardIdList()`
 
 ### Shards
 


### PR DESCRIPTION
## Short Summary

Keeps GetShardIdList() only under “Shards”, eliminating redundancy and clarifying RPC grouping for integrators and tooling.

## Checklist

- [x] I have read and followed the [Contributing Guide](https://github.com/NilFoundation/nil/blob/main/CONTRIBUTION-GUIDE.md)
- [x] I have tested the changes locally
- [ ] I have added relevant tests (if applicable)
- [x] I have updated documentation/comments (if applicable)
