### PR TITLE
Upgrade to checkout v4

### DIFF
--- a/.github/workflows/build_artifacts.yml
+++ b/.github/workflows/build_artifacts.yml
@@ -19,7 +19,7 @@ jobs:
     environment: prod
     steps:
       - name: checkout local actions
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
         check: ["ibft", "heavy", "nil", "nildocs", "niljs", "nilexplorer", "uniswap", "rollup-bridge-contracts", "clijs", "walletextension", "nilhardhat"]
     steps:
       - name: checkout local actions
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Update GitHub Actions to actions/checkout@v4 for improved performance and features.
Confirmation: https://github.com/actions/checkout/releases/tag/v4.2.2
