### PR TITLE
[release] Bump js lib versions

### DIFF
--- a/create-nil-hardhat-project/package.json
+++ b/create-nil-hardhat-project/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-nil-hardhat-project",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "main": "index.js",
   "bin": {
     "create-nil-hardhat-template": "scripts/cli.js"
@@ -28,7 +28,6 @@
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^5.0.0",
     "dotenv": "^16.4.5",
-    "ts-node": "^10.9.2",
-    "@nilfoundation/smart-contracts": "0.7.0"
+    "ts-node": "^10.9.2"
   }
 }

--- a/hardhat-plugin/package.json
+++ b/hardhat-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nilfoundation/hardhat-nil-plugin",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"description": "Custom Hardhat plugin to enable seamless deployment and interaction with applications within =nil;",
 	"main": "dist/index.js",
 	"module": "dist/index.esm.js",

--- a/niljs/package.json
+++ b/niljs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nilfoundation/niljs",
   "author": "=nil; Foundation",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/NilFoundation/nil.js.git"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -853,10 +853,10 @@ importers:
   rollup-bridge-contracts:
     dependencies:
       '@nilfoundation/niljs':
-        specifier: 0.26.0
+        specifier: 0.27.0
         version: link:../niljs
       '@nilfoundation/smart-contracts':
-        specifier: 0.8.0
+        specifier: 0.9.0
         version: link:../smart-contracts
       '@openzeppelin/contracts':
         specifier: ^5.1.0

--- a/rollup-bridge-contracts/package.json
+++ b/rollup-bridge-contracts/package.json
@@ -81,7 +81,7 @@
     "hardhat-deploy": "0.14.0",
     "path-exists": "^5.0.0",
     "yargs": "^17.7.2",
-    "@nilfoundation/niljs": "0.26.0",
-    "@nilfoundation/smart-contracts": "0.8.0"
+    "@nilfoundation/niljs": "0.27.0",
+    "@nilfoundation/smart-contracts": "0.9.0"
   }
 }

--- a/smart-contracts/package.json
+++ b/smart-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nilfoundation/smart-contracts",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Nil smart-contracts implementations",
   "sideEffects": false,
   "files": [


### PR DESCRIPTION
Bumping versions for release:
niljs
smart-contracts
create-nil-hardhat-project
hardhat-plugin
rollup-bridge-contracts