### PR TITLE
[GH-240] Completely migrating macOS CI to Nix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
         run: nix build .#checks.x86_64-linux.${{ matrix.check == 'nil' && 'others' || matrix.check }} -L
 
   nix_check_macos:
-    name: macOS CI (${{ matrix.platform.os}}, ${{ matrix.platform.arch }}) - ${{ matrix.check }}
+    name: ${{ matrix.platform.os}} (${{ matrix.platform.arch }}) - ${{ matrix.check }}
     runs-on: ${{ matrix.platform.os }}
     strategy:
       fail-fast: false
@@ -47,13 +47,6 @@ jobs:
           - os: macos-15-large
             arch: x64
             nixArch: x86_64-darwin
-        exclude:
-          # nil/services/indexer/clickhouse/clickhouse_test.go:79
-          # Received unexpected error:
-          # dial tcp 127.0.0.1:9003: connect: connection refused
-          - check: nil
-            platform:
-              arch: x64
     env:
       AWS_ACCOUNT_ID: "070427263827"
       SSM_CONFIG_PATH: /github-action-runners/nil-githhub-actions/runners/config
@@ -162,44 +155,10 @@ jobs:
           path: |
             result/clijs
 
-  ensure_cluster_builds_macos:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include:
-          # N.B. The architecture is chosen by GitHub at `runs-on` depending on the label (`os`)
-          # See https://github.com/actions/runner-images?tab=readme-ov-file#available-images
-          # The other fields only affect the logic of our steps
-          - os: macos-latest
-            arch: aarch64
-          - os: macos-13
-            arch: x64
-    environment: prod
-    name: MacOS CI
-    steps:
-      - name: checkout local actions
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Install Golang and solc
-        run: |
-          brew update
-          brew tap ethereum/ethereum
-          brew install go solidity protobuf coreutils
-          go install golang.org/x/tools/cmd/stringer@latest
-          go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-          python3 -m pip install safe-pysha3 --break-system-packages
-
-      - name: build binaries
-        run: |
-          export PATH=$PATH:$(go env GOPATH)/bin
-          make nild nil
-
-      - name: Upload nil binary as artifact
-        if: github.event_name == 'workflow_dispatch'
+      - name: Upload old nil binary as artifact
+        if: github.event_name == 'workflow_dispatch' && matrix.check == 'nil'
         uses: actions/upload-artifact@v4
         with:
-          name: nil-darwin-${{ matrix.arch }}
+          name: nil-darwin-${{ matrix.platform.arch }}
           path: |
-            build/bin/nil
+            result/bin/nil


### PR DESCRIPTION
- Fixed unstable Clickhouse tests and enabled builds for macOS x86_64 via Nix.
- Artifacts are now taken from builds via Nix.
- Old jobs for non-Nix builds have been removed.
- The names of macOS builds have been shortened.