### PR TITLE
Sync Committee: BridgeStateGetter Fix

### DIFF
--- a/nil/services/synccommittee/core/proposer.go
+++ b/nil/services/synccommittee/core/proposer.go
@@ -131,7 +131,9 @@ func (p *proposer) updateState(
 		return fmt.Errorf("failed to get latest block for shard %d", p.config.BridgeStateKeeperShardId)
 	}
 
-	bridgeData, err := p.bridgeStateGetter.GetBridgeState(ctx, bridgeContractShardBlock.MainShardHash)
+	bridgeData, err := p.bridgeStateGetter.GetBridgeState(
+		ctx, bridgeContractShardBlock.Hash, bridgeContractShardBlock.MainShardHash,
+	)
 	if err != nil {
 		return fmt.Errorf("failed to get bridge state: %w", err)
 	}


### PR DESCRIPTION
### Sync Committee: BridgeStateGetter Fix

This PR addresses the following error occurred in dev env:
```
"failed to get bridge state: failed to check if L2 bridge contract exists at block 0x0000de8d2aebbe70fc91df7bf2aad6c91e40465211ea279a6f2f30fef8cef248: rpc error: {code:-32000,message:failed to call method GetCode on shard 1: requested block not found}"
```

Updated `GetBridgeState(...)` method to accept separate shard block hashes (both execution shard and main shard block hashes)