### PR TITLE
enable full pipeline in bridge integration test

### DIFF
--- a/nil/services/relayer/internal/l2/contract_wrapper.go
+++ b/nil/services/relayer/internal/l2/contract_wrapper.go
@@ -135,7 +135,7 @@ func (w *l2ContractWrapper) RelayMessage(
 		w.smartAccountAddr,
 		calldata,
 		evt.FeePack,
-		evt.L2Limit,
+		types.Value0,
 		nil,
 		w.contractAddr,
 		w.privateKey,


### PR DESCRIPTION
## Short Summary

relayMessage is not a payable function and should be executed with zero value. Fixed the bug and enabled full integration test for the rollup bridge contracts

## Checklist

- [x] I have read and followed the [Contributing Guide](https://github.com/NilFoundation/nil/blob/main/CONTRIBUTION-GUIDE.md)
- [x] I have tested the changes locally
- [x] I have added relevant tests (if applicable)
- [x] I have updated documentation/comments (if applicable)
