### PR TITLE
[cache] Sharing LRU caches for blocks and txns

### DIFF
--- a/nil/internal/collate/block_listener.go
+++ b/nil/internal/collate/block_listener.go
@@ -184,7 +184,7 @@ func SetBlockRequestHandler(
 	}
 
 	// Sharing accessor between all handlers enables caching.
-	accessor := execution.NewStateAccessor()
+	accessor := execution.NewStateAccessor(128, 0)
 	handler := func(s network.Stream) {
 		if err := s.SetDeadline(time.Now().Add(requestTimeout)); err != nil {
 			return

--- a/nil/internal/execution/block_generator.go
+++ b/nil/internal/execution/block_generator.go
@@ -18,11 +18,12 @@ import (
 type BlockGeneratorParams struct {
 	ShardId          types.ShardId
 	NShards          uint32
-	EvmTracingHooks  *tracing.Hooks
 	MainKeysPath     string
 	DisableConsensus bool
-	FeeCalculator    FeeCalculator
 	ExecutionMode    string
+	StateAccessor    *StateAccessor
+	FeeCalculator    FeeCalculator
+	EvmTracingHooks  *tracing.Hooks
 }
 
 func NewBlockGeneratorParams(shardId types.ShardId, nShards uint32) BlockGeneratorParams {
@@ -60,6 +61,7 @@ type BlockGenerationResult struct {
 	InTxnHashes  []common.Hash
 	OutTxns      []*types.Transaction
 	OutTxnHashes []common.Hash
+	Receipts     []*types.Receipt
 	ConfigParams map[string][]byte
 
 	Counters *BlockGeneratorCounters
@@ -83,6 +85,7 @@ func NewBlockGenerator(
 
 	executionState, err := NewExecutionState(rwTx, params.ShardId, StateParams{
 		Block:          prevBlock,
+		StateAccessor:  params.StateAccessor,
 		ConfigAccessor: configAccessor,
 		FeeCalculator:  params.FeeCalculator,
 		Mode:           params.ExecutionMode,

--- a/nil/internal/execution/transactions_test.go
+++ b/nil/internal/execution/transactions_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/NilFoundation/nil/nil/common"
-	"github.com/NilFoundation/nil/nil/internal/config"
 	"github.com/NilFoundation/nil/nil/internal/db"
 	"github.com/NilFoundation/nil/nil/internal/types"
 	ethcommon "github.com/ethereum/go-ethereum/common"
@@ -38,12 +37,7 @@ func (s *TransactionsSuite) TestValidateExternalTransaction() {
 	s.Require().NoError(err)
 	defer tx.Rollback()
 
-	es, err := NewExecutionState(tx, types.BaseShardId, StateParams{
-		ConfigAccessor: config.GetStubAccessor(),
-	})
-	s.Require().NoError(err)
-	s.Require().NotNil(es)
-	es.BaseFee = types.DefaultGasPrice
+	es := NewTestExecutionState(s.T(), tx, types.BaseShardId, StateParams{})
 	es.GasPrice = es.BaseFee
 
 	validate := func(txn *types.Transaction) types.ExecError {

--- a/nil/internal/execution/zerostate_test.go
+++ b/nil/internal/execution/zerostate_test.go
@@ -119,8 +119,6 @@ func (s *SuiteZeroState) TestWithdrawFromFaucet() {
 func TestZerostateFromConfig(t *testing.T) {
 	t.Parallel()
 
-	var state *ExecutionState
-
 	database, err := db.NewBadgerDbInMemory()
 	require.NoError(t, err)
 	tx, err := database.CreateRwTx(t.Context())
@@ -129,8 +127,9 @@ func TestZerostateFromConfig(t *testing.T) {
 
 	configAccessor, err := config.NewConfigAccessorTx(tx, nil)
 	require.NoError(t, err)
-	state, err = NewExecutionState(tx, 0, StateParams{ConfigAccessor: configAccessor})
-	require.NoError(t, err)
+	state := NewTestExecutionState(t, tx, types.MainShardId, StateParams{
+		ConfigAccessor: configAccessor,
+	})
 
 	zeroState := &ZeroStateConfig{
 		ConfigParams: ConfigParams{
@@ -143,10 +142,7 @@ func TestZerostateFromConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 0, state.GasPrice.Cmp(types.NewValueFromUint64(1)))
 
-	state, err = NewExecutionState(tx, 1, StateParams{
-		ConfigAccessor: config.GetStubAccessor(),
-	})
-	require.NoError(t, err)
+	state = NewTestExecutionState(t, tx, 1, StateParams{})
 	zeroState = &ZeroStateConfig{
 		ConfigParams: ConfigParams{
 			GasPrice: config.ParamGasPrice{
@@ -159,10 +155,7 @@ func TestZerostateFromConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 0, state.GasPrice.Cmp(types.NewValueFromUint64(2)))
 
-	state, err = NewExecutionState(tx, 2, StateParams{
-		ConfigAccessor: config.GetStubAccessor(),
-	})
-	require.NoError(t, err)
+	state = NewTestExecutionState(t, tx, 2, StateParams{})
 	zeroState = &ZeroStateConfig{
 		ConfigParams: ConfigParams{
 			GasPrice: config.ParamGasPrice{
@@ -177,8 +170,9 @@ func TestZerostateFromConfig(t *testing.T) {
 
 	smartAccountAddr := types.ShardAndHexToAddress(types.MainShardId, "0x111111111111111111111111111111111111")
 
-	state, err = NewExecutionState(tx, types.MainShardId, StateParams{ConfigAccessor: configAccessor})
-	require.NoError(t, err)
+	state = NewTestExecutionState(t, tx, types.MainShardId, StateParams{
+		ConfigAccessor: configAccessor,
+	})
 	zeroState = &ZeroStateConfig{
 		Contracts: []*ContractDescr{
 			{Name: "Faucet", Value: types.NewValueFromUint64(87654321), Contract: "Faucet"},
@@ -210,9 +204,7 @@ func TestZerostateFromConfig(t *testing.T) {
 	require.Equal(t, faucet.Balance, types.NewValueFromUint64(87654321))
 
 	// Test should fail because contract hasn't `code` item
-	state, err = NewExecutionState(tx, types.BaseShardId, StateParams{
-		ConfigAccessor: config.GetStubAccessor(),
-	})
+	state = NewTestExecutionState(t, tx, types.BaseShardId, StateParams{})
 	require.NoError(t, err)
 	zeroState = &ZeroStateConfig{
 		Contracts: []*ContractDescr{
@@ -223,10 +215,7 @@ func TestZerostateFromConfig(t *testing.T) {
 	require.Error(t, err)
 
 	// Test only one contract should deployed in specific shard
-	state, err = NewExecutionState(tx, types.BaseShardId, StateParams{
-		ConfigAccessor: config.GetStubAccessor(),
-	})
-	require.NoError(t, err)
+	state = NewTestExecutionState(t, tx, types.BaseShardId, StateParams{})
 	zeroState = &ZeroStateConfig{
 		Contracts: []*ContractDescr{
 			{Name: "Faucet", Value: types.NewValueFromUint64(87654321), Contract: "Faucet", Shard: 1},

--- a/nil/services/nilservice/config.go
+++ b/nil/services/nilservice/config.go
@@ -87,7 +87,8 @@ type Config struct {
 
 	L1Fetcher rollup.L1BlockFetcher `yaml:"-"`
 
-	FeeCalculator         execution.FeeCalculator                                                   `yaml:"-"`
+	StateAccessor *execution.StateAccessor `yaml:"-"`
+
 	NetworkManagerFactory func(ctx context.Context, cfg *Config, db db.DB) (network.Manager, error) `yaml:"-"`
 }
 
@@ -226,6 +227,6 @@ func (c *Config) BlockGeneratorParams(shardId types.ShardId) execution.BlockGene
 		EvmTracingHooks:  verboseTracingHook,
 		MainKeysPath:     c.MainKeysPath,
 		DisableConsensus: c.DisableConsensus,
-		FeeCalculator:    c.FeeCalculator,
+		StateAccessor:    c.StateAccessor,
 	}
 }

--- a/nil/services/nilservice/service.go
+++ b/nil/services/nilservice/service.go
@@ -497,6 +497,10 @@ func CreateNode(
 		return nil, err
 	}
 
+	if cfg.StateAccessor == nil {
+		cfg.StateAccessor = execution.NewStateAccessor(1024, 0)
+	}
+
 	var txnPools map[types.ShardId]txnpool.Pool
 	var syncersResult *syncersResult
 	switch cfg.RunMode {

--- a/nil/services/rpc/jsonrpc/eth_accounts_test.go
+++ b/nil/services/rpc/jsonrpc/eth_accounts_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/NilFoundation/nil/nil/common"
-	"github.com/NilFoundation/nil/nil/internal/config"
 	"github.com/NilFoundation/nil/nil/internal/db"
 	"github.com/NilFoundation/nil/nil/internal/execution"
 	"github.com/NilFoundation/nil/nil/internal/mpt"
@@ -49,11 +48,7 @@ func (suite *SuiteEthAccounts) SetupSuite() {
 	suite.Require().NoError(err)
 	defer tx.Rollback()
 
-	es, err := execution.NewExecutionState(tx, shardId, execution.StateParams{
-		ConfigAccessor: config.GetStubAccessor(),
-	})
-	suite.Require().NoError(err)
-	es.BaseFee = types.DefaultGasPrice
+	es := execution.NewTestExecutionState(suite.T(), tx, shardId, execution.StateParams{})
 
 	suite.smcAddr = types.GenerateRandomAddress(shardId)
 	suite.Require().NotEmpty(suite.smcAddr)

--- a/nil/services/rpc/jsonrpc/eth_api.go
+++ b/nil/services/rpc/jsonrpc/eth_api.go
@@ -6,7 +6,6 @@ import (
 	"github.com/NilFoundation/nil/nil/common"
 	"github.com/NilFoundation/nil/nil/common/logging"
 	"github.com/NilFoundation/nil/nil/internal/db"
-	"github.com/NilFoundation/nil/nil/internal/execution"
 	"github.com/NilFoundation/nil/nil/internal/types"
 	"github.com/NilFoundation/nil/nil/services/rpc/filters"
 	"github.com/NilFoundation/nil/nil/services/rpc/rawapi"
@@ -349,8 +348,6 @@ type EthAPI interface {
 
 // APIImpl is implementation of the EthAPI interface based on remote Db access
 type APIImplRo struct {
-	accessor *execution.StateAccessor
-
 	logs            *LogsAggregator
 	logger          logging.Logger
 	clientEventsLog logging.Logger
@@ -374,10 +371,8 @@ func NewEthAPIRo(
 	pollBlocksForLogs bool,
 	logClientEvents bool,
 ) *APIImplRo {
-	accessor := execution.NewStateAccessor()
 	api := &APIImplRo{
 		logger:          logging.NewLogger("eth-api"),
-		accessor:        accessor,
 		rawapi:          rawapi,
 		clientEventsLog: logging.NewLogger("eth-api-rpc-requests"),
 	}

--- a/nil/services/rpc/jsonrpc/send_transaction_test.go
+++ b/nil/services/rpc/jsonrpc/send_transaction_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/NilFoundation/nil/nil/common"
-	"github.com/NilFoundation/nil/nil/internal/config"
 	"github.com/NilFoundation/nil/nil/internal/db"
 	"github.com/NilFoundation/nil/nil/internal/execution"
 	"github.com/NilFoundation/nil/nil/internal/types"
@@ -37,11 +36,9 @@ func (suite *SuiteSendTransaction) SetupSuite() {
 	suite.Require().NoError(err)
 	defer tx.Rollback()
 
-	es, err := execution.NewExecutionState(tx, shardId, execution.StateParams{
-		Block:          mainBlock,
-		ConfigAccessor: config.GetStubAccessor(),
+	es := execution.NewTestExecutionState(suite.T(), tx, shardId, execution.StateParams{
+		Block: mainBlock,
 	})
-	suite.Require().NoError(err)
 
 	suite.smcAddr = types.CreateAddress(shardId, types.BuildDeployPayload([]byte("1234"), common.EmptyHash))
 	suite.Require().NotEqual(types.Address{}, suite.smcAddr)

--- a/nil/services/rpc/jsonrpc/test_block.go
+++ b/nil/services/rpc/jsonrpc/test_block.go
@@ -48,6 +48,7 @@ func writeTestBlock(t *testing.T, tx db.RwTx, shardId types.ShardId, blockNumber
 		InTxnHashes:  inTxnHashes,
 		OutTxns:      outTransactions,
 		OutTxnHashes: outTxnHashes,
+		Receipts:     receipts,
 	}
 }
 

--- a/nil/services/rpc/rawapi/internal/local_api_ro.go
+++ b/nil/services/rpc/rawapi/internal/local_api_ro.go
@@ -29,12 +29,12 @@ func newLocalShardApiRo(
 	shardId types.ShardId,
 	db db.ReadOnlyDB,
 	bootstrapConfig *rpctypes.BootstrapConfig,
+	accessor *execution.StateAccessor,
 ) *localShardApiRo {
-	stateAccessor := execution.NewStateAccessor()
 	return &localShardApiRo{
 		bootstrapConfig: bootstrapConfig,
 		db:              db,
-		accessor:        stateAccessor,
+		accessor:        accessor,
 		shard:           shardId,
 		logger:          logging.NewLogger("local_api"),
 	}

--- a/nil/services/rpc/rawapi/internal/local_call.go
+++ b/nil/services/rpc/rawapi/internal/local_call.go
@@ -228,6 +228,7 @@ func (api *localShardApiRo) Call(
 	es, err := execution.NewExecutionState(tx, shardId, execution.StateParams{
 		Block:          block,
 		ConfigAccessor: configAccessor,
+		StateAccessor:  api.accessor,
 		Mode:           execution.ModeReadOnly,
 	})
 	if err != nil {
@@ -285,6 +286,7 @@ func (api *localShardApiRo) Call(
 	esOld, err := execution.NewExecutionState(tx, shardId, execution.StateParams{
 		Block:          block,
 		ConfigAccessor: config.GetStubAccessor(),
+		StateAccessor:  api.accessor,
 		Mode:           execution.ModeReadOnly,
 	})
 	if err != nil {

--- a/nil/services/synccommittee/prover/tracer/tracer_mock_client_test.go
+++ b/nil/services/synccommittee/prover/tracer/tracer_mock_client_test.go
@@ -237,16 +237,11 @@ func (s *TracerMockClientTestSuite) simpleContractCallTrace(code []byte) *Execut
 	mptTracer, err := newDummyMptTracer(s.accounts, s.shardId, rwTx)
 	s.Require().NoError(err)
 
-	es, err := execution.NewExecutionState(
-		rwTx,
-		s.shardId,
-		execution.StateParams{
-			Block:                 prevBlock.Block,
-			ConfigAccessor:        configAccessor,
-			ContractMptRepository: mptTracer,
-		},
-	)
-	s.Require().NoError(err)
+	es := execution.NewTestExecutionState(s.T(), rwTx, s.shardId, execution.StateParams{
+		Block:                 prevBlock.Block,
+		ConfigAccessor:        configAccessor,
+		ContractMptRepository: mptTracer,
+	})
 
 	esTracer := NewEVMTracer(es)
 


### PR DESCRIPTION
Introduced StateAccessor on higher levels to be shared:
- between validators (caches blocks only; used by execution state and the likes),
- between api methods (blocks + txns).

Used the accessor in some places instead of ReadBlock. But also ReadBlock instead of the accessor in tests (it's much faster and shorter).

Since some objects now require a state accessor, added test constructors that initialize corresponding accessors (also simplified existing code somewhat).