### PR TITLE
Fix broken API reference in README

### DIFF
--- a/nil/services/cometa/README.md
+++ b/nil/services/cometa/README.md
@@ -2,4 +2,4 @@
 **Cometa**(Contracts Metadata) is a service that provides metadata about the contracts deployed on the blockchain,
 such as source code, debug information, etc.
 
-The data can be accessed via the Cometa API, which can be found in the [CometaAPI](jsonrpc.go) interface.
+The data can be accessed via the Cometa API, which can be found in the [CometaAPI](service.go) interface.


### PR DESCRIPTION
## Short Summary

Corrected the link in the Cometa service README from a non-existent jsonrpc.go file to the actual service.go file, where the Cometa API interface is implemented. This improves documentation accuracy and helps developers find the relevant code more easily.
