### PR TITLE
fix spelling issues

### DIFF
--- a/niljs/README.md
+++ b/niljs/README.md
@@ -193,7 +193,7 @@ await tx.wait();
 ```
 
 =nil; also supports token bouncing. If a transaction carries custom tokens, and
-it is unsuccesful, the funds will be returned to the address specified in the
+it is unsuccessful, the funds will be returned to the address specified in the
 `bounceTo` parameter when sending the transaction.
 
 ## Accessing the dev environment

--- a/niljs/src/contract-factory/ContractFactory.ts
+++ b/niljs/src/contract-factory/ContractFactory.ts
@@ -204,7 +204,7 @@ export type ContractFunctionParameters<
   ///
   allFunctionNames = ContractFunctionName<abi, mutability>,
   allArgs = ContractFunctionArgs<abi, mutability, functionName>,
-  // when `args` is inferred to `readonly []` ("inputs": []) or `never` (`abi` declared as `Abi` or not inferrable), allow `args` to be optional.
+  // when `args` is inferred to `readonly []` ("inputs": []) or `never` (`abi` declared as `Abi` or not inferable), allow `args` to be optional.
   // important that both branches return same structural type
 > = {
   abi: abi;


### PR DESCRIPTION
## Short Summary

Hey team! Fixed errors in niljs/README.md and niljs/src/contract-factory/ContractFactory.ts

`unsuccesful` - `unsuccessful`
`inferrable` - `inferable`

## Checklist

- [x] I have read and followed the [Contributing Guide](https://github.com/NilFoundation/nil/blob/main/CONTRIBUTION-GUIDE.md)
- [ ] I have tested the changes locally
- [ ] I have added relevant tests (if applicable)
- [x] I have updated documentation/comments (if applicable)
