### PR TITLE
[explorer] add search bar to the main page

### DIFF
--- a/explorer_frontend/src/features/search/components/Search.tsx
+++ b/explorer_frontend/src/features/search/components/Search.tsx
@@ -20,7 +20,6 @@ const Search = () => {
   return (
     <div
       className={css({
-        marginLeft: "32px",
         width: "100%",
         position: "relative",
         zIndex: 2,

--- a/explorer_frontend/src/features/shared/components/Heading/index.tsx
+++ b/explorer_frontend/src/features/shared/components/Heading/index.tsx
@@ -1,6 +1,7 @@
 import { HeadingXLarge, HeadingXXLarge } from "@nilfoundation/ui-kit";
 import { useStyletron } from "styletron-react";
 import type { StylesObject } from "../..";
+import Search from "../../../search/components/Search";
 import { useMobile } from "../../hooks/useMobile";
 
 type HeadingProps = {
@@ -23,10 +24,16 @@ export const Heading = ({ className = "" }: HeadingProps) => {
   return (
     <div
       className={`${css({
+        display: "flex",
+        alignItems: "flex-start",
+        justifyContent: "center",
+        flexDirection: "column",
         flex: 0,
+        gap: "24px",
       })} ${className}`.trim()}
     >
       <TitleComponent className={css(s.heading)}>Explore =nil; Network</TitleComponent>
+      <Search />
     </div>
   );
 };

--- a/explorer_frontend/src/pages/explorer/styles.ts
+++ b/explorer_frontend/src/pages/explorer/styles.ts
@@ -47,7 +47,8 @@ const blocks = {
 };
 
 const heading: StyleObject = {
-  gridColumn: "1 / 5",
+  gridColumn: "1 / 3",
+  marginBottom: SPACE[24],
 };
 
 export const styles = {


### PR DESCRIPTION
This diff restores the search bar on the main part, but in an appropriate place like on the design template.