### PR TITLE
Sync Committee CLI: Block and Batch Diagnostics

### DIFF
--- a/nil/cmd/sync_committee_cli/internal/commands/batch_fields.go
+++ b/nil/cmd/sync_committee_cli/internal/commands/batch_fields.go
@@ -1,0 +1,50 @@
+package commands
+
+import (
+	"maps"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/NilFoundation/nil/nil/cmd/sync_committee_cli/internal/output"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/public"
+)
+
+type BatchField = string
+
+var BatchViewFields = map[BatchField]struct {
+	Getter func(batch *public.BatchViewCompact) string
+}{
+	"Id": {func(batch *public.BatchViewCompact) string { return batch.Id.String() }},
+	"ParentId": {func(batch *public.BatchViewCompact) string {
+		if batch.ParentId != nil {
+			return batch.ParentId.String()
+		}
+		return output.EmptyCell
+	}},
+	"IsSealed":    {func(batch *public.BatchViewCompact) string { return strconv.FormatBool(batch.IsSealed) }},
+	"CreatedAt":   {func(batch *public.BatchViewCompact) string { return batch.CreatedAt.Format(output.TimeFormat) }},
+	"UpdatedAt":   {func(batch *public.BatchViewCompact) string { return batch.UpdatedAt.Format(output.TimeFormat) }},
+	"BlocksCount": {func(batch *public.BatchViewCompact) string { return strconv.Itoa(batch.BlocksCount) }},
+}
+
+func AllBatchFields() []BatchField {
+	fields := slices.Collect(maps.Keys(BatchViewFields))
+	sortBatchFields(fields)
+	return fields
+}
+
+func sortBatchFields(fields []BatchField) {
+	slices.SortFunc(fields, func(l, r BatchField) int {
+		switch {
+		// The `Id` field always goes first
+		case l == "Id":
+			return -1
+		case r == "Id":
+			return 1
+		// All others are sorted alphabetically
+		default:
+			return strings.Compare(l, r)
+		}
+	})
+}

--- a/nil/cmd/sync_committee_cli/internal/commands/get_batch.go
+++ b/nil/cmd/sync_committee_cli/internal/commands/get_batch.go
@@ -1,0 +1,81 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/NilFoundation/nil/nil/cmd/sync_committee_cli/internal/exec"
+	"github.com/NilFoundation/nil/nil/common/logging"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/debug"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/public"
+	"github.com/spf13/cobra"
+)
+
+type GetBatchParams struct {
+	exec.Params
+	BatchId public.BatchId
+}
+
+type getBatch struct {
+	logger logging.Logger
+}
+
+func NewGetBatchCmd(logger logging.Logger) *getBatch {
+	return &getBatch{
+		logger: logger,
+	}
+}
+
+func (c *getBatch) Build() (*cobra.Command, error) {
+	paramsWithEndpoint := defaultParamsWithEndpoint()
+
+	cmdParams := &GetBatchParams{
+		Params: paramsWithEndpoint.Params,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "get-batch",
+		Short: "Retrieves detailed information about a specific block batch identified by the given BatchId",
+		RunE: func(*cobra.Command, []string) error {
+			executor := exec.NewExecutor(os.Stdout, c.logger, cmdParams)
+			client := debug.NewBlocksClient(paramsWithEndpoint.RpcEndpoint, c.logger)
+			return executor.Run(func(ctx context.Context) (exec.CmdOutput, error) {
+				return c.getBatch(ctx, cmdParams.BatchId, client)
+			})
+		},
+	}
+
+	paramsWithEndpoint.bind(cmd)
+
+	const batchIdFlag = "batch-id"
+	cmd.Flags().Var(&cmdParams.BatchId, batchIdFlag, "batch identifier")
+	if err := cmd.MarkFlagRequired(batchIdFlag); err != nil {
+		return nil, err
+	}
+
+	return cmd, nil
+}
+
+func (c *getBatch) getBatch(
+	ctx context.Context, batchId public.BatchId, api public.BlockDebugApi,
+) (exec.CmdOutput, error) {
+	batch, err := api.GetBatchView(ctx, batchId)
+	if err != nil {
+		return exec.EmptyOutput, fmt.Errorf("failed to get batches from debug API: %w", err)
+	}
+
+	if batch == nil {
+		return exec.EmptyOutput, fmt.Errorf(
+			"%w: batch with id=%s is not found in the local storage", exec.ErrNoDataFound, batchId,
+		)
+	}
+
+	jsonBytes, err := json.MarshalIndent(batch, "", "  ")
+	if err != nil {
+		return exec.EmptyOutput, fmt.Errorf("batch json marshaling failed: %w", err)
+	}
+
+	return string(jsonBytes), nil
+}

--- a/nil/cmd/sync_committee_cli/internal/commands/get_batch_stats.go
+++ b/nil/cmd/sync_committee_cli/internal/commands/get_batch_stats.go
@@ -1,0 +1,70 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/NilFoundation/nil/nil/cmd/sync_committee_cli/internal/exec"
+	"github.com/NilFoundation/nil/nil/cmd/sync_committee_cli/internal/output"
+	"github.com/NilFoundation/nil/nil/common/logging"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/debug"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/public"
+	"github.com/spf13/cobra"
+)
+
+type getBatchStats struct {
+	logger logging.Logger
+}
+
+func NewGetBatchStatsCmd(logger logging.Logger) *getBatchStats {
+	return &getBatchStats{
+		logger: logger,
+	}
+}
+
+func (c *getBatchStats) Build() (*cobra.Command, error) {
+	paramsWithEndpoint := defaultParamsWithEndpoint()
+
+	cmd := &cobra.Command{
+		Use:   "get-batch-stats",
+		Short: "Retrieve statistics about batches currently persisted in the storage",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			executor := exec.NewExecutor(os.Stdout, c.logger, paramsWithEndpoint)
+			client := debug.NewBlocksClient(paramsWithEndpoint.RpcEndpoint, c.logger)
+			return executor.Run(func(ctx context.Context) (exec.CmdOutput, error) {
+				return c.getBatchStats(ctx, client)
+			})
+		},
+	}
+
+	paramsWithEndpoint.bind(cmd)
+	return cmd, nil
+}
+
+func (c *getBatchStats) getBatchStats(ctx context.Context, client public.BlockDebugApi) (exec.CmdOutput, error) {
+	batchStats, err := client.GetBatchStats(ctx)
+	if err != nil {
+		return exec.EmptyOutput, fmt.Errorf("failed to get batch stats: %w", err)
+	}
+
+	table, err := c.dataAsTable(batchStats)
+	if err != nil {
+		return exec.EmptyOutput, fmt.Errorf("failed to build batch stats table: %w", err)
+	}
+
+	return table.AsCmdOutput(), nil
+}
+
+func (c *getBatchStats) dataAsTable(stats *public.BatchStats) (*output.Table, error) {
+	header := output.NewTableRowStr("Field", "Value")
+
+	rows := []output.TableRow{
+		output.NewTableRowStr("Total Batches Created", strconv.Itoa(stats.TotalCount)),
+		output.NewTableRowStr("Sealed Batches Count", strconv.Itoa(stats.SealedCount)),
+		output.NewTableRowStr("Proved Batches Count", strconv.Itoa(stats.ProvedCount)),
+	}
+
+	return output.NewTable(header, rows)
+}

--- a/nil/cmd/sync_committee_cli/internal/commands/get_batches.go
+++ b/nil/cmd/sync_committee_cli/internal/commands/get_batches.go
@@ -1,0 +1,106 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/NilFoundation/nil/nil/cmd/sync_committee_cli/internal/exec"
+	"github.com/NilFoundation/nil/nil/cmd/sync_committee_cli/internal/output"
+	"github.com/NilFoundation/nil/nil/common/logging"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/debug"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/public"
+	"github.com/spf13/cobra"
+)
+
+type GetBatchesParams struct {
+	exec.Params
+	public.BatchDebugRequest
+}
+
+func (p *GetBatchesParams) Validate() error {
+	return errors.Join(
+		p.Params.Validate(),
+		p.BatchDebugRequest.Validate(),
+	)
+}
+
+type getBatches struct {
+	logger logging.Logger
+}
+
+func NewGetBatchesCmd(logger logging.Logger) *getBatches {
+	return &getBatches{
+		logger: logger,
+	}
+}
+
+func (c *getBatches) Build() (*cobra.Command, error) {
+	paramsWithEndpoint := defaultParamsWithEndpoint()
+
+	cmdParams := &GetBatchesParams{
+		Params:            paramsWithEndpoint.Params,
+		BatchDebugRequest: public.DefaultBatchDebugRequest(),
+	}
+
+	cmd := &cobra.Command{
+		Use:   "get-batches",
+		Short: "Retrieve a list of batches currently persisted in the storage based on the given parameters",
+		RunE: func(*cobra.Command, []string) error {
+			executor := exec.NewExecutor(os.Stdout, c.logger, cmdParams)
+			client := debug.NewBlocksClient(paramsWithEndpoint.RpcEndpoint, c.logger)
+			return executor.Run(func(ctx context.Context) (exec.CmdOutput, error) {
+				return c.getBatches(ctx, cmdParams.BatchDebugRequest, client)
+			})
+		},
+	}
+
+	paramsWithEndpoint.bind(cmd)
+	bindListRequest(&cmdParams.ListRequest, cmd)
+	return cmd, nil
+}
+
+func (c *getBatches) getBatches(
+	ctx context.Context, request public.BatchDebugRequest, api public.BlockDebugApi,
+) (exec.CmdOutput, error) {
+	batches, err := api.GetBatchViews(ctx, request)
+	if err != nil {
+		return exec.EmptyOutput, fmt.Errorf("failed to get batches from debug API: %w", err)
+	}
+
+	if len(batches) == 0 {
+		return exec.EmptyOutput, fmt.Errorf("%w: no batches are currently created", exec.ErrNoDataFound)
+	}
+
+	tasksTable, err := c.dataAsTable(batches)
+	if err != nil {
+		return exec.EmptyOutput, fmt.Errorf("failed to build tasks table: %w", err)
+	}
+	tableOutput := tasksTable.AsCmdOutput()
+	return tableOutput, nil
+}
+
+func (c *getBatches) dataAsTable(batches []*public.BatchViewCompact) (*output.Table, error) {
+	fields := AllBatchFields()
+
+	rows := make([]output.TableRow, 0, len(batches))
+	for _, batch := range batches {
+		row := c.batchAsRow(batch, fields)
+		rows = append(rows, row)
+	}
+
+	return output.NewTable(fields, rows)
+}
+
+func (c *getBatches) batchAsRow(batch *public.BatchViewCompact, fieldsToInclude []BatchField) output.TableRow {
+	row := make(output.TableRow, 0, len(fieldsToInclude))
+
+	for _, fieldName := range fieldsToInclude {
+		fieldData := BatchViewFields[fieldName]
+		strValue := fieldData.Getter(batch)
+		row = append(row, strValue)
+	}
+
+	return row
+}

--- a/nil/cmd/sync_committee_cli/internal/commands/get_latest_fetched.go
+++ b/nil/cmd/sync_committee_cli/internal/commands/get_latest_fetched.go
@@ -1,0 +1,78 @@
+package commands
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"maps"
+	"os"
+	"slices"
+
+	"github.com/NilFoundation/nil/nil/cmd/sync_committee_cli/internal/exec"
+	"github.com/NilFoundation/nil/nil/cmd/sync_committee_cli/internal/output"
+	"github.com/NilFoundation/nil/nil/common/logging"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/debug"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/public"
+	"github.com/spf13/cobra"
+)
+
+type getLatestFetched struct {
+	logger logging.Logger
+}
+
+func NewGetLatestFetchedCmd(logger logging.Logger) *getLatestFetched {
+	return &getLatestFetched{
+		logger: logger,
+	}
+}
+
+func (c *getLatestFetched) Build() (*cobra.Command, error) {
+	paramsWithEndpoint := defaultParamsWithEndpoint()
+
+	cmd := &cobra.Command{
+		Use:   "get-latest-fetched",
+		Short: "Retrieves references to the latest fetched blocks for all shards",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			executor := exec.NewExecutor(os.Stdout, c.logger, paramsWithEndpoint)
+			client := debug.NewBlocksClient(paramsWithEndpoint.RpcEndpoint, c.logger)
+			return executor.Run(func(ctx context.Context) (exec.CmdOutput, error) {
+				return c.getLatestFetched(ctx, client)
+			})
+		},
+	}
+
+	paramsWithEndpoint.bind(cmd)
+	return cmd, nil
+}
+
+func (c *getLatestFetched) getLatestFetched(ctx context.Context, client public.BlockDebugApi) (exec.CmdOutput, error) {
+	latestFetched, err := client.GetLatestFetched(ctx)
+	if err != nil {
+		return exec.EmptyOutput, fmt.Errorf("failed to get state root data: %w", err)
+	}
+
+	table, err := c.dataAsTable(latestFetched)
+	if err != nil {
+		return exec.EmptyOutput, fmt.Errorf("failed to build state root data table: %w", err)
+	}
+
+	return table.AsCmdOutput(), nil
+}
+
+func (*getLatestFetched) dataAsTable(latestFetched public.BlockRefs) (*output.Table, error) {
+	headers := output.NewTableRowStr("Shard Id", "Block Hash", "Block Number")
+
+	rows := make([]output.TableRow, 0, len(latestFetched))
+
+	sortedRefs := slices.SortedFunc(
+		maps.Values(latestFetched),
+		func(l public.BlockRef, r public.BlockRef) int { return cmp.Compare(l.ShardId, r.ShardId) },
+	)
+
+	for _, ref := range sortedRefs {
+		row := output.NewTableRow(ref.ShardId, ref.Hash, ref.Number)
+		rows = append(rows, row)
+	}
+
+	return output.NewTable(headers, rows)
+}

--- a/nil/cmd/sync_committee_cli/internal/commands/get_state_root_data.go
+++ b/nil/cmd/sync_committee_cli/internal/commands/get_state_root_data.go
@@ -1,0 +1,68 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/NilFoundation/nil/nil/cmd/sync_committee_cli/internal/exec"
+	"github.com/NilFoundation/nil/nil/cmd/sync_committee_cli/internal/output"
+	"github.com/NilFoundation/nil/nil/common/logging"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/debug"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/public"
+	"github.com/spf13/cobra"
+)
+
+type getStateRootData struct {
+	logger logging.Logger
+}
+
+func NewGetStateRootDataCmd(logger logging.Logger) *getStateRootData {
+	return &getStateRootData{
+		logger: logger,
+	}
+}
+
+func (c *getStateRootData) Build() (*cobra.Command, error) {
+	paramsWithEndpoint := defaultParamsWithEndpoint()
+
+	cmd := &cobra.Command{
+		Use:   "get-state-root-data",
+		Short: "Retrieve the current state root data, including the L1 state root and the local state root",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			executor := exec.NewExecutor(os.Stdout, c.logger, paramsWithEndpoint)
+			client := debug.NewBlocksClient(paramsWithEndpoint.RpcEndpoint, c.logger)
+			return executor.Run(func(ctx context.Context) (exec.CmdOutput, error) {
+				return c.getStateRootData(ctx, client)
+			})
+		},
+	}
+
+	paramsWithEndpoint.bind(cmd)
+	return cmd, nil
+}
+
+func (c *getStateRootData) getStateRootData(ctx context.Context, client public.BlockDebugApi) (exec.CmdOutput, error) {
+	stateRootData, err := client.GetStateRootData(ctx)
+	if err != nil {
+		return exec.EmptyOutput, fmt.Errorf("failed to get state root data: %w", err)
+	}
+
+	table, err := c.dataAsTable(stateRootData)
+	if err != nil {
+		return exec.EmptyOutput, fmt.Errorf("failed to build state root data table: %w", err)
+	}
+
+	return table.AsCmdOutput(), nil
+}
+
+func (*getStateRootData) dataAsTable(data *public.StateRootData) (*output.Table, error) {
+	header := output.NewTableRowStr("Field", "Value")
+
+	rows := []output.TableRow{
+		output.NewTableRow(output.StrCell("L1 State Root"), data.L1StateRoot),
+		output.NewTableRow(output.StrCell("Local State Root"), data.LocalStateRoot),
+	}
+
+	return output.NewTable(header, rows)
+}

--- a/nil/cmd/sync_committee_cli/internal/commands/get_task_tree.go
+++ b/nil/cmd/sync_committee_cli/internal/commands/get_task_tree.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/NilFoundation/nil/nil/cmd/sync_committee_cli/internal/exec"
+	"github.com/NilFoundation/nil/nil/cmd/sync_committee_cli/internal/output"
 	"github.com/NilFoundation/nil/nil/common/logging"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/debug"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/public"
@@ -83,7 +84,7 @@ func (c *getTaskTree) getTaskTree(
 }
 
 func (*getTaskTree) buildTreeOutput(tree *public.TaskTreeView) (exec.CmdOutput, error) {
-	var builder exec.OutputBuilder
+	var builder output.Builder
 
 	var toTreeRec func(tree *public.TaskTreeView, prefix string, isLast bool, currentDepth int) error
 	toTreeRec = func(node *public.TaskTreeView, prefix string, isLast bool, currentDepth int) error {
@@ -102,24 +103,24 @@ func (*getTaskTree) buildTreeOutput(tree *public.TaskTreeView) (exec.CmdOutput, 
 
 		var execTimeStr string
 		if execTime := node.ExecutionTime; execTime != nil {
-			execTimeStr = exec.YellowStr(" (%s)", execTime.String())
+			execTimeStr = output.YellowStr(" (%s)", execTime.String())
 		}
 
 		builder.WriteLine(
-			node.Id.String(), exec.GreenStr(" %s %s", node.Type, node.CircuitType), execTimeStr,
+			node.Id.String(), output.GreenStr(" %s %s", node.Type, node.CircuitType), execTimeStr,
 		)
 
 		var statusStr string
 		var errorText string
 		if node.IsFailed() {
-			statusStr = exec.RedStr("%s", node.Status)
+			statusStr = output.RedStr("%s", node.Status)
 			errorText = " " + node.ResultErrorText
 		} else {
-			statusStr = exec.CyanStr("%s", node.Status)
+			statusStr = output.CyanStr("%s", node.Status)
 		}
 
 		builder.WriteLine(
-			prefix, "  Owner=", exec.CyanStr("%s", node.Owner), " Status=", statusStr, errorText,
+			prefix, "  Owner=", output.CyanStr("%s", node.Owner), " Status=", statusStr, errorText,
 		)
 
 		if len(node.Dependencies) == 0 {

--- a/nil/cmd/sync_committee_cli/internal/commands/params_with_endpoint.go
+++ b/nil/cmd/sync_committee_cli/internal/commands/params_with_endpoint.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/NilFoundation/nil/nil/cmd/sync_committee_cli/internal/exec"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/core"
+	"github.com/NilFoundation/nil/nil/services/synccommittee/public"
 	"github.com/spf13/cobra"
 )
 
@@ -29,4 +30,16 @@ func defaultParamsWithEndpoint() ParamsWithEndpoint {
 		Params:      exec.DefaultExecutorParams(),
 		RpcEndpoint: core.DefaultOwnRpcEndpoint,
 	}
+}
+
+func bindListRequest(params *public.ListRequest, cmd *cobra.Command) {
+	cmd.Flags().IntVar(
+		&params.Limit,
+		"limit",
+		params.Limit,
+		fmt.Sprintf(
+			"limit the number of rows returned, should be in range [%d, %d]",
+			public.DebugMinLimit, public.DebugMaxLimit,
+		),
+	)
 }

--- a/nil/cmd/sync_committee_cli/internal/commands/task_fields.go
+++ b/nil/cmd/sync_committee_cli/internal/commands/task_fields.go
@@ -4,17 +4,12 @@ import (
 	"maps"
 	"slices"
 	"strings"
-	"time"
 
+	"github.com/NilFoundation/nil/nil/cmd/sync_committee_cli/internal/output"
 	"github.com/NilFoundation/nil/nil/services/synccommittee/public"
 )
 
 type TaskField = string
-
-const (
-	timeFormat = time.RFC3339
-	emptyCell  = "nil"
-)
 
 var TaskViewFields = map[TaskField]struct {
 	Getter           func(task *public.TaskView) string
@@ -24,26 +19,26 @@ var TaskViewFields = map[TaskField]struct {
 	"BatchId":     {func(task *public.TaskView) string { return task.BatchId.String() }, false},
 	"Type":        {func(task *public.TaskView) string { return task.Type.String() }, true},
 	"CircuitType": {func(task *public.TaskView) string { return task.CircuitType.String() }, true},
-	"CreatedAt":   {func(task *public.TaskView) string { return task.CreatedAt.Format(timeFormat) }, true},
+	"CreatedAt":   {func(task *public.TaskView) string { return task.CreatedAt.Format(output.TimeFormat) }, true},
 	"StartedAt": {func(task *public.TaskView) string {
 		if task.StartedAt != nil {
-			return task.StartedAt.Format(timeFormat)
+			return task.StartedAt.Format(output.TimeFormat)
 		}
-		return emptyCell
+		return output.EmptyCell
 	}, false},
 	"ExecutionTime": {func(task *public.TaskView) string {
 		if task.ExecutionTime != nil {
 			return task.ExecutionTime.String()
 		}
-		return emptyCell
+		return output.EmptyCell
 	}, true},
 	"Owner":  {func(task *public.TaskView) string { return task.Owner.String() }, true},
 	"Status": {func(task *public.TaskView) string { return task.Status.String() }, true},
 }
 
-func AllFields() []TaskField {
+func AllTaskFields() []TaskField {
 	fields := slices.Collect(maps.Keys(TaskViewFields))
-	sortFields(fields)
+	sortTaskFields(fields)
 	return fields
 }
 
@@ -54,11 +49,11 @@ func DefaultTaskFields() []TaskField {
 			fields = append(fields, field)
 		}
 	}
-	sortFields(fields)
+	sortTaskFields(fields)
 	return fields
 }
 
-func sortFields(fields []TaskField) {
+func sortTaskFields(fields []TaskField) {
 	slices.SortFunc(fields, func(l, r TaskField) int {
 		switch {
 		// The `Id` field always goes first

--- a/nil/cmd/sync_committee_cli/internal/commands/task_fields_flag.go
+++ b/nil/cmd/sync_committee_cli/internal/commands/task_fields_flag.go
@@ -27,7 +27,7 @@ func (f TaskFieldsFlag) Set(str string) error {
 	}
 
 	if len(values) == 1 && strings.ToLower(values[0]) == "all" {
-		*f.FieldsToInclude = AllFields()
+		*f.FieldsToInclude = AllTaskFields()
 		return nil
 	}
 

--- a/nil/cmd/sync_committee_cli/internal/output/builder.go
+++ b/nil/cmd/sync_committee_cli/internal/output/builder.go
@@ -1,4 +1,4 @@
-package exec
+package output
 
 import (
 	"strings"
@@ -6,11 +6,11 @@ import (
 	"github.com/fatih/color"
 )
 
-type OutputBuilder struct {
+type Builder struct {
 	strings.Builder
 }
 
-func (b *OutputBuilder) WriteLine(parts ...string) {
+func (b *Builder) WriteLine(parts ...string) {
 	for _, part := range parts {
 		b.WriteString(part)
 	}

--- a/nil/cmd/sync_committee_cli/internal/output/table.go
+++ b/nil/cmd/sync_committee_cli/internal/output/table.go
@@ -1,0 +1,108 @@
+package output
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/NilFoundation/nil/nil/cmd/sync_committee_cli/internal/exec"
+)
+
+const (
+	TimeFormat = time.RFC3339
+	EmptyCell  = "nil"
+)
+
+type StrCell string
+
+func (c StrCell) String() string {
+	return string(c)
+}
+
+type TableRow []string
+
+func NewTableRow(cells ...fmt.Stringer) TableRow {
+	return newTableRowWithConverter(cells, func(cell fmt.Stringer) string {
+		if cell == nil {
+			return EmptyCell
+		}
+		if v := reflect.ValueOf(cell); v.Kind() == reflect.Pointer && v.IsNil() {
+			return EmptyCell
+		}
+		return cell.String()
+	})
+}
+
+func NewTableRowStr(cells ...string) TableRow {
+	return newTableRowWithConverter(cells, func(cell string) string { return cell })
+}
+
+func newTableRowWithConverter[T any](cells []T, converter func(T) string) TableRow {
+	row := make(TableRow, len(cells))
+	for i, cell := range cells {
+		row[i] = converter(cell)
+	}
+	return row
+}
+
+type Table struct {
+	header TableRow
+	rows   []TableRow
+}
+
+func NewTable(header TableRow, rows []TableRow) (*Table, error) {
+	if len(header) == 0 {
+		return nil, errors.New("header must not be empty")
+	}
+	if len(rows) == 0 {
+		return nil, errors.New("rows must not be empty")
+	}
+	if len(header) != len(rows[0]) {
+		return nil, errors.New("header and rows must have the same length")
+	}
+
+	return &Table{header: header, rows: rows}, nil
+}
+
+func (t *Table) AsCmdOutput() exec.CmdOutput {
+	var builder Builder
+
+	colWidths := make([]int, len(t.header))
+	for colIdx, cell := range t.header {
+		colWidths[colIdx] = len(cell)
+	}
+	for _, row := range t.rows {
+		for colIdx, cell := range row {
+			if len(cell) > colWidths[colIdx] {
+				colWidths[colIdx] = len(cell)
+			}
+		}
+	}
+
+	printRow := func(row []string) {
+		builder.WriteString("|")
+		for colIdx, cell := range row {
+			padding := strings.Repeat(" ", colWidths[colIdx]-len(cell))
+			builder.WriteString(" " + cell + padding + " |")
+		}
+		builder.WriteString("\n")
+	}
+
+	printRow(t.header)
+
+	// print header separator
+	builder.WriteString("|")
+	for _, width := range colWidths {
+		builder.WriteString(strings.Repeat("-", width+2))
+		builder.WriteString("|")
+	}
+	builder.WriteString("\n")
+
+	for _, row := range t.rows {
+		printRow(row)
+	}
+
+	return builder.String()
+}

--- a/nil/cmd/sync_committee_cli/main.go
+++ b/nil/cmd/sync_committee_cli/main.go
@@ -31,8 +31,15 @@ func execute() error {
 	}{
 		commands.NewGetTasksCmd(logger),
 		commands.NewGetTaskTreeCmd(logger),
+
 		commands.NewDecodeBatchCmd(logger),
 		commands.NewRollbackStateCmd(logger),
+
+		commands.NewGetStateRootDataCmd(logger),
+		commands.NewGetBatchesCmd(logger),
+		commands.NewGetBatchCmd(logger),
+		commands.NewGetLatestFetchedCmd(logger),
+		commands.NewGetBatchStatsCmd(logger),
 	}
 
 	for _, builder := range builders {

--- a/nil/services/synccommittee/public/batch_view.go
+++ b/nil/services/synccommittee/public/batch_view.go
@@ -9,6 +9,7 @@ import (
 )
 
 type (
+	BlockRef              = types.BlockRef
 	BlockRefs             = types.BlockRefs
 	ShardChainSegmentView = []common.Hash
 	ChainSegmentsView     = map[coreTypes.ShardId]ShardChainSegmentView

--- a/nil/services/synccommittee/public/block_debug_api.go
+++ b/nil/services/synccommittee/public/block_debug_api.go
@@ -31,14 +31,14 @@ func NewStateRootData(
 }
 
 type BatchDebugRequest struct {
-	listRequestCommon
+	ListRequest
 }
 
 func NewBatchDebugRequest(
 	limit *int,
 ) *BatchDebugRequest {
 	return &BatchDebugRequest{
-		listRequestCommon: newListRequestCommon(limit),
+		ListRequest: newListRequestCommon(limit),
 	}
 }
 
@@ -65,7 +65,7 @@ func NewBatchStats(
 }
 
 type BlockDebugApi interface {
-	// GetStateRootData retrieves the current state root data.
+	// GetStateRootData retrieves the current state root data, including the L1 state root and the local state root.
 	GetStateRootData(ctx context.Context) (*StateRootData, error)
 
 	// GetLatestFetched retrieves references to the latest fetched blocks for all shards.

--- a/nil/services/synccommittee/public/list_request_common.go
+++ b/nil/services/synccommittee/public/list_request_common.go
@@ -8,22 +8,22 @@ const (
 	DebugMaxLimit = 1000
 )
 
-type listRequestCommon struct {
+type ListRequest struct {
 	Limit int `json:"limit"`
 }
 
-func newListRequestCommon(limit *int) listRequestCommon {
+func newListRequestCommon(limit *int) ListRequest {
 	targetLimit := DefaultLimit
 	if limit != nil {
 		targetLimit = *limit
 	}
 
-	return listRequestCommon{
+	return ListRequest{
 		Limit: targetLimit,
 	}
 }
 
-func (r *listRequestCommon) Validate() error {
+func (r *ListRequest) Validate() error {
 	if r.Limit < DebugMinLimit || r.Limit > DebugMaxLimit {
 		return fmt.Errorf(
 			"limit must be between %d and %d, actual is %d", DebugMinLimit, DebugMaxLimit, r.Limit)

--- a/nil/services/synccommittee/public/task_debug_api.go
+++ b/nil/services/synccommittee/public/task_debug_api.go
@@ -53,7 +53,7 @@ const (
 )
 
 type TaskDebugRequest struct {
-	listRequestCommon
+	ListRequest
 
 	Status TaskStatus     `json:"status,omitempty"`
 	Type   TaskType       `json:"type,omitempty"`
@@ -98,7 +98,7 @@ func NewTaskDebugRequest(
 	}
 
 	return &TaskDebugRequest{
-		listRequestCommon: newListRequestCommon(limit),
+		ListRequest: newListRequestCommon(limit),
 
 		Status:    targetStatus,
 		Type:      targetType,


### PR DESCRIPTION
### Extended `sync_committee_cli` with new diagnostic commands:

### `get-state-root-data`
Retrieves the current state root data, including both the L1 and local state roots.

```shell
❯ ./sync_committee_cli get-state-root-data
| Field            | Value                                                              |
|------------------|--------------------------------------------------------------------|
| L1 State Root    | 0x0000000000000000000000000000000000000000000000000000000000000000 |
| Local State Root | nil                                                                |
```

### `get-batch`
Returns detailed information about a specific block batch identified by a `BatchId`.

```shell
❯ ./sync_committee_cli get-batch --batch-id 5f4d76de-f4a8-4ce2-9ee4-cf096bae71ec
{
  "id": "5f4d76de-f4a8-4ce2-9ee4-cf096bae71ec",
  "parentId": "9ab2c2af-5366-4cd6-bad8-200651309dde",
  "isSealed": false,
  "createdAt": "2025-01-01T00:00:00Z",
  "updatedAt": "2025-01-01T00:00:00Z",
  "blocks": {
    "0": [
      "0xe3badda00b235e4628c000eefc6d747f8cfbc663d2400d61e05d8ee2d92d8b96"
    ],
    "1": [
      "0x311bb80341285b2ccc00b59d3b81976d834b3fcdb04c99bd092e9e429c830beb"
    ],
    "2": [
      "0x6162ad356886ee3decd3495878f807f28b6962e6d3b0cd6062768e88d7d393ea"
    ],
    "3": [
      "0x00f8a06eeed35cb258655f7db9c965f6be4fd76cf43941c67e61ff138f81f4d0"
    ],
    "4": [
      "0xd66762dbc8fb32d9657dd685548d68ef53b1bbef674576c10e165cd477d3382c"
    ]
  }
}%    
```

### `get-batches`
Lists compact views of batches matching the provided `BatchDebugRequest` parameters.

```shell
❯ ./sync_committee_cli get-batches --limit 4
| Id                                   | BlocksCount | CreatedAt            | IsSealed | ParentId                             | UpdatedAt            |
|--------------------------------------|-------------|----------------------|----------|--------------------------------------|----------------------|
| 5f4d76de-f4a8-4ce2-9ee4-cf096bae71ec | 5           | 2025-01-01T00:00:00Z | false    | 9ab2c2af-5366-4cd6-bad8-200651309dde | 2025-01-01T00:00:00Z |
| 9ab2c2af-5366-4cd6-bad8-200651309dde | 5           | 2025-01-01T00:00:00Z | false    | d7b87fd4-705f-4cee-8c67-50940d7b0275 | 2025-01-01T00:00:00Z |
| d7b87fd4-705f-4cee-8c67-50940d7b0275 | 5           | 2025-01-01T00:00:00Z | false    | 7d78ea7d-5eca-4f82-aff9-72fbc83c5e4e | 2025-01-01T00:00:00Z |
| 7d78ea7d-5eca-4f82-aff9-72fbc83c5e4e | 5           | 2025-01-01T00:00:00Z | false    | bc0b5355-a9f6-4d47-b906-ab1bd22b5b0d | 2025-01-01T00:00:00Z |
```


### `get-latest-fetched`
Displays the latest fetched block references for all shards.

```shell
❯ ./sync_committee_cli get-latest-fetched
| Shard Id | Block Hash                                                         | Block Number |
|----------|--------------------------------------------------------------------|--------------|
| 0        | 0xe3badda00b235e4628c000eefc6d747f8cfbc663d2400d61e05d8ee2d92d8b96 | 10           |
| 1        | 0x311bb80341285b2ccc00b59d3b81976d834b3fcdb04c99bd092e9e429c830beb | 10           |
| 2        | 0x6162ad356886ee3decd3495878f807f28b6962e6d3b0cd6062768e88d7d393ea | 10           |
| 3        | 0x00f8a06eeed35cb258655f7db9c965f6be4fd76cf43941c67e61ff138f81f4d0 | 10           |
| 4        | 0xd66762dbc8fb32d9657dd685548d68ef53b1bbef674576c10e165cd477d3382c | 10           |
```

### `get-batch-stats`
Reports statistics on batches currently persisted in storage.

```shell
❯ ./sync_committee_cli get-batch-stats
| Field                 | Value |
|-----------------------|-------|
| Total Batches Created | 10    |
| Sealed Batches Count  | 0     |
| Proved Batches Count  | 0     |
```