### PR TITLE
bridge state getter: fix block ref type

### DIFF
--- a/nil/services/synccommittee/core/bridgecontract/bridge_state_getter.go
+++ b/nil/services/synccommittee/core/bridgecontract/bridge_state_getter.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 
 	"github.com/NilFoundation/nil/nil/client"
+	"github.com/NilFoundation/nil/nil/common"
 	"github.com/NilFoundation/nil/nil/common/hexutil"
 	"github.com/NilFoundation/nil/nil/internal/abi"
 	"github.com/NilFoundation/nil/nil/internal/types"
@@ -22,7 +23,7 @@ type BridgeState struct {
 }
 
 type BridgeStateGetter interface {
-	GetBridgeState(ctx context.Context, blockID any) (*BridgeState, error)
+	GetBridgeState(ctx context.Context, blockHash common.Hash) (*BridgeState, error)
 }
 
 type bridgeStateGetter struct {
@@ -42,12 +43,12 @@ func NewBridgeStateGetter(
 	}
 }
 
-func (b *bridgeStateGetter) GetBridgeState(ctx context.Context, blockID any) (*BridgeState, error) {
+func (b *bridgeStateGetter) GetBridgeState(ctx context.Context, blockHash common.Hash) (*BridgeState, error) {
 	eg, gCtx := errgroup.WithContext(ctx)
 
 	var l1MessageHash *big.Int
 	eg.Go(func() error {
-		ret, err := callContract[bytes32](gCtx, b.nilClient, blockID, b.contractAddr, b.abi, "l1MessageHash")
+		ret, err := callContract[bytes32](gCtx, b.nilClient, blockHash, b.contractAddr, b.abi, "l1MessageHash")
 		if err != nil {
 			return err
 		}
@@ -57,7 +58,7 @@ func (b *bridgeStateGetter) GetBridgeState(ctx context.Context, blockID any) (*B
 
 	var l2ToL1Root *big.Int
 	eg.Go(func() error {
-		ret, err := callContract[bytes32](gCtx, b.nilClient, blockID, b.contractAddr, b.abi, "getL2ToL1Root")
+		ret, err := callContract[bytes32](gCtx, b.nilClient, blockHash, b.contractAddr, b.abi, "getL2ToL1Root")
 		if err != nil {
 			return err
 		}
@@ -67,7 +68,7 @@ func (b *bridgeStateGetter) GetBridgeState(ctx context.Context, blockID any) (*B
 
 	var depositNonce *big.Int
 	eg.Go(func() error {
-		ret, err := callContract[*big.Int](gCtx, b.nilClient, blockID, b.contractAddr, b.abi, "getLatestDepositNonce")
+		ret, err := callContract[*big.Int](gCtx, b.nilClient, blockHash, b.contractAddr, b.abi, "getLatestDepositNonce")
 		if err != nil {
 			return err
 		}

--- a/nil/services/synccommittee/core/feeupdater/updater_test.go
+++ b/nil/services/synccommittee/core/feeupdater/updater_test.go
@@ -152,8 +152,6 @@ func (s *UpdaterTestSuite) TestInitialUpdate() {
 		return block, nil
 	}
 
-	s.runUpdater()
-
 	updateCalled := make(chan struct{})
 	entered := false
 	s.l1ContractMock.SetOracleFeeFunc = func(
@@ -169,12 +167,9 @@ func (s *UpdaterTestSuite) TestInitialUpdate() {
 		return nil
 	}
 
-	const ticks = 3
+	s.runUpdater()
 
-	s.clock.Advance(ticks * s.config.PollInterval)
-	for range ticks {
-		<-updateCalled
-	}
+	<-updateCalled
 }
 
 func (s *UpdaterTestSuite) TestUpdateOnSignificantChange() {

--- a/nil/services/synccommittee/core/proposer.go
+++ b/nil/services/synccommittee/core/proposer.go
@@ -131,7 +131,7 @@ func (p *proposer) updateState(
 		return fmt.Errorf("failed to get latest block ref for shard %d", p.config.BridgeStateKeeperShardId)
 	}
 
-	bridgeData, err := p.bridgeStateGetter.GetBridgeState(ctx, blockRef)
+	bridgeData, err := p.bridgeStateGetter.GetBridgeState(ctx, blockRef.Hash)
 	if err != nil {
 		return fmt.Errorf("failed to get bridge state: %w", err)
 	}

--- a/rollup-bridge-contracts/task/validate-l2-eth-bridging.ts
+++ b/rollup-bridge-contracts/task/validate-l2-eth-bridging.ts
@@ -41,7 +41,7 @@ task("validate-l2-eth-bridging", "Validates the state changes of l2BridgeMesseng
         const retries: number = 10
         let isDepositMessageRelayed: boolean = false;
 
-        for (let i = 0; i < 6; i++) {
+        for (let i = 0; i < retries; i++) {
             console.log(`Verifying relayedMessageHash: ${messageHash} inclusion in L2BridgeMessenger: ${l2NetworkConfig.l2BridgeMessengerConfig.l2BridgeMessengerContracts.l2BridgeMessengerProxy}... attempt ${i + 1}/${retries}`);
             try {
                 isDepositMessageRelayed = await l2BridgeMessengerProxyInstance.read.isDepositMessageRelayed([messageHash]);


### PR DESCRIPTION
## Short Summary

By mistake used invalid type for referencing a block while getting bridge state from the L2 contract

