### PR TITLE
[explorer] fix playground logo title

### DIFF
--- a/explorer_frontend/src/features/shared/components/Layout/Logo.tsx
+++ b/explorer_frontend/src/features/shared/components/Layout/Logo.tsx
@@ -1,21 +1,27 @@
 import { Link } from "atomic-router-react";
-import { useStore } from "effector-react";
+import type { ReactNode } from "react";
 import { useStyletron } from "styletron-react";
 import { explorerRoute } from "../../../routing/routes/explorerRoute";
-import { tutorialWithUrlStringRoute } from "../../../routing/routes/tutorialRoute";
 import logo from "./assets/Logo.svg";
 import { styles } from "./styles";
 
-export const Logo = () => {
+type LogoProps = {
+  subtitle?: ReactNode;
+};
+
+export const Logo = ({ subtitle = null }: LogoProps) => {
   const [css] = useStyletron();
-  const isTutorial = useStore(tutorialWithUrlStringRoute.$isOpened);
 
   return (
     <Link className={css(styles.logo)} to={explorerRoute}>
-      <img src={logo} alt="logo" />
-      {!isTutorial && <span className={css(styles.playgroundText)}>Playground v1.0</span>}
-
-      {isTutorial && <span className={css(styles.tutorialText)}>Tutorials v1.0</span>}
+      <img
+        src={logo}
+        alt="logo"
+        className={css({
+          marginBottom: "4px",
+        })}
+      />
+      {subtitle}
     </Link>
   );
 };

--- a/explorer_frontend/src/features/shared/components/Layout/Navbar.tsx
+++ b/explorer_frontend/src/features/shared/components/Layout/Navbar.tsx
@@ -1,4 +1,4 @@
-import { useStore, useUnit } from "effector-react";
+import { useUnit } from "effector-react";
 import { type ReactNode, memo, useCallback } from "react";
 import { useStyletron } from "styletron-react";
 import { fetchSolidityCompiler } from "../../../../services/compiler";
@@ -6,25 +6,23 @@ import { getMobileStyles } from "../../../../styleHelpers";
 import { CodeToolbar } from "../../../code/code-toolbar/CodeToolbar";
 import { useCompileButton } from "../../../code/hooks/useCompileButton";
 import { compile, compileCodeFx } from "../../../code/model";
-import { tutorialWithUrlStringRoute } from "../../../routing/routes/tutorialRoute";
 import { useMobile } from "../../hooks/useMobile";
-import { Logo } from "./Logo";
 import { styles } from "./styles";
 
 type NavbarProps = {
   children?: ReactNode;
   showCodeInteractionButtons?: boolean;
+  logo?: ReactNode;
 };
 
 const MemoizedCodeToolbar = memo(CodeToolbar);
 
-export const Navbar = ({ children, showCodeInteractionButtons }: NavbarProps) => {
+export const Navbar = ({ children, showCodeInteractionButtons, logo }: NavbarProps) => {
   const [css] = useStyletron();
   const [isDownloading, compiling] = useUnit([
     fetchSolidityCompiler.pending,
     compileCodeFx.pending,
   ]);
-  const isTutorial = useStore(tutorialWithUrlStringRoute.$isOpened);
   const [isMobile] = useMobile();
   const templateColumns = isMobile ? "93% 1fr" : "1fr 33%";
   const btnTextContent = useCompileButton();
@@ -57,7 +55,7 @@ export const Navbar = ({ children, showCodeInteractionButtons }: NavbarProps) =>
           }),
         })}
       >
-        <Logo />
+        {logo}
         {showCodeInteractionButtons && (
           <MemoizedCodeToolbar
             disabled={isDownloading}

--- a/explorer_frontend/src/pages/playground/PlaygroundPage.tsx
+++ b/explorer_frontend/src/pages/playground/PlaygroundPage.tsx
@@ -1,4 +1,4 @@
-import { PROGRESS_BAR_SIZE, ProgressBar } from "@nilfoundation/ui-kit";
+import { COLORS, LabelXSmall, PROGRESS_BAR_SIZE, ProgressBar } from "@nilfoundation/ui-kit";
 import { useStyletron } from "baseui";
 import { useUnit } from "effector-react";
 import { expandProperty } from "inline-style-expand-shorthand";
@@ -12,6 +12,7 @@ import { NetworkErrorNotification } from "../../features/healthcheck";
 import { $rpcIsHealthy } from "../../features/healthcheck/model";
 import { Logs } from "../../features/logs/components/Logs";
 import { useMobile } from "../../features/shared";
+import { Logo } from "../../features/shared/components/Layout/Logo";
 import { Navbar } from "../../features/shared/components/Layout/Navbar";
 import { mobileContainerStyle, styles } from "../../features/shared/components/Layout/styles";
 import { fetchSolidityCompiler } from "../../services/compiler";
@@ -40,7 +41,14 @@ export const PlaygroundPage = () => {
     <div className={css(isMobile ? mobileContainerStyle : styles.playgroundContainer)}>
       {!isRPCHealthy && <NetworkErrorNotification />}
       {displayNavbar && (
-        <Navbar showCodeInteractionButtons={true}>{isMobile ? null : <AccountPane />}</Navbar>
+        <Navbar
+          showCodeInteractionButtons={true}
+          logo={
+            <Logo subtitle={<LabelXSmall color={COLORS.gray400}>Playground v1.0</LabelXSmall>} />
+          }
+        >
+          {isMobile ? null : <AccountPane />}
+        </Navbar>
       )}
       <div
         className={css({

--- a/explorer_frontend/src/pages/tutorials/TutorialPage.tsx
+++ b/explorer_frontend/src/pages/tutorials/TutorialPage.tsx
@@ -3,6 +3,7 @@ import {
   BUTTON_SIZE,
   Button,
   COLORS,
+  LabelXSmall,
   PROGRESS_BAR_SIZE,
   ProgressBar,
   Tab,
@@ -28,6 +29,7 @@ import { TutorialText } from "../../features/tutorial/TutorialText";
 import { fetchSolidityCompiler } from "../../services/compiler";
 import { TutorialMobileLayout } from "./TutorialMobileLayout";
 import "./init.ts";
+import { Logo } from "../../features/shared/components/Layout/Logo.tsx";
 import { runTutorialCheck, runTutorialCheckFx } from "../../features/tutorial-check/model.ts";
 import { TutorialsPanel } from "../../features/tutorial/TutorialsPanel.tsx";
 import { $tutorials } from "../../features/tutorial/model.ts";
@@ -98,7 +100,10 @@ export const TutorialPage = () => {
   return (
     <div className={css(isMobile ? mobileContainerStyle : styles.container)}>
       {!isRPCHealthy && <NetworkErrorNotification />}
-      <Navbar showCodeInteractionButtons={true}>
+      <Navbar
+        showCodeInteractionButtons={true}
+        logo={<Logo subtitle={<LabelXSmall color={COLORS.blue400}>Tutorials v1.0</LabelXSmall>} />}
+      >
         <AccountPane />
       </Navbar>
 


### PR DESCRIPTION
This diff removes logo subtitle from explorer page and makes components architecture easier to maintain.