### PR TITLE
feat: add coinbase address to block structure and RPC

### DIFF
--- a/nil/internal/types/block.go
+++ b/nil/internal/types/block.go
@@ -51,6 +51,7 @@ type BlockData struct {
 	BaseFee             Value            `json:"gasPrice" ch:"gas_price"`
 	GasUsed             Gas              `json:"gasUsed" ch:"gas_used"`
 	L1BlockNumber       uint64           `json:"l1BlockNumber" ch:"l1_block_number"`
+	Coinbase            Address          `json:"miner" ch:"miner"`
 
 	// Incremented after every rollback, used to prevent rollback replay attacks
 	RollbackCounter uint32 `json:"rollbackCounter" ch:"rollback_counter"`

--- a/nil/internal/types/serialization_test.go
+++ b/nil/internal/types/serialization_test.go
@@ -34,7 +34,7 @@ func TestSerializeBlock(t *testing.T) {
 	h, err := common.Keccak(&block2)
 	require.NoError(t, err)
 
-	h2, err := hex.DecodeString("24ff2a9b05d533266c08cc1906bffcd746ecd1a427255de2319f9a9a45fa1a75")
+	h2, err := hex.DecodeString("03b723f064c70966267e9ded7d13fc07e1a082f5ea4e2156c77765cfe933c657")
 	require.NoError(t, err)
 
 	require.Equal(t, common.BytesToHash(h2), common.BytesToHash(h[:]))

--- a/nil/services/cliservice/block.go
+++ b/nil/services/cliservice/block.go
@@ -123,6 +123,7 @@ Block #{{ .block.Id }} [{{ .color.bold }}{{ .block.Hash .shardId }}{{ .color.res
   PrevBlock: {{ .block.PrevBlock }}
   BaseFee: {{ .block.BaseFee }}
   GasUsed: {{ .block.GasUsed }}
+  Coinbase: {{ .block.Coinbase }}
   ChildBlocksRootHash: {{ .block.ChildBlocksRootHash }}
 {{- if len .block.ChildBlocks}}
   ChildBlocks:

--- a/nil/services/cliservice/block_format_test.go
+++ b/nil/services/cliservice/block_format_test.go
@@ -147,10 +147,11 @@ func TestDebugBlockToText(t *testing.T) {
 		text, err := s.debugBlockToText(types.ShardId(13), block, false, false)
 		require.NoError(t, err)
 
-		expectedText := `Block #100500 [0x000d1288cfedf4f9c748f80d9d0e3edb422c092a2a17725878e36aa9383c6bfa] @ 13 shard
+		expectedText := `Block #100500 [0x000dcc04885a7be4c360239bfbad32edb62f486770189fe98244c43c793ae9b6] @ 13 shard
   PrevBlock: 0x00000000000000000000000000000000000000000000000000000000deadbeef
   BaseFee: 0
   GasUsed: 1234
+  Coinbase: 0x0000000000000000000000000000000000000000
   ChildBlocksRootHash: 0x00000000000000000000000000000000000000000000000000000000deadbabe
   ChildBlocks:
     - 1: 0x0000000000000000000000000000000000000000000000000000000000000111

--- a/nil/services/rpc/jsonrpc/eth_block_test.go
+++ b/nil/services/rpc/jsonrpc/eth_block_test.go
@@ -91,6 +91,7 @@ func (suite *SuiteEthBlock) TestGetBlockByHash() {
 	suite.Require().NoError(err)
 	suite.Require().NotNil(data)
 	suite.Equal(suite.lastBlockHash, data.Hash)
+	suite.Equal(data.Coinbase, types.ShardAndHexToAddress(shardId, "0x0"))
 }
 
 func (suite *SuiteEthBlock) TestGetBlockTransactionCountByHash() {

--- a/nil/services/rpc/jsonrpc/types.go
+++ b/nil/services/rpc/jsonrpc/types.go
@@ -72,6 +72,7 @@ type RPCInTransaction struct {
 // @componentprop ParentHash parentHash string true "The hash of the parent block."
 // @componentprop ReceiptsRoot receiptsRoot string true "The root of the block receipts."
 // @componentprop ShardId shardId integer true "The ID of the shard where the block was generated."
+// @componentprop Coinbase miner string true "The address of the fee recipient that receives priority fees."
 type RPCBlock struct {
 	Number              types.BlockNumber   `json:"number"`
 	Hash                common.Hash         `json:"hash"`
@@ -93,6 +94,7 @@ type RPCBlock struct {
 	L1Number            uint64              `json:"l1Number"`
 	LogsBloom           hexutil.Bytes       `json:"logsBloom,omitempty"`
 	GasUsed             types.Gas           `json:"gasUsed,omitempty"`
+	Coinbase            types.Address       `json:"miner"`
 }
 
 type ShardCount struct {
@@ -435,6 +437,7 @@ func NewRPCBlock(shardId types.ShardId, data *BlockWithEntities, fullTx bool) (*
 		LogsBloom:           bloom,
 		L1Number:            block.L1BlockNumber,
 		GasUsed:             block.GasUsed,
+		Coinbase:            block.Coinbase,
 	}, nil
 }
 


### PR DESCRIPTION
## Short Summary

The coinbase address is used at the execution layer to receive priority fees, and can be accessed via the `COINBASE` opcode from smart contracts.

Add the coinbase address to the block structure and the relevant RPC responses. Currently, the coinbase address is hardcoded as `0x0` for each shard and will require further adjustments in accordance with protocol.

Re-canonize tests to reflect the new block structure.

## What Changes Were Made

<!-- List the changes introduced in this PR -->

- Add coinbase to block and RPC response
- Re-canonize tests

## Checklist

_Please mark each item with an `x` inside the brackets (e.g., [x]) once completed._

- [x] I have read and followed the [Contributing Guide](https://github.com/NilFoundation/nil/blob/main/CONTRIBUTION-GUIDE.md)
- [x] I have tested the changes locally
- [x] I have added relevant tests (if applicable)
- [x] I have updated documentation/comments (if applicable)
