### PR TITLE
[GH-240] Nix cache for macOS CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,10 @@ on:
   workflow_dispatch:
   merge_group:
 
+permissions:
+  id-token: write
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -26,54 +30,118 @@ jobs:
       - name: run check
         run: nix build .#checks.x86_64-linux.${{ matrix.check == 'nil' && 'others' || matrix.check }} -L
 
-  # TODO: enable check after adding caches to the build
-  # nix_check_macos:
-  #   name: macOS CI (${{ matrix.platform.os}}, ${{ matrix.platform.arch }}) - ${{ matrix.check }}
-  #   environment: prod
-  #   runs-on: ${{ matrix.platform.os }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       # Add other checks later, when they are stabilized, and caching will be configured for Nix.
-  #       check: ["clijs"]
-  #       platform:
-  #         # N.B. The architecture is chosen by GitHub at `runs-on` depending on the label (`os`)
-  #         # See https://github.com/actions/runner-images?tab=readme-ov-file#available-images
-  #         # The other fields only affect the logic of our steps
-  #         - os: macos-latest
-  #           arch: aarch64
-  #           nixArch: aarch64-darwin
-  #         # we're out of CI runners capacity right now. this needs to be returned later
-  #         # - os: macos-15-large
-  #         #   arch: x64
-  #         #   nixArch: x86_64-darwin
-  #   steps:
-  #     - name: checkout local actions
-  #       uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: 0
+  nix_check_macos:
+    name: macOS CI (${{ matrix.platform.os}}, ${{ matrix.platform.arch }}) - ${{ matrix.check }}
+    runs-on: ${{ matrix.platform.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        check: ["nil", "clijs"]
+        platform:
+          # N.B. The architecture is chosen by GitHub at `runs-on` depending on the label (`os`)
+          # See https://github.com/actions/runner-images?tab=readme-ov-file#available-images
+          # The other fields only affect the logic of our steps
+          - os: macos-latest
+            arch: aarch64
+            nixArch: aarch64-darwin
+          - os: macos-15-large
+            arch: x64
+            nixArch: x86_64-darwin
+        exclude:
+          # nil/services/indexer/clickhouse/clickhouse_test.go:79
+          # Received unexpected error:
+          # dial tcp 127.0.0.1:9003: connect: connection refused
+          - check: nil
+            platform:
+              arch: x64
+    env:
+      AWS_ACCOUNT_ID: "070427263827"
+      SSM_CONFIG_PATH: /github-action-runners/nil-githhub-actions/runners/config
+      S3_LOCATION_NIX_CACHE: s3://nil-githhub-actions-nix-cache-qrba32i47dik503juihjai4x
+    steps:
+      - name: Checkout local actions
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-  #     # https://github.com/NixOS/nix/issues/2242#issuecomment-2336841344
-  #     - name: macOS 15 eDSRecordAlreadyExists workaround
-  #       run: echo "NIX_FIRST_BUILD_UID=30001" >> "$GITHUB_ENV"
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/github-actions/gha_nix_cache
+          aws-region: eu-west-2
+          role-duration-seconds: 7200 # 2h
 
-  #     - name: Install Nix
-  #       uses: cachix/install-nix-action@v27
-  #       with:
-  #         github_access_token: ${{ secrets.GITHUB_TOKEN }}
-  #         extra_nix_config: |
-  #           max-jobs = 1
+      - name: Show AWS identity
+        run: aws sts get-caller-identity
 
-  #     - name: Run check
-  #       run: nix build .#checks.${{ matrix.platform.nixArch }}.${{ matrix.check == 'nil' && 'others' || matrix.check }} -L
+      - name: Get nix_cache_key_pub from SSM
+        id: get_nix_cache_key_pub
+        run: |
+          param=$(aws ssm get-parameter \
+            --name arn:aws:ssm:${{ env.AWS_REGION }}:${{ env.AWS_ACCOUNT_ID }}:parameter${{ env.SSM_CONFIG_PATH }}/nix_cache_key_pub \
+            --with-decryption \
+            | jq -r '.Parameter.Value')
+          echo "NIX_CACHE_KEY_PUB=$param" >>"$GITHUB_OUTPUT"
 
-  #     - name: Upload nil binary as artifact
-  #       if: github.event_name == 'workflow_dispatch'
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: clijs-darwin-${{ matrix.platform.arch }}
-  #         path: |
-  #           result/clijs
+      - name: Get nix_cache_key_sec from SSM
+        id: get_nix_cache_key_sec
+        run: |
+          param=$(aws ssm get-parameter \
+            --name arn:aws:ssm:${{ env.AWS_REGION }}:${{ env.AWS_ACCOUNT_ID }}:parameter${{ env.SSM_CONFIG_PATH }}/nix_cache_key_sec \
+            --with-decryption \
+            | jq -r '.Parameter.Value')
+          echo "$param" | sudo cp /dev/stdin /private/nix-signing-key
+
+      - name: Create /etc/nix/upload-to-cache.sh
+        run: |
+          sudo mkdir -p /etc/nix
+          sudo tee /etc/nix/upload-to-cache.sh <<EOL
+          #!/bin/bash
+
+          set -f # disable globbing
+          export IFS=' '
+          echo "Signing and uploading paths" \$OUT_PATHS
+
+          exec /nix/var/nix/profiles/default/bin/nix copy --to '${{ env.S3_LOCATION_NIX_CACHE }}?region=${{ env.AWS_REGION }}&secret-key=/private/nix-signing-key' \$OUT_PATHS
+          EOL
+          sudo chmod a+x /etc/nix/upload-to-cache.sh
+
+      - name: Expose AWS credentials to the nix-daemon
+        run: |
+          sudo launchctl setenv AWS_ACCESS_KEY_ID     "$AWS_ACCESS_KEY_ID"
+          sudo launchctl setenv AWS_SECRET_ACCESS_KEY "$AWS_SECRET_ACCESS_KEY"
+          sudo launchctl setenv AWS_SESSION_TOKEN     "$AWS_SESSION_TOKEN"
+
+      # https://github.com/NixOS/nix/issues/2242#issuecomment-2336841344
+      - name: macOS 15 eDSRecordAlreadyExists workaround
+        run: echo "NIX_FIRST_BUILD_UID=30001" >> "$GITHUB_ENV"
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_nix_config: |
+            max-jobs = 1
+            extra-substituters = ${{ env.S3_LOCATION_NIX_CACHE }}?region=${{ env.AWS_REGION }}
+            extra-trusted-public-keys = ${{ steps.get_nix_cache_key_pub.outputs.NIX_CACHE_KEY_PUB }}
+            post-build-hook = /etc/nix/upload-to-cache.sh
+
+      - name: Show /etc/nix/nix.conf
+        run: cat /etc/nix/nix.conf
+
+      # The following "build" command can be used for debugging without having to wait a long time:
+      # nix-build -E 'let pkgs = import (builtins.fetchTarball "https://github.com/NixOS/nixpkgs/archive/nixos-24.05.tar.gz") {}; in pkgs.writeText "example" "001"'
+      # Counter 001 can be modified to check for cache hits or misses.
+      - name: Run check
+        run: nix build .#checks.${{ matrix.platform.nixArch }}.${{ matrix.check == 'nil' && 'others' || matrix.check }} -L
+
+      - name: Upload nil binary as artifact
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: clijs-darwin-${{ matrix.platform.arch }}
+          path: |
+            result/clijs
 
   ensure_cluster_builds_macos:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,32 +58,49 @@ jobs:
       AWS_ACCOUNT_ID: "070427263827"
       SSM_CONFIG_PATH: /github-action-runners/nil-githhub-actions/runners/config
       S3_LOCATION_NIX_CACHE: s3://nil-githhub-actions-nix-cache-qrba32i47dik503juihjai4x
+      NIX_CACHE_KEY_PUB: nil-nix-cache:LX95txIkFncQOsRIXc3KjQkdjikbxDlSFISV/s9+aps=
     steps:
       - name: Checkout local actions
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Configure AWS credentials via OIDC
+      - name: Try configure AWS credentials via OIDC
+        continue-on-error: true
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/github-actions/gha_nix_cache
           aws-region: eu-west-2
           role-duration-seconds: 7200 # 2h
+          retry-max-attempts: 3
+
+      - name: Decide write flag
+        id: calculate_write_flag
+        run: if [[ -n "$AWS_ACCESS_KEY_ID" ]]; then echo "has_write=1" >> "$GITHUB_OUTPUT"; fi
 
       - name: Show AWS identity
+        if: steps.calculate_write_flag.outputs.has_write
         run: aws sts get-caller-identity
 
-      - name: Get nix_cache_key_pub from SSM
-        id: get_nix_cache_key_pub
+      # The source of truth for nix_cache_key_pub is SSM. But we cannot read values from it anonymously.
+      # Since this is a public key, it is acceptable to hardcode it directly in the workflow. Additionally, we can use
+      # OIDC authorized runs to verify that our hardcoded value is not outdated.
+      - name: Compare NIX_CACHE_KEY_PUB hardcode with value saved in SSM
+        if: steps.calculate_write_flag.outputs.has_write
         run: |
           param=$(aws ssm get-parameter \
             --name arn:aws:ssm:${{ env.AWS_REGION }}:${{ env.AWS_ACCOUNT_ID }}:parameter${{ env.SSM_CONFIG_PATH }}/nix_cache_key_pub \
             --with-decryption \
             | jq -r '.Parameter.Value')
-          echo "NIX_CACHE_KEY_PUB=$param" >>"$GITHUB_OUTPUT"
+          test "${{ env.NIX_CACHE_KEY_PUB }}" == "$param" || { \
+            echo "ERROR: NIX_CACHE_KEY_PUB hardcoded value does not match" \
+            "the reference stored in SSM ('$param'). The SSM value should be considered" \
+            "authoritative. Please update the hardcoded value in the workflow file.";
+            exit 1; \
+          }
 
       - name: Get nix_cache_key_sec from SSM
+        if: steps.calculate_write_flag.outputs.has_write
         id: get_nix_cache_key_sec
         run: |
           param=$(aws ssm get-parameter \
@@ -93,6 +110,7 @@ jobs:
           echo "$param" | sudo cp /dev/stdin /private/nix-signing-key
 
       - name: Create /etc/nix/upload-to-cache.sh
+        if: steps.calculate_write_flag.outputs.has_write
         run: |
           sudo mkdir -p /etc/nix
           sudo tee /etc/nix/upload-to-cache.sh <<EOL
@@ -107,6 +125,7 @@ jobs:
           sudo chmod a+x /etc/nix/upload-to-cache.sh
 
       - name: Expose AWS credentials to the nix-daemon
+        if: steps.calculate_write_flag.outputs.has_write
         run: |
           sudo launchctl setenv AWS_ACCESS_KEY_ID     "$AWS_ACCESS_KEY_ID"
           sudo launchctl setenv AWS_SECRET_ACCESS_KEY "$AWS_SECRET_ACCESS_KEY"
@@ -123,8 +142,8 @@ jobs:
           extra_nix_config: |
             max-jobs = 1
             extra-substituters = ${{ env.S3_LOCATION_NIX_CACHE }}?region=${{ env.AWS_REGION }}
-            extra-trusted-public-keys = ${{ steps.get_nix_cache_key_pub.outputs.NIX_CACHE_KEY_PUB }}
-            post-build-hook = /etc/nix/upload-to-cache.sh
+            extra-trusted-public-keys = ${{ env.NIX_CACHE_KEY_PUB }}
+            ${{ steps.calculate_write_flag.outputs.has_write && 'post-build-hook = /etc/nix/upload-to-cache.sh' }}
 
       - name: Show /etc/nix/nix.conf
         run: cat /etc/nix/nix.conf
@@ -136,7 +155,7 @@ jobs:
         run: nix build .#checks.${{ matrix.platform.nixArch }}.${{ matrix.check == 'nil' && 'others' || matrix.check }} -L
 
       - name: Upload nil binary as artifact
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch' && matrix.check == 'clijs'
         uses: actions/upload-artifact@v4
         with:
           name: clijs-darwin-${{ matrix.platform.arch }}

--- a/clijs/test/globalSetup.ts
+++ b/clijs/test/globalSetup.ts
@@ -27,6 +27,8 @@ export async function setup() {
     throw new Error("Failed to start nild");
   }
 
+  await waitForServerReady(testEnv.endpoint, 30000); // 30 sec
+
   nildInstance = {
     pid: nild.pid,
     process: nild,
@@ -44,6 +46,18 @@ export async function teardown() {
       resolve();
     });
   });
+}
+
+async function waitForServerReady(endpoint: string, timeout: number): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeout) {
+    try {
+      const response = await fetch(endpoint, { method: "GET" });
+      if (response.ok) return;
+    } catch (e) {}
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw new Error(`Server not ready after ${timeout}ms`);
 }
 
 const COUNTER_COMPILATION_COMMAND =

--- a/clijs/vitest.config.ts
+++ b/clijs/vitest.config.ts
@@ -22,5 +22,6 @@ export default defineConfig({
     globalSetup: [
       "./test/globalSetup.ts",
     ],
+    reporters: ['verbose']
   },
 });


### PR DESCRIPTION
The `nix_check_macos` matrix job has been added.
First we try to authorize our workflow via OIDC for write access in AWS to the Nix cache. This is possible for main and PR's according to the role settings. For runs via `workflow_dispatch` and forks, the access will be read-only. The cache bucket is made public read-only for this purpose.

Restored `clijs` builds for macOS `aarch64` & `x86_64`. Also added `nil` builds for the same platforms, but disabled for `x86_64` for now due to test issues. I plan to deal with this later and leave only Nix builds for macOS.