### PR TITLE
Remove Broken Links 

### DIFF
--- a/clijs/package.json
+++ b/clijs/package.json
@@ -6,7 +6,7 @@
   "bin": {
     "clijs": "./bin/run.js"
   },
-  "bugs": "https://github.com/nil-blockchain/issues",
+  "bugs": "",
   "dependencies": {
     "@libp2p/peer-id": "^5.0.9",
     "@nilfoundation/niljs": "workspace:*",
@@ -38,7 +38,7 @@
     "/dist",
     "/oclif.manifest.json"
   ],
-  "homepage": "https://github.com/nil-blockchain/clijs",
+  "homepage": "",
   "keywords": [
     "oclif"
   ],


### PR DESCRIPTION
I recommend removing or replacing the non-functional links in package.json.
Suggested replacement: https://github.com/NilFoundation/nil-hardhat-example.
If you have better alternatives, please share them, and I will update the links accordingly.
<img width="1264" alt="Знімок екрана 2025-06-17 о 19 49 13" src="https://github.com/user-attachments/assets/9b4bb290-a642-4f1d-87b6-49cfbdfdb28d" />
<img width="1219" alt="Знімок екрана 2025-06-17 о 19 49 34" src="https://github.com/user-attachments/assets/0910926c-cd7b-40ce-ad7c-b320e2747e82" />
