### PR TITLE
[build] fix several Makefile issues

### DIFF
--- a/nil/Makefile.inc
+++ b/nil/Makefile.inc
@@ -41,5 +41,5 @@ $(root_db)/db_generated_mock.go: $(root_db)/kv.go $(root_db)/rwtx_generated_mock
 $(root_rollup)/l1_fetcher_generated_mock.go: $(root_rollup)/l1_fetcher.go
 	cd $(root_rollup) && go generate l1_fetcher.go
 
-$(root_execution)/account_state_helpers_generated_mock.go: $(root_execution)/account_state.go error_stringer
+$(root_execution)/account_state_helpers_generated_mock.go: $(root_execution)/account_state.go rlp_execution
 	cd $(root_execution) && go generate account_state.go

--- a/nil/internal/types/Makefile.inc
+++ b/nil/internal/types/Makefile.inc
@@ -1,3 +1,6 @@
+ifndef RLP_TARGETS_INCLUDED
+RLP_TARGETS_INCLUDED := true
+
 RLP_TARGETS = \
     nil/internal/types/signature_rlp_encoding.go \
     nil/internal/types/log_rlp_encoding.go \
@@ -84,3 +87,5 @@ nil/internal/types/token_balance_rlp_encoding.go: nil/internal/types/account.go
 
 nil/internal/types/version_info_rlp_encoding.go: nil/internal/types/version_info.go
 	$(TYPES_RLPGEN) -type VersionInfo -out version_info_rlp_encoding.go -decoder
+
+endif


### PR DESCRIPTION
  * fixed double include that produced following warning:
```
nil/internal/types/Makefile.inc:27: warning: overriding recipe for target 'nil/internal/types/error_string.go'
nil/internal/types/Makefile.inc:27: warning: ignoring old recipe for target 'nil/internal/types/error_string.go'
nil/internal/types/Makefile.inc:35: warning: overriding recipe for target 'nil/internal/types/signature_rlp_encoding.go'
nil/internal/types/Makefile.inc:35: warning: ignoring old recipe for target 'nil/internal/types/signature_rlp_encoding.go'
nil/internal/types/Makefile.inc:38: warning: overriding recipe for target 'nil/internal/types/log_rlp_encoding.go'
nil/internal/types/Makefile.inc:38: warning: ignoring old recipe for target 'nil/internal/types/log_rlp_encoding.go'
nil/internal/types/Makefile.inc:41: warning: overriding recipe for target 'nil/internal/types/debug_log_rlp_encoding.go'
nil/internal/types/Makefile.inc:41: warning: ignoring old recipe for target 'nil/internal/types/debug_log_rlp_encoding.go'
nil/internal/types/Makefile.inc:44: warning: overriding recipe for target 'nil/internal/types/receipt_rlp_encoding.go'
nil/internal/types/Makefile.inc:44: warning: ignoring old recipe for target 'nil/internal/types/receipt_rlp_encoding.go'
nil/internal/types/Makefile.inc:47: warning: overriding recipe for target 'nil/internal/types/transaction_rlp_encoding.go'
nil/internal/types/Makefile.inc:47: warning: ignoring old recipe for target 'nil/internal/types/transaction_rlp_encoding.go'
nil/internal/types/Makefile.inc:50: warning: overriding recipe for target 'nil/internal/types/external_transaction_rlp_encoding.go'
nil/internal/types/Makefile.inc:50: warning: ignoring old recipe for target 'nil/internal/types/external_transaction_rlp_encoding.go'
nil/internal/types/Makefile.inc:53: warning: overriding recipe for target 'nil/internal/types/internal_transaction_payload_rlp_encoding.go'
nil/internal/types/Makefile.inc:53: warning: ignoring old recipe for target 'nil/internal/types/internal_transaction_payload_rlp_encoding.go'
nil/internal/types/Makefile.inc:56: warning: overriding recipe for target 'nil/internal/types/transaction_digest_rlp_encoding.go'
nil/internal/types/Makefile.inc:56: warning: ignoring old recipe for target 'nil/internal/types/transaction_digest_rlp_encoding.go'
nil/internal/types/Makefile.inc:59: warning: overriding recipe for target 'nil/internal/types/tx_count_rlp_encoding.go'
nil/internal/types/Makefile.inc:59: warning: ignoring old recipe for target 'nil/internal/types/tx_count_rlp_encoding.go'
nil/internal/types/Makefile.inc:62: warning: overriding recipe for target 'nil/internal/types/async_context_rlp_encoding.go'
nil/internal/types/Makefile.inc:62: warning: ignoring old recipe for target 'nil/internal/types/async_context_rlp_encoding.go'
nil/internal/types/Makefile.inc:65: warning: overriding recipe for target 'nil/internal/types/async_response_payload_rlp_encoding.go'
nil/internal/types/Makefile.inc:65: warning: ignoring old recipe for target 'nil/internal/types/async_response_payload_rlp_encoding.go'
nil/internal/types/Makefile.inc:68: warning: overriding recipe for target 'nil/internal/types/block_data_rlp_encoding.go'
nil/internal/types/Makefile.inc:68: warning: ignoring old recipe for target 'nil/internal/types/block_data_rlp_encoding.go'
nil/internal/types/Makefile.inc:71: warning: overriding recipe for target 'nil/internal/types/block_rlp_encoding.go'
nil/internal/types/Makefile.inc:71: warning: ignoring old recipe for target 'nil/internal/types/block_rlp_encoding.go'
nil/internal/types/Makefile.inc:74: warning: overriding recipe for target 'nil/internal/types/neighbor_rlp_encoding.go'
nil/internal/types/Makefile.inc:74: warning: ignoring old recipe for target 'nil/internal/types/neighbor_rlp_encoding.go'
nil/internal/types/Makefile.inc:77: warning: overriding recipe for target 'nil/internal/types/collator_state_rlp_encoding.go'
nil/internal/types/Makefile.inc:77: warning: ignoring old recipe for target 'nil/internal/types/collator_state_rlp_encoding.go'
nil/internal/types/Makefile.inc:80: warning: overriding recipe for target 'nil/internal/types/account_rlp_encoding.go'
nil/internal/types/Makefile.inc:80: warning: ignoring old recipe for target 'nil/internal/types/account_rlp_encoding.go'
nil/internal/types/Makefile.inc:83: warning: overriding recipe for target 'nil/internal/types/token_balance_rlp_encoding.go'
nil/internal/types/Makefile.inc:83: warning: ignoring old recipe for target 'nil/internal/types/token_balance_rlp_encoding.go'
nil/internal/types/Makefile.inc:86: warning: overriding recipe for target 'nil/internal/types/version_info_rlp_encoding.go'
nil/internal/types/Makefile.inc:86: warning: ignoring old recipe for target 'nil/internal/types/version_info_rlp_encoding.go'

```

  * fixed incorrect dependency for account_state_helpers_generated_mock.go