### PR TITLE
[db] Getters with extended error message (shard, table, key)

### DIFF
--- a/nil/services/rpc/rawapi/pb/conversion.go
+++ b/nil/services/rpc/rawapi/pb/conversion.go
@@ -3,6 +3,7 @@ package pb
 import (
 	"encoding/binary"
 	"errors"
+	"strings"
 	"unicode/utf8"
 
 	"github.com/NilFoundation/nil/nil/common"
@@ -187,7 +188,7 @@ func (ar *AccountRequest) PackProtoMessage(address types.Address, blockReference
 // Error converters
 
 func (e *Error) UnpackProtoMessage() error {
-	if e.GetMessage() == db.ErrKeyNotFound.Error() {
+	if strings.HasPrefix(e.GetMessage(), db.ErrKeyNotFound.Error()) {
 		return db.ErrKeyNotFound
 	}
 	return errors.New(e.GetMessage())

--- a/nil/tests/rpc_node/call_test.go
+++ b/nil/tests/rpc_node/call_test.go
@@ -135,7 +135,7 @@ func (s *SuiteRpcNodeCall) TestCall() {
 		}
 
 		_, err = s.DefaultClient.EstimateFee(s.Context, callArgs, "latest")
-		s.NoError(err, db.ErrKeyNotFound.Error())
+		s.NoError(err)
 	})
 }
 


### PR DESCRIPTION
Added functions that wrap transaction's Get method and add shard id, table name and key to the ErrKeyNotFound message.
Only message is used and not a new error struct type, because it is intended only for debug purposes (e.g., I don't expect it to be passed via API to puzzle the users).