### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/nil/common/hexutil/json.go
+++ b/nil/common/hexutil/json.go
@@ -55,10 +55,7 @@ func (b *Big) UnmarshalText(input []byte) error {
 	words := make([]big.Word, len(raw)/bigWordNibbles+1)
 	end := len(raw)
 	for i := range words {
-		start := end - bigWordNibbles
-		if start < 0 {
-			start = 0
-		}
+		start := max(end-bigWordNibbles, 0)
 		for ri := start; ri < end; ri++ {
 			nib := decodeNibble(raw[ri])
 			if nib == badNibble {


### PR DESCRIPTION
## Short Summary

In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.



## What Changes Were Made

<!-- List the changes introduced in this PR -->

-
-
-

## Related Issue

<!-- If this PR addresses an existing issue, please link it here -->

Fixes #[Issue Number]  
or  
Related to #[Issue Number]

## Breaking Changes (if any)

<!-- OPTIONAL: Describe any breaking changes this PR introduces -->

## Screenshots / Visual Changes

<!-- OPTIONAL: Add screenshots, recordings, or visual references if relevant -->

## Checklist

_Please mark each item with an `x` inside the brackets (e.g., [x]) once completed._

- [ ] I have read and followed the [Contributing Guide](https://github.com/NilFoundation/nil/blob/main/CONTRIBUTION-GUIDE.md)
- [ ] I have tested the changes locally
- [ ] I have added relevant tests (if applicable)
- [ ] I have updated documentation/comments (if applicable)
