### PR TITLE
Sync Committee: Block Debugger API

### DIFF
--- a/nil/cmd/sync_committee_cli/internal/commands/executor.go
+++ b/nil/cmd/sync_committee_cli/internal/commands/executor.go
@@ -49,7 +49,7 @@ func (t *Executor[P]) Run(
 	defer stop()
 
 	executorParams := t.params.GetExecutorParams()
-	client := debug.NewClient(executorParams.DebugRpcEndpoint, t.logger)
+	client := debug.NewTasksClient(executorParams.DebugRpcEndpoint, t.logger)
 
 	runIteration := func(ctx context.Context) {
 		output, err := command(ctx, t.params, client)

--- a/nil/cmd/sync_committee_cli/main.go
+++ b/nil/cmd/sync_committee_cli/main.go
@@ -80,7 +80,7 @@ func buildGetTasksCmd(commonParam *commands.ExecutorParams, logger logging.Logge
 		cmdParams.Limit,
 		fmt.Sprintf(
 			"limit the number of tasks returned, should be in range [%d, %d]",
-			public.TaskDebugMinLimit, public.TaskDebugMaxLimit,
+			public.DebugMinLimit, public.DebugMaxLimit,
 		),
 	)
 

--- a/nil/services/synccommittee/core/service.go
+++ b/nil/services/synccommittee/core/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/NilFoundation/nil/nil/services/synccommittee/core/reset"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/core/rollupcontract"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/core/syncer"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/debug"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/l1client"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/metrics"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/rpc"
@@ -113,11 +114,14 @@ func New(ctx context.Context, cfg *Config, database db.DB) (*SyncCommittee, erro
 		logger,
 	)
 
+	blockDebugger := debug.NewBlockDebugger(rollupContractWrapper, blockStorage)
+
 	rpcServer := rpc.NewServerWithTasks(
 		rpc.NewServerConfig(cfg.OwnRpcEndpoint),
 		logger,
 		taskScheduler,
-		scheduler.NewTaskDebugger(taskStorage, logger),
+		debug.NewTaskDebugger(taskStorage, logger),
+		rpc.DebugBlocksServerHandler(blockDebugger),
 	)
 
 	feeUpdaterMetrics, err := metrics.NewFeeUpdaterMetrics()

--- a/nil/services/synccommittee/debug/client.go
+++ b/nil/services/synccommittee/debug/client.go
@@ -6,6 +6,10 @@ import (
 	"github.com/NilFoundation/nil/nil/services/synccommittee/public"
 )
 
-func NewClient(endpoint string, logger logging.Logger) public.TaskDebugApi {
+func NewTasksClient(endpoint string, logger logging.Logger) public.TaskDebugApi {
 	return rpc.NewTaskDebugRpcClient(endpoint, logger)
+}
+
+func NewBlocksClient(endpoint string, logger logging.Logger) public.BlockDebugApi {
+	return rpc.NewBlockDebugRpcClient(endpoint, logger)
 }

--- a/nil/services/synccommittee/internal/debug/block_debugger.go
+++ b/nil/services/synccommittee/internal/debug/block_debugger.go
@@ -1,0 +1,69 @@
+package debug
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/NilFoundation/nil/nil/common"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/public"
+)
+
+type DebuggerL1Client interface {
+	GetLatestFinalizedStateRoot(ctx context.Context) (common.Hash, error)
+}
+
+type DebuggerBlockStorage interface {
+	TryGetProvedStateRoot(ctx context.Context) (*common.Hash, error)
+	GetLatestFetched(ctx context.Context) (public.BlockRefs, error)
+	GetBatchView(ctx context.Context, batchId public.BatchId) (*public.BatchViewDetailed, error)
+	GetBatchViews(ctx context.Context, request public.BatchDebugRequest) ([]*public.BatchViewCompact, error)
+	GetBatchStats(ctx context.Context) (*public.BatchStats, error)
+}
+
+type blockDebugger struct {
+	l1Client DebuggerL1Client
+	storage  DebuggerBlockStorage
+}
+
+func NewBlockDebugger(
+	l1Client DebuggerL1Client,
+	storage DebuggerBlockStorage,
+) public.BlockDebugApi {
+	return &blockDebugger{
+		l1Client: l1Client,
+		storage:  storage,
+	}
+}
+
+func (d *blockDebugger) GetStateRootData(ctx context.Context) (*public.StateRootData, error) {
+	l1StateRoot, err := d.l1Client.GetLatestFinalizedStateRoot(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get latest finalized state root from L1: %w", err)
+	}
+
+	localStateRoot, err := d.storage.TryGetProvedStateRoot(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get locally stored state root: %w", err)
+	}
+
+	stateRootData := public.NewStateRootData(l1StateRoot, localStateRoot)
+	return stateRootData, nil
+}
+
+func (d *blockDebugger) GetLatestFetched(ctx context.Context) (public.BlockRefs, error) {
+	return d.storage.GetLatestFetched(ctx)
+}
+
+func (d *blockDebugger) GetBatchView(ctx context.Context, batchId public.BatchId) (*public.BatchViewDetailed, error) {
+	return d.storage.GetBatchView(ctx, batchId)
+}
+
+func (d *blockDebugger) GetBatchViews(
+	ctx context.Context, request public.BatchDebugRequest,
+) ([]*public.BatchViewCompact, error) {
+	return d.storage.GetBatchViews(ctx, request)
+}
+
+func (d *blockDebugger) GetBatchStats(ctx context.Context) (*public.BatchStats, error) {
+	return d.storage.GetBatchStats(ctx)
+}

--- a/nil/services/synccommittee/internal/debug/task_debugger.go
+++ b/nil/services/synccommittee/internal/debug/task_debugger.go
@@ -1,4 +1,4 @@
-package scheduler
+package debug
 
 import (
 	"context"

--- a/nil/services/synccommittee/internal/rpc/block_debug_rpc_client.go
+++ b/nil/services/synccommittee/internal/rpc/block_debug_rpc_client.go
@@ -1,0 +1,66 @@
+package rpc
+
+import (
+	"context"
+
+	"github.com/NilFoundation/nil/nil/client"
+	"github.com/NilFoundation/nil/nil/common/logging"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/public"
+)
+
+type blockDebugRpcClient struct {
+	client client.RawClient
+}
+
+func NewBlockDebugRpcClient(apiEndpoint string, logger logging.Logger) public.BlockDebugApi {
+	return &blockDebugRpcClient{
+		client: NewRetryClient(apiEndpoint, logger),
+	}
+}
+
+func (c blockDebugRpcClient) GetLatestFetched(ctx context.Context) (public.BlockRefs, error) {
+	return doRPCCall[public.BlockRefs](
+		ctx,
+		c.client,
+		public.DebugGetLatestFetched,
+	)
+}
+
+func (c blockDebugRpcClient) GetStateRootData(ctx context.Context) (*public.StateRootData, error) {
+	return doRPCCall[*public.StateRootData](
+		ctx,
+		c.client,
+		public.DebugGetStateRootData,
+	)
+}
+
+func (c blockDebugRpcClient) GetBatchView(
+	ctx context.Context, batchId public.BatchId,
+) (*public.BatchViewDetailed, error) {
+	return doRPCCall2[public.BatchId, *public.BatchViewDetailed](
+		ctx,
+		c.client,
+		public.DebugGetBatchView,
+		batchId,
+	)
+}
+
+func (c blockDebugRpcClient) GetBatchViews(
+	ctx context.Context,
+	request public.BatchDebugRequest,
+) ([]*public.BatchViewCompact, error) {
+	return doRPCCall2[public.BatchDebugRequest, []*public.BatchViewCompact](
+		ctx,
+		c.client,
+		public.DebugGetBatchViews,
+		request,
+	)
+}
+
+func (c blockDebugRpcClient) GetBatchStats(ctx context.Context) (*public.BatchStats, error) {
+	return doRPCCall[*public.BatchStats](
+		ctx,
+		c.client,
+		public.DebugGetBatchStats,
+	)
+}

--- a/nil/services/synccommittee/internal/rpc/block_debug_rpc_test.go
+++ b/nil/services/synccommittee/internal/rpc/block_debug_rpc_test.go
@@ -1,0 +1,220 @@
+package rpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/NilFoundation/nil/nil/common"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/core/rollupcontract"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/debug"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/storage"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/testaide"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/public"
+	"github.com/stretchr/testify/suite"
+)
+
+type BlockDebugRpcTestSuite struct {
+	ServerTestSuite
+	l1Client  rollupcontract.WrapperMock
+	storage   *storage.BlockStorage
+	rpcClient public.BlockDebugApi
+}
+
+func TestBlockDebugRpcTestSuite(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(BlockDebugRpcTestSuite))
+}
+
+func (s *BlockDebugRpcTestSuite) SetupSuite() {
+	s.ServerTestSuite.SetupSuite()
+
+	s.l1Client = rollupcontract.WrapperMock{}
+	cfg := storage.DefaultBlockStorageConfig()
+	s.storage = storage.NewBlockStorage(s.database, cfg, s.clock, s.metricsHandler, s.logger)
+
+	blockDebugger := debug.NewBlockDebugger(&s.l1Client, s.storage)
+	handler := DebugBlocksServerHandler(blockDebugger)
+	s.RunRpcServer(handler)
+
+	s.rpcClient = NewBlockDebugRpcClient(s.serverEndpoint, s.logger)
+}
+
+func (s *BlockDebugRpcTestSuite) Test_GetLatestFetched_Empty() {
+	refs, err := s.rpcClient.GetLatestFetched(s.context)
+	s.Require().NoError(err)
+	s.Require().Empty(refs)
+}
+
+func (s *BlockDebugRpcTestSuite) Test_GetLatestFetched() {
+	batch := testaide.NewBlockBatch(testaide.ShardsCount)
+	err := s.storage.PutBlockBatch(s.context, batch)
+	s.Require().NoError(err)
+
+	refs, err := s.rpcClient.GetLatestFetched(s.context)
+	s.Require().NoError(err)
+	s.Require().NotEmpty(refs)
+	s.Require().Equal(batch.LatestRefs(), refs)
+}
+
+func (s *BlockDebugRpcTestSuite) Test_GetStateRootData_Empty_Local() {
+	l1StateRoot := testaide.RandomHash()
+	s.l1Client.GetLatestFinalizedStateRootFunc = func(ctx context.Context) (common.Hash, error) {
+		return l1StateRoot, nil
+	}
+
+	stateRootData, err := s.rpcClient.GetStateRootData(s.context)
+	s.Require().NoError(err)
+	s.Require().NotNil(stateRootData)
+
+	s.Equal(l1StateRoot, stateRootData.L1StateRoot)
+	s.Nil(stateRootData.LocalStateRoot)
+}
+
+func (s *BlockDebugRpcTestSuite) Test_GetStateRootData() {
+	l1StateRoot := testaide.RandomHash()
+	s.l1Client.GetLatestFinalizedStateRootFunc = func(ctx context.Context) (common.Hash, error) {
+		return l1StateRoot, nil
+	}
+
+	localStateRoot := testaide.RandomHash()
+	err := s.storage.SetProvedStateRoot(s.context, localStateRoot)
+	s.Require().NoError(err)
+
+	stateRootData, err := s.rpcClient.GetStateRootData(s.context)
+	s.Require().NoError(err)
+	s.Require().NotNil(stateRootData)
+
+	s.Equal(l1StateRoot, stateRootData.L1StateRoot)
+	s.Equal(&localStateRoot, stateRootData.LocalStateRoot)
+}
+
+func (s *BlockDebugRpcTestSuite) Test_GetBatchView_NotExists() {
+	batchId := types.NewBatchId()
+	view, err := s.rpcClient.GetBatchView(s.context, batchId)
+	s.Require().NoError(err)
+	s.Require().Nil(view)
+}
+
+func (s *BlockDebugRpcTestSuite) Test_GetBatchView() {
+	batch := testaide.NewBlockBatch(testaide.ShardsCount)
+	err := s.storage.PutBlockBatch(s.context, batch)
+	s.Require().NoError(err)
+
+	view, err := s.rpcClient.GetBatchView(s.context, batch.Id)
+	s.Require().NoError(err)
+	s.Require().NotNil(view)
+	s.requireBatchViewEqual(batch, view)
+}
+
+func (s *BlockDebugRpcTestSuite) Test_GetBatchViews_Empty() {
+	request := public.DefaultBatchDebugRequest()
+	views, err := s.rpcClient.GetBatchViews(s.context, request)
+	s.Require().NoError(err)
+	s.Require().Empty(views)
+}
+
+func (s *BlockDebugRpcTestSuite) Test_GetBatchViews() {
+	batches := testaide.NewBatchesSequence(3)
+	for _, batch := range batches {
+		err := s.storage.PutBlockBatch(s.context, batch)
+		s.Require().NoError(err)
+	}
+
+	request := public.DefaultBatchDebugRequest()
+	views, err := s.rpcClient.GetBatchViews(s.context, request)
+	s.Require().NoError(err)
+	s.Require().Len(views, len(batches))
+
+	s.requireViewsEqualToLatest(views, batches)
+}
+
+func (s *BlockDebugRpcTestSuite) Test_GetBatchViews_Limit() {
+	batches := testaide.NewBatchesSequence(10)
+	for _, batch := range batches {
+		err := s.storage.PutBlockBatch(s.context, batch)
+		s.Require().NoError(err)
+	}
+
+	limit := 5
+	request := public.NewBatchDebugRequest(&limit)
+	views, err := s.rpcClient.GetBatchViews(s.context, *request)
+	s.Require().NoError(err)
+	s.Require().Len(views, limit)
+
+	s.requireViewsEqualToLatest(views, batches)
+}
+
+func (s *BlockDebugRpcTestSuite) requireViewsEqualToLatest(
+	views []*public.BatchViewCompact, batches []*types.BlockBatch,
+) {
+	s.T().Helper()
+
+	// Views are expected to be in reverse order (the latest batch comes first)
+
+	for i, view := range views {
+		batch := batches[len(batches)-1-i]
+		s.requireBatchViewCompactEqual(batch, view)
+	}
+}
+
+func (s *BlockDebugRpcTestSuite) Test_GetBatchStats_Empty() {
+	stats, err := s.rpcClient.GetBatchStats(s.context)
+	s.Require().NoError(err)
+	s.Require().Equal(public.NewBatchStats(0, 0, 0), stats)
+}
+
+func (s *BlockDebugRpcTestSuite) Test_GetBatchStats() {
+	batches := testaide.NewBatchesSequence(3)
+
+	for _, batch := range batches {
+		err := s.storage.PutBlockBatch(s.context, batch)
+		s.Require().NoError(err)
+	}
+
+	stats, err := s.rpcClient.GetBatchStats(s.context)
+	s.Require().NoError(err)
+	s.Require().Equal(public.NewBatchStats(len(batches), 0, 0), stats)
+
+	// Seal the first two batches
+
+	fstSealed, err := batches[0].Seal(testaide.NewDataProofs(), s.clock.Now())
+	s.Require().NoError(err)
+	err = s.storage.PutBlockBatch(s.context, fstSealed)
+	s.Require().NoError(err)
+
+	sndSealed, err := batches[1].Seal(testaide.NewDataProofs(), s.clock.Now())
+	s.Require().NoError(err)
+	err = s.storage.PutBlockBatch(s.context, sndSealed)
+	s.Require().NoError(err)
+
+	// Mark the first batch as proved
+
+	err = s.storage.SetBatchAsProved(s.context, batches[0].Id)
+	s.Require().NoError(err)
+
+	stats, err = s.rpcClient.GetBatchStats(s.context)
+	s.Require().NoError(err)
+	s.Require().Equal(public.NewBatchStats(len(batches), 2, 1), stats)
+}
+
+func (s *BlockDebugRpcTestSuite) requireBatchViewEqual(
+	expected *types.BlockBatch, actual *public.BatchViewDetailed,
+) {
+	s.T().Helper()
+	s.Require().Equal(expected.Id, actual.Id)
+	s.Require().Equal(expected.ParentId, actual.ParentId)
+	s.Require().Equal(expected.IsSealed, actual.IsSealed)
+	s.Require().Equal(expected.CreatedAt, actual.CreatedAt)
+	s.Require().Equal(expected.UpdatedAt, actual.UpdatedAt)
+}
+
+func (s *BlockDebugRpcTestSuite) requireBatchViewCompactEqual(
+	expected *types.BlockBatch, actual *public.BatchViewCompact,
+) {
+	s.T().Helper()
+	s.Require().Equal(expected.Id, actual.Id)
+	s.Require().Equal(expected.ParentId, actual.ParentId)
+	s.Require().Equal(expected.IsSealed, actual.IsSealed)
+	s.Require().Equal(expected.CreatedAt, actual.CreatedAt)
+}

--- a/nil/services/synccommittee/internal/rpc/server_with_tasks.go
+++ b/nil/services/synccommittee/internal/rpc/server_with_tasks.go
@@ -6,6 +6,18 @@ import (
 	"github.com/NilFoundation/nil/nil/services/synccommittee/public"
 )
 
+func TaskRequestServerHandler(service api.TaskRequestHandler) Handler {
+	return NewHandler(api.TaskRequestHandlerNamespace, service)
+}
+
+func DebugTasksServerHandler(service public.TaskDebugApi) Handler {
+	return NewHandler(public.DebugTasksNamespace, service)
+}
+
+func DebugBlocksServerHandler(service public.BlockDebugApi) Handler {
+	return NewHandler(public.DebugBlocksNamespace, service)
+}
+
 func NewServerWithTasks(
 	config ServerConfig,
 	logger logging.Logger,
@@ -14,8 +26,8 @@ func NewServerWithTasks(
 	additionalHandlers ...Handler,
 ) *server {
 	handlers := make([]Handler, 0, len(additionalHandlers)+2)
-	handlers = append(handlers, NewHandler(api.TaskRequestHandlerNamespace, requestHandler))
-	handlers = append(handlers, NewHandler(public.DebugNamespace, debugApi))
+	handlers = append(handlers, TaskRequestServerHandler(requestHandler))
+	handlers = append(handlers, DebugTasksServerHandler(debugApi))
 	handlers = append(handlers, additionalHandlers...)
 	return NewServer(config, logger, handlers...)
 }

--- a/nil/services/synccommittee/internal/rpc/task_debug_rpc_client.go
+++ b/nil/services/synccommittee/internal/rpc/task_debug_rpc_client.go
@@ -23,7 +23,7 @@ func (c *taskDebugRpcClient) GetTasks(
 	ctx context.Context,
 	request *public.TaskDebugRequest,
 ) ([]*public.TaskView, error) {
-	return doRPCCall[*public.TaskDebugRequest, []*public.TaskView](
+	return doRPCCall2[*public.TaskDebugRequest, []*public.TaskView](
 		ctx,
 		c.client,
 		public.DebugGetTasks,
@@ -32,7 +32,7 @@ func (c *taskDebugRpcClient) GetTasks(
 }
 
 func (c *taskDebugRpcClient) GetTaskTree(ctx context.Context, taskId types.TaskId) (*public.TaskTreeView, error) {
-	return doRPCCall[types.TaskId, *public.TaskTreeView](
+	return doRPCCall2[types.TaskId, *public.TaskTreeView](
 		ctx,
 		c.client,
 		public.DebugGetTaskTree,

--- a/nil/services/synccommittee/internal/rpc/task_request_rpc_client.go
+++ b/nil/services/synccommittee/internal/rpc/task_request_rpc_client.go
@@ -20,7 +20,7 @@ func NewTaskRequestRpcClient(apiEndpoint string, logger logging.Logger) api.Task
 }
 
 func (r *taskRequestRpcClient) GetTask(ctx context.Context, request *api.TaskRequest) (*types.Task, error) {
-	return doRPCCall[*api.TaskRequest, *types.Task](
+	return doRPCCall2[*api.TaskRequest, *types.Task](
 		ctx,
 		r.client,
 		api.TaskRequestHandlerGetTask,
@@ -29,7 +29,7 @@ func (r *taskRequestRpcClient) GetTask(ctx context.Context, request *api.TaskReq
 }
 
 func (r *taskRequestRpcClient) CheckIfTaskIsActive(ctx context.Context, request *api.TaskCheckRequest) (bool, error) {
-	return doRPCCall[*api.TaskCheckRequest, bool](
+	return doRPCCall2[*api.TaskCheckRequest, bool](
 		ctx,
 		r.client,
 		api.TaskRequestHandlerCheckIfTaskExists,
@@ -38,7 +38,7 @@ func (r *taskRequestRpcClient) CheckIfTaskIsActive(ctx context.Context, request 
 }
 
 func (r *taskRequestRpcClient) SetTaskResult(ctx context.Context, result *types.TaskResult) error {
-	_, err := doRPCCall[*types.TaskResult, any](
+	_, err := doRPCCall2[*types.TaskResult, any](
 		ctx,
 		r.client,
 		api.TaskRequestHandlerSetTaskResult,

--- a/nil/services/synccommittee/proofprovider/service.go
+++ b/nil/services/synccommittee/proofprovider/service.go
@@ -7,6 +7,7 @@ import (
 	"github.com/NilFoundation/nil/nil/common/logging"
 	"github.com/NilFoundation/nil/nil/internal/db"
 	"github.com/NilFoundation/nil/nil/internal/telemetry"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/debug"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/executor"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/metrics"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/rpc"
@@ -87,7 +88,7 @@ func New(config *Config, database db.DB) (*ProofProvider, error) {
 		rpc.NewServerConfig(config.OwnRpcEndpoint),
 		logger,
 		taskScheduler,
-		scheduler.NewTaskDebugger(taskStorage, logger),
+		debug.NewTaskDebugger(taskStorage, logger),
 	)
 
 	taskCancelChecker := scheduler.NewTaskCancelChecker(

--- a/nil/services/synccommittee/public/batch_view.go
+++ b/nil/services/synccommittee/public/batch_view.go
@@ -1,0 +1,91 @@
+package public
+
+import (
+	"time"
+
+	"github.com/NilFoundation/nil/nil/common"
+	coreTypes "github.com/NilFoundation/nil/nil/internal/types"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/internal/types"
+)
+
+type (
+	BlockRefs             = types.BlockRefs
+	ShardChainSegmentView = []common.Hash
+	ChainSegmentsView     = map[coreTypes.ShardId]ShardChainSegmentView
+)
+
+type batchViewCommon struct {
+	Id        BatchId   `json:"id"`
+	ParentId  *BatchId  `json:"parentId"`
+	IsSealed  bool      `json:"isSealed"`
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+func newBatchViewCommon(
+	id BatchId,
+	parentId *BatchId,
+	isSealed bool,
+	createdAt time.Time,
+	updatedAt time.Time,
+) batchViewCommon {
+	return batchViewCommon{
+		Id:        id,
+		ParentId:  parentId,
+		IsSealed:  isSealed,
+		CreatedAt: createdAt,
+		UpdatedAt: updatedAt,
+	}
+}
+
+type BatchViewCompact struct {
+	batchViewCommon
+	BlocksCount int `json:"blocksCount"`
+}
+
+func NewBatchViewCompact(
+	id BatchId,
+	parentId *BatchId,
+	isSealed bool,
+	createdAt time.Time,
+	updatedAt time.Time,
+	blocksCount int,
+) *BatchViewCompact {
+	return &BatchViewCompact{
+		batchViewCommon: newBatchViewCommon(
+			id,
+			parentId,
+			isSealed,
+			createdAt,
+			updatedAt,
+		),
+		BlocksCount: blocksCount,
+	}
+}
+
+type BatchViewDetailed struct {
+	batchViewCommon
+	Blocks ChainSegmentsView `json:"blocks"`
+}
+
+func NewBatchViewDetailed(batch *types.BlockBatch) *BatchViewDetailed {
+	blocks := make(ChainSegmentsView)
+	for shardId, segment := range batch.Blocks {
+		view := make(ShardChainSegmentView, 0, len(segment))
+		for _, blockId := range segment {
+			view = append(view, blockId.Hash)
+		}
+		blocks[shardId] = view
+	}
+
+	return &BatchViewDetailed{
+		batchViewCommon: newBatchViewCommon(
+			batch.Id,
+			batch.ParentId,
+			batch.IsSealed,
+			batch.CreatedAt,
+			batch.UpdatedAt,
+		),
+		Blocks: blocks,
+	}
+}

--- a/nil/services/synccommittee/public/block_debug_api.go
+++ b/nil/services/synccommittee/public/block_debug_api.go
@@ -1,0 +1,82 @@
+package public
+
+import (
+	"context"
+
+	"github.com/NilFoundation/nil/nil/common"
+)
+
+const (
+	DebugBlocksNamespace  = "DebugBlocks"
+	DebugGetStateRootData = DebugBlocksNamespace + "_getStateRootData"
+	DebugGetLatestFetched = DebugBlocksNamespace + "_getLatestFetched"
+	DebugGetBatchView     = DebugBlocksNamespace + "_getBatchView"
+	DebugGetBatchViews    = DebugBlocksNamespace + "_getBatchViews"
+	DebugGetBatchStats    = DebugBlocksNamespace + "_getBatchStats"
+)
+
+type StateRootData struct {
+	L1StateRoot    common.Hash  `json:"l1StateRoot"`
+	LocalStateRoot *common.Hash `json:"localStateRoot"`
+}
+
+func NewStateRootData(
+	l1StateRoot common.Hash,
+	localStateRoot *common.Hash,
+) *StateRootData {
+	return &StateRootData{
+		L1StateRoot:    l1StateRoot,
+		LocalStateRoot: localStateRoot,
+	}
+}
+
+type BatchDebugRequest struct {
+	listRequestCommon
+}
+
+func NewBatchDebugRequest(
+	limit *int,
+) *BatchDebugRequest {
+	return &BatchDebugRequest{
+		listRequestCommon: newListRequestCommon(limit),
+	}
+}
+
+func DefaultBatchDebugRequest() BatchDebugRequest {
+	return *NewBatchDebugRequest(nil)
+}
+
+type BatchStats struct {
+	TotalCount  int `json:"totalCount"`
+	SealedCount int `json:"sealedCount"`
+	ProvedCount int `json:"provedCount"`
+}
+
+func NewBatchStats(
+	totalCount int,
+	sealedCount int,
+	provedCount int,
+) *BatchStats {
+	return &BatchStats{
+		TotalCount:  totalCount,
+		SealedCount: sealedCount,
+		ProvedCount: provedCount,
+	}
+}
+
+type BlockDebugApi interface {
+	// GetStateRootData retrieves the current state root data.
+	GetStateRootData(ctx context.Context) (*StateRootData, error)
+
+	// GetLatestFetched retrieves references to the latest fetched blocks for all shards.
+	GetLatestFetched(ctx context.Context) (BlockRefs, error)
+
+	// GetBatchView retrieves detailed information about a specific block batch identified by the given BatchId.
+	GetBatchView(ctx context.Context, batchId BatchId) (*BatchViewDetailed, error)
+
+	// GetBatchViews retrieves a list of compact batch views based on the given BatchDebugRequest parameters.
+	GetBatchViews(ctx context.Context, request BatchDebugRequest) ([]*BatchViewCompact, error)
+
+	// GetBatchStats retrieves statistics about batches currently persisted in the storage.
+	GetBatchStats(ctx context.Context) (*BatchStats, error)
+}

--- a/nil/services/synccommittee/public/list_request_common.go
+++ b/nil/services/synccommittee/public/list_request_common.go
@@ -1,0 +1,33 @@
+package public
+
+import "fmt"
+
+const (
+	DefaultLimit  = 20
+	DebugMinLimit = 1
+	DebugMaxLimit = 1000
+)
+
+type listRequestCommon struct {
+	Limit int `json:"limit"`
+}
+
+func newListRequestCommon(limit *int) listRequestCommon {
+	targetLimit := DefaultLimit
+	if limit != nil {
+		targetLimit = *limit
+	}
+
+	return listRequestCommon{
+		Limit: targetLimit,
+	}
+}
+
+func (r *listRequestCommon) Validate() error {
+	if r.Limit < DebugMinLimit || r.Limit > DebugMaxLimit {
+		return fmt.Errorf(
+			"limit must be between %d and %d, actual is %d", DebugMinLimit, DebugMaxLimit, r.Limit)
+	}
+
+	return nil
+}

--- a/nil/services/synccommittee/public/task_debug_api.go
+++ b/nil/services/synccommittee/public/task_debug_api.go
@@ -10,14 +10,9 @@ import (
 )
 
 const (
-	DebugNamespace   = "Debug"
-	DebugGetTasks    = DebugNamespace + "_getTasks"
-	DebugGetTaskTree = DebugNamespace + "_getTaskTree"
-)
-
-const (
-	TaskDebugMinLimit = 1
-	TaskDebugMaxLimit = 1000
+	DebugTasksNamespace = "DebugTasks"
+	DebugGetTasks       = DebugTasksNamespace + "_getTasks"
+	DebugGetTaskTree    = DebugTasksNamespace + "_getTaskTree"
 )
 
 type TaskDebugOrder int8
@@ -55,22 +50,22 @@ const (
 	DefaultDebugTaskType   = types.TaskTypeNone
 	DefaultDebugTaskOwner  = types.UnknownExecutorId
 	DefaultDebugTaskOrder  = OrderByCreatedAt
-	DefaultDebugTaskLimit  = 20
 )
 
 type TaskDebugRequest struct {
+	listRequestCommon
+
 	Status TaskStatus     `json:"status,omitempty"`
 	Type   TaskType       `json:"type,omitempty"`
 	Owner  TaskExecutorId `json:"owner,omitempty"`
 
 	Order     TaskDebugOrder `json:"order"`
 	Ascending bool           `json:"ascending,omitempty"`
-	Limit     int            `json:"limit"`
 }
 
 func DefaultTaskDebugRequest() TaskDebugRequest {
 	defaultOrder := DefaultDebugTaskOrder
-	defaultLimit := DefaultDebugTaskLimit
+	defaultLimit := DefaultLimit
 	return *NewTaskDebugRequest(nil, nil, nil, &defaultOrder, false, &defaultLimit)
 }
 
@@ -102,28 +97,15 @@ func NewTaskDebugRequest(
 		targetOrder = *order
 	}
 
-	targetLimit := DefaultDebugTaskLimit
-	if limit != nil {
-		targetLimit = *limit
-	}
-
 	return &TaskDebugRequest{
+		listRequestCommon: newListRequestCommon(limit),
+
 		Status:    targetStatus,
 		Type:      targetType,
 		Owner:     targetOwner,
 		Order:     targetOrder,
 		Ascending: ascending,
-		Limit:     targetLimit,
 	}
-}
-
-func (r *TaskDebugRequest) Validate() error {
-	if r.Limit < TaskDebugMinLimit || r.Limit > TaskDebugMaxLimit {
-		return fmt.Errorf(
-			"limit must be between %d and %d, actual is %d", TaskDebugMinLimit, TaskDebugMaxLimit, r.Limit)
-	}
-
-	return nil
 }
 
 // TaskDebugApi provides methods to retrieve debug information on tasks.


### PR DESCRIPTION
### Sync Committee: Block Debugger API

Now SC, in addition to task-related methods, exposes a block debugging API, which provides the following data:

* State root (both local and L1)
* Latest fetched blocks across all shards
* Detailed information about a specific block batch (full list of block hashes, when it was created, etc.)
* List of `K` most recently created batches
* Statistics about currently stored batches

The client part will be added to `sync_committee_cli` in a follow-up PR
