### PR TITLE
docs(nil-101): replace broken CLI installer URL

### DIFF
--- a/docs/nil/nil-101.mdx
+++ b/docs/nil/nil-101.mdx
@@ -17,7 +17,7 @@ The =nil; CLI is an easy-to-use tool for interacting with the cluster.
 To install the CLI:
 
 ```bash
-curl -fsSL https://github.com/NilFoundation/nil/raw/master/install.sh | bash
+curl -fsSL https://github.com/NilFoundation/nil/raw/main/scripts/install_cli.sh | bash
 ```
 
 To generate a new private key and set inside the CLI config:


### PR DESCRIPTION
## Short Summary

The tutorial’s install command pointed to  `https://github.com/NilFoundation/nil/raw/master/install.sh`,  which now returns **404**.  
This PR updates the link to the maintained script at  
`https://github.com/NilFoundation/nil/blob/main/scripts/install_cli.sh`,  
restoring a working one-line installer for the =nil; CLI and preventing installation errors for new users.

## Checklist

_Please mark each item with an `x` inside the brackets (e.g., [x]) once completed._

- [x] I have read and followed the [Contributing Guide](https://github.com/NilFoundation/nil/blob/main/CONTRIBUTION-GUIDE.md)
- [ ] I have tested the changes locally
- [ ] I have added relevant tests (if applicable)
- [x] I have updated documentation/comments (if applicable)
