### PR TITLE
[nix] build only nil/nild binaries for dependencies tests

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -55,64 +55,74 @@
           uniswap = (pkgs.callPackage ./nix/uniswap.nix { });
           docsaibackend = (pkgs.callPackage ./nix/docsaibackend.nix { });
         };
-        checks = rec {
-          nil = (pkgs.callPackage ./nix/nil.nix {
-            enableRaceDetector = true;
-            enableTesting = true;
-            solc = packages.solc;
-          });
+        checks =
+          let
+            nilMinimal = pkgs.callPackage ./nix/nil.nix {
+              solc = packages.solc;
+              enableTesting = false;
+              enableRaceDetector = false;
+              testGroup = "none";
+              subPackages = [ "nil/cmd/nil" "nil/cmd/nild" "nil/cmd/relayer" ];
+            };
+          in
+          rec {
+            nil = (pkgs.callPackage ./nix/nil.nix {
+              enableRaceDetector = true;
+              enableTesting = true;
+              solc = packages.solc;
+            });
 
-          # split tests into groups
-          ibft = nil.override {
-            testGroup = "ibft";
-            parallelTesting = true;
-          };
-          heavy = nil.override {
-            testGroup = "heavy";
-            parallelTesting = true;
-          };
-          others = nil.override {
-            testGroup = "others";
-            parallelTesting = true;
-          };
+            # split tests into groups
+            ibft = nil.override {
+              testGroup = "ibft";
+              parallelTesting = true;
+            };
+            heavy = nil.override {
+              testGroup = "heavy";
+              parallelTesting = true;
+            };
+            others = nil.override {
+              testGroup = "others";
+              parallelTesting = true;
+            };
 
-          niljs = (pkgs.callPackage ./nix/niljs.nix {
-            nil = packages.nil;
-            solc = packages.solc;
-            enableTesting = true;
-          });
-          clijs = (pkgs.callPackage ./nix/clijs.nix {
-            nil = packages.nil;
-            enableTesting = true;
-          });
-          nilhardhat = (pkgs.callPackage ./nix/nilhardhat.nix {
-            nil = packages.nil;
-            solc = packages.solc;
-            enableTesting = true;
-          });
-          nildocs = (pkgs.callPackage ./nix/nildocs.nix {
-            nil = packages.nil;
-            enableTesting = true;
-            solc = packages.solc;
-          });
-          nilexplorer = (pkgs.callPackage ./nix/nilexplorer.nix {
-            enableTesting = true;
-            nil = packages.nil;
-          });
-          walletextension = (pkgs.callPackage ./nix/walletextension.nix {
-            nil = packages.nil;
-            enableTesting = true;
-          });
-          uniswap = (pkgs.callPackage ./nix/uniswap.nix {
-            nil = packages.nil;
-            enableTesting = true;
-          });
-          rollup-bridge-contracts =
-            (pkgs.callPackage ./nix/rollup-bridge-contracts.nix {
-              nil = packages.nil;
+            niljs = (pkgs.callPackage ./nix/niljs.nix {
+              nil = nilMinimal;
+              solc = packages.solc;
               enableTesting = true;
             });
-        };
+            clijs = (pkgs.callPackage ./nix/clijs.nix {
+              nil = nilMinimal;
+              enableTesting = true;
+            });
+            nilhardhat = (pkgs.callPackage ./nix/nilhardhat.nix {
+              nil = nilMinimal;
+              solc = packages.solc;
+              enableTesting = true;
+            });
+            nildocs = (pkgs.callPackage ./nix/nildocs.nix {
+              nil = nilMinimal;
+              enableTesting = true;
+              solc = packages.solc;
+            });
+            nilexplorer = (pkgs.callPackage ./nix/nilexplorer.nix {
+              enableTesting = true;
+              nil = nilMinimal;
+            });
+            walletextension = (pkgs.callPackage ./nix/walletextension.nix {
+              nil = nilMinimal;
+              enableTesting = true;
+            });
+            uniswap = (pkgs.callPackage ./nix/uniswap.nix {
+              nil = nilMinimal;
+              enableTesting = true;
+            });
+            rollup-bridge-contracts =
+              (pkgs.callPackage ./nix/rollup-bridge-contracts.nix {
+                nil = nilMinimal;
+                enableTesting = true;
+              });
+          };
 
         bundlers = rec {
           deb = pkg:

--- a/nil/services/rpc/jsonrpc/debug_api.go
+++ b/nil/services/rpc/jsonrpc/debug_api.go
@@ -89,7 +89,6 @@ func (api *DebugAPIImpl) getBlockByReference(
 ) (*DebugRPCBlock, error) {
 	var blockData *types.RawBlockWithExtractedData
 	var err error
-	fmt.Println("====================== withTransactions", withTransactions)
 	if withTransactions {
 		blockData, err = api.rawApi.GetFullBlockData(ctx, shardId, blockReference)
 		if err != nil {

--- a/rollup-bridge-contracts/test_integration.sh
+++ b/rollup-bridge-contracts/test_integration.sh
@@ -26,11 +26,6 @@ if [ -z "$NILD_BIN" ]; then
     exit 1
 fi
 
-if [ -z "$FAUCET_BIN" ]; then
-    echo "FAUCET_BIN is not set!"
-    exit 1
-fi
-
 if [ -z "$RELAYER_BIN" ]; then
     echo "RELAYER_BIN is not set!"
     exit 1
@@ -105,11 +100,6 @@ $NILD_BIN run --http-port 8529 --collator-tick-ms=100 >$LOG_DIR/nild.log 2>&1 &
 pids+=("$!")
 wait_for_http_service "http://127.0.0.1:8529"
 
-echo "Starting faucet"
-$FAUCET_BIN run --port 8527 &
-pids+=("$!")
-wait_for_http_service "http://127.0.0.1:8527"
-
 npx hardhat l2-task-runner --networkname local --l1networkname geth
 
 echo "Starting relayer"
@@ -121,7 +111,7 @@ $RELAYER_BIN run \
     --l2-endpoint=http://127.0.0.1:8529 \
     --l2-debug-mode=true \
     --l2-smart-account-salt=1234567890 \
-    --l2-faucet-address=http://127.0.0.1:8527 \
+    --l2-faucet-address=http://127.0.0.1:8529 \
     --l2-contract-addr=0xdeadbeef \
     >$LOG_DIR/relayer.log 2>&1 &
 pids+=("$!")


### PR DESCRIPTION
It's too long to build all binaries and then upload their cache to S3. After this patch we will build only nild and nil packages for niljs, nildocs, etc tests.
