### PR TITLE
SC: Fix typo in config

### DIFF
--- a/nil/services/synccommittee/core/config.go
+++ b/nil/services/synccommittee/core/config.go
@@ -20,7 +20,7 @@ type Config struct {
 	ContractWrapperConfig     rollupcontract.WrapperConfig     `yaml:",inline"`
 	L1FeeUpdateConfig         feeupdater.Config                `yaml:",inline"`
 	L1FeeUpdateContractConfig feeupdater.ContractWrapperConfig `yaml:",inline"`
-	L2BridgeMessegerAdddress  string                           `yaml:"l2BridgeMessegerAdddress"`
+	L2BridgeMessengerAddress  string                           `yaml:"l2BridgeMessengerAddress"`
 	Telemetry                 *telemetry.Config                `yaml:",inline"`
 }
 

--- a/nil/services/synccommittee/core/service.go
+++ b/nil/services/synccommittee/core/service.go
@@ -103,7 +103,7 @@ func New(ctx context.Context, cfg *Config, database db.DB) (*SyncCommittee, erro
 		fetcher, blockStorage, metricsHandler, fetching.NewDefaultLagTrackerConfig(), logger,
 	)
 
-	l2BridgeMessengerAddress := types.HexToAddress(cfg.L2BridgeMessegerAdddress)
+	l2BridgeMessengerAddress := types.HexToAddress(cfg.L2BridgeMessengerAddress)
 
 	bridgeStateGetter := bridgecontract.NewBridgeStateGetter(
 		nilClient,


### PR DESCRIPTION
SC: Fix typo in the `L2BridgeMessengerAddress` config field