### PR TITLE
Panic on concurrent block updates

### DIFF
--- a/nil/internal/consensus/ibft/logger.go
+++ b/nil/internal/consensus/ibft/logger.go
@@ -7,11 +7,11 @@ type ibftLogger struct {
 }
 
 func (l *ibftLogger) Info(msg string, args ...any) {
-	l.logger.Info().Fields(args).Msg(msg)
+	l.logger.Trace().Fields(args).Msg(msg)
 }
 
 func (l *ibftLogger) Debug(msg string, args ...any) {
-	l.logger.Debug().Fields(args).Msg(msg)
+	l.logger.Trace().Fields(args).Msg(msg)
 }
 
 func (l *ibftLogger) Error(msg string, args ...any) {

--- a/nil/services/nilservice/service.go
+++ b/nil/services/nilservice/service.go
@@ -60,7 +60,7 @@ func startRpcServer(
 	httpConfig := &httpcfg.HttpCfg{
 		HttpURL:         addr,
 		HttpCompression: true,
-		TraceRequests:   true,
+		TraceRequests:   false,
 		HTTPTimeouts:    httpcfg.DefaultHTTPTimeouts,
 		HttpCORSDomain:  []string{"*"},
 		KeepHeaders:     []string{"Client-Version", "Client-Type", "X-UID"},


### PR DESCRIPTION
Here I check that when we write the new block hash to the table by number, we don't have an already present record.
This check panics in some tests (not always tho).