### PR TITLE
Release 2025.05.15 (0.2.0)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
       let
         revCount = self.revCount or self.dirtyRevCount or 1;
         rev = self.shortRev or self.dirtyShortRev or "unknown";
-        version = "0.1.5-${toString revCount}";
+        version = "0.2.0-${toString revCount}";
         versionFull = "${version}-${rev}";
         pkgs = import nixpkgs {
           inherit system;

--- a/nil/services/rpc/internal/http/connection.go
+++ b/nil/services/rpc/internal/http/connection.go
@@ -8,8 +8,8 @@ import (
 
 const (
 	MaxRequestContentLength  = 1024 * 1024 * 32 // 32MB
-	minSupportedRevision     = 1185
-	minSupportedNiljsVersion = "0.24.0"
+	minSupportedRevision     = 1416
+	minSupportedNiljsVersion = "0.27.0"
 	niljsClientVersionPrefix = "niljs/"
 )
 


### PR DESCRIPTION
Release changes:

- Switching from poseidon to Keccak256 as hash function
- For more compatibility with Etherium all data now serialised using RLP mechanism instead of SSZ