### PR TITLE
fix: fix NetworkErrorNotification imports

### DIFF
--- a/explorer_frontend/src/features/healthcheck/components/NetworkErrorNotification.tsx
+++ b/explorer_frontend/src/features/healthcheck/components/NetworkErrorNotification.tsx
@@ -1,5 +1,6 @@
 import { COLORS, Notification, WarningIcon } from "@nilfoundation/ui-kit";
 import type { FC } from "react";
+import { useMobile } from "../../shared/hooks/useMobile";
 
 export const NetworkErrorNotification: FC = () => {
   const [isMobile] = useMobile();


### PR DESCRIPTION
This diff fixes `NetworkErrorNotification` component imports section. The `useMobile` import was deleted accidentally.