### PR TITLE
Sync Committee: Fix Bridge State Getter

### DIFF
--- a/nil/services/synccommittee/core/proposer.go
+++ b/nil/services/synccommittee/core/proposer.go
@@ -126,12 +126,12 @@ func (p *proposer) updateState(
 		return fmt.Errorf("failed to get batch with id=%s: %w", proposalData.BatchId, err)
 	}
 
-	blockRef, ok := batch.LatestRefs()[types.ShardId(p.config.BridgeStateKeeperShardId)]
+	bridgeContractShardBlock, ok := batch.LatestBlocks()[types.ShardId(p.config.BridgeStateKeeperShardId)]
 	if !ok {
-		return fmt.Errorf("failed to get latest block ref for shard %d", p.config.BridgeStateKeeperShardId)
+		return fmt.Errorf("failed to get latest block for shard %d", p.config.BridgeStateKeeperShardId)
 	}
 
-	bridgeData, err := p.bridgeStateGetter.GetBridgeState(ctx, blockRef.Hash)
+	bridgeData, err := p.bridgeStateGetter.GetBridgeState(ctx, bridgeContractShardBlock.MainShardHash)
 	if err != nil {
 		return fmt.Errorf("failed to get bridge state: %w", err)
 	}
@@ -139,8 +139,8 @@ func (p *proposer) updateState(
 	updateStateData := scTypes.NewUpdateStateData(
 		proposalData,
 		[]byte{0x0A, 0x0B, 0x0C}, // TODO place valid proof
-		common.BigToHash(bridgeData.L2toL1Root),
-		common.BigToHash(bridgeData.L1MessageHash),
+		bridgeData.L2toL1Root,
+		bridgeData.L1MessageHash,
 		bridgeData.DepositNonce,
 	)
 

--- a/nil/services/synccommittee/core/proposer_test.go
+++ b/nil/services/synccommittee/core/proposer_test.go
@@ -147,7 +147,7 @@ func (s *ProposerTestSuite) SetupSuite() {
 	fetcher := fetching.NewFetcher(s.rpcClientMock, logger)
 	l1Syncer := syncer.NewStateRootSyncer(fetcher, contractWrapper, s.storage, logger, syncer.NewDefaultConfig())
 	resetLauncher := reset.NewResetLauncher(s.storage, l1Syncer, nil, logger)
-	bridgeStateGetter := bridgecontract.NewBridgeStateGetter(s.rpcClientMock, l2BridgeMessengerContractAddr)
+	bridgeStateGetter := bridgecontract.NewBridgeStateGetter(s.rpcClientMock, l2BridgeMessengerContractAddr, logger)
 
 	s.proposer, err = NewProposer(
 		s.params,

--- a/nil/services/synccommittee/core/service.go
+++ b/nil/services/synccommittee/core/service.go
@@ -105,10 +105,7 @@ func New(ctx context.Context, cfg *Config, database db.DB) (*SyncCommittee, erro
 
 	l2BridgeMessengerAddress := types.HexToAddress(cfg.L2BridgeMessengerAddress)
 
-	bridgeStateGetter := bridgecontract.NewBridgeStateGetter(
-		nilClient,
-		l2BridgeMessengerAddress,
-	)
+	bridgeStateGetter := bridgecontract.NewBridgeStateGetter(nilClient, l2BridgeMessengerAddress, logger)
 
 	proposer, err := NewProposer(
 		cfg.ProposerParams,


### PR DESCRIPTION
### Sync Committee: Fix Bridge State Getter

* Use the corresponding main shard hash to invoke the L2 bridge messenger contract instead of the block from the shard with id `BridgeStateKeeperShardId`.
* Add a contract existence check to `BridgeStateGetter` to return an empty state if the contract does not yet exist at the specified block.
