### PR TITLE
[explorer] fix block and account tabs navigation

### DIFF
--- a/explorer_frontend/src/pages/address/AddressPage.tsx
+++ b/explorer_frontend/src/pages/address/AddressPage.tsx
@@ -44,7 +44,11 @@ export const AddressPage = () => {
               key="overview"
               onClick={(e) => {
                 e.preventDefault();
-                addressRoute.open(params);
+                addressRoute.navigate({
+                  params,
+                  query: {},
+                  replace: true,
+                });
               }}
               kind={TAB_KIND.secondary}
             >
@@ -55,7 +59,11 @@ export const AddressPage = () => {
               key="transactions"
               onClick={(e) => {
                 e.preventDefault();
-                addressTransactionsRoute.open(params);
+                addressTransactionsRoute.navigate({
+                  params,
+                  query: {},
+                  replace: true,
+                });
               }}
               kind={TAB_KIND.secondary}
             >

--- a/explorer_frontend/src/pages/block/BlockPage.tsx
+++ b/explorer_frontend/src/pages/block/BlockPage.tsx
@@ -97,6 +97,7 @@ export const BlockPage = () => {
                     details: "all",
                   },
                   query: {},
+                  replace: true,
                 });
               }}
             >
@@ -127,6 +128,7 @@ export const BlockPage = () => {
                     details: "incoming",
                   },
                   query: {},
+                  replace: true,
                 });
               }}
             >
@@ -157,6 +159,7 @@ export const BlockPage = () => {
                     details: "outgoing",
                   },
                   query: {},
+                  replace: true,
                 });
               }}
             >


### PR DESCRIPTION
This diff fixes tabs navigation on block and account pages by making this navigation "invisible" to browser.
fixes #919 